### PR TITLE
Improve Rhea import

### DIFF
--- a/src/pyobo/sources/famplex.py
+++ b/src/pyobo/sources/famplex.py
@@ -151,9 +151,11 @@ def _get_xref_df(version: str) -> Mapping[str, List[Reference]]:
     }
     xrefs_df[0] = xrefs_df[0].map(lambda s: ns_remapping.get(s, s))
     xrefs_df[1] = [
-        bioregistry.standardize_identifier(xref_prefix, xref_identifier)
-        if xref_prefix != "nextprot.family"
-        else xref_identifier[len("FA:") :]
+        (
+            bioregistry.standardize_identifier(xref_prefix, xref_identifier)
+            if xref_prefix != "nextprot.family"
+            else xref_identifier[len("FA:") :]
+        )
         for xref_prefix, xref_identifier in xrefs_df[[0, 1]].values
     ]
 

--- a/src/pyobo/sources/rhea.py
+++ b/src/pyobo/sources/rhea.py
@@ -18,6 +18,7 @@ from pyobo.struct.typedef import (
     has_output,
     has_participant,
     has_right_to_left_reaction,
+    reaction_enabled_by_molecular_function,
 )
 from pyobo.utils.path import ensure_df
 
@@ -45,6 +46,7 @@ class RheaGetter(Obo):
         has_input,
         has_output,
         has_participant,
+        reaction_enabled_by_molecular_function,
     ]
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
@@ -180,7 +182,7 @@ def iter_terms(version: str, force: bool = False) -> Iterable[Term]:
         ("reactome", "rhea2reactome", None),
         ("macie", "rhea2macie", None),
         ("metacyc", "rhea2metacyc", None),
-        ("go", "rhea2go", None),  # TODO what is the relationship?
+        ("go", "rhea2go", reaction_enabled_by_molecular_function),
         ("uniprot", "rhea2uniprot", enabled_by),
     ]:
         xref_df = ensure_df(

--- a/src/pyobo/sources/rhea.py
+++ b/src/pyobo/sources/rhea.py
@@ -3,7 +3,7 @@
 """Converter for Rhea."""
 
 import logging
-from typing import Dict, Iterable, Optional
+from typing import TYPE_CHECKING, Dict, Iterable, Optional
 
 import bioversions
 import pystow
@@ -20,6 +20,9 @@ from pyobo.struct.typedef import (
     has_right_to_left_reaction,
 )
 from pyobo.utils.path import ensure_df
+
+if TYPE_CHECKING:
+    import rdflib
 
 __all__ = [
     "RheaGetter",
@@ -124,8 +127,7 @@ def iter_terms(version: str, force: bool = False) -> Iterable[Term]:
       ?compound rh:chebi|rh:underlyingChebi|(rh:reactivePart/rh:chebi) ?chebi .
     }
     """
-    results = graph.query(sparql)
-    for master_rhea_id, side_uri, chebi_uri in results:
+    for master_rhea_id, side_uri, chebi_uri in graph.query(sparql):
         master_rhea_id = str(master_rhea_id)
         chebi_reference = Reference(
             prefix="chebi", identifier=chebi_uri[len("http://purl.obolibrary.org/obo/CHEBI_") :]
@@ -161,7 +163,7 @@ def iter_terms(version: str, force: bool = False) -> Iterable[Term]:
         ("macie", "rhea2macie", None),
         ("metacyc", "rhea2metacyc", None),
         ("go", "rhea2go", None),  # TODO what is the relationship?
-        ("go", "rhea2uniprot", enabled_by),
+        ("uniprot", "rhea2uniprot", enabled_by),
     ]:
         xref_df = ensure_df(
             PREFIX,
@@ -188,7 +190,7 @@ def iter_terms(version: str, force: bool = False) -> Iterable[Term]:
 
     ec_df = ensure_df(
         PREFIX,
-        url=f"ftp://ftp.expasy.org/databases/rhea/tsv/rhea-ec-iubmb.tsv",
+        url="ftp://ftp.expasy.org/databases/rhea/tsv/rhea-ec-iubmb.tsv",
         version=version,
         force=force,
     )

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -395,9 +395,7 @@ class Term(Referenced):
 
     def iterate_relations(self) -> Iterable[Tuple[TypeDef, Reference]]:
         """Iterate over pairs of typedefs and targets."""
-        for typedef, targets in sorted(
-            self.relationships.items(), key=lambda pair: pair[0].preferred_curie
-        ):
+        for typedef, targets in sorted(self.relationships.items(), key=_sort_relations):
             for target in sorted(targets, key=lambda ref: ref.preferred_curie):
                 yield typedef, target
 
@@ -468,7 +466,7 @@ _TYPEDEF_WARNINGS: Set[Tuple[str, str]] = set()
 
 def _sort_relations(r):
     typedef, _references = r
-    return typedef.reference.name or typedef.reference.identifier
+    return typedef.preferred_curie
 
 
 def _sort_properties(r):

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -395,14 +395,16 @@ class Term(Referenced):
 
     def iterate_relations(self) -> Iterable[Tuple[TypeDef, Reference]]:
         """Iterate over pairs of typedefs and targets."""
-        for typedef, targets in self.relationships.items():
-            for target in targets:
+        for typedef, targets in sorted(
+            self.relationships.items(), key=lambda pair: pair[0].preferred_curie
+        ):
+            for target in sorted(targets, key=lambda ref: ref.preferred_curie):
                 yield typedef, target
 
     def iterate_properties(self) -> Iterable[Tuple[str, str]]:
         """Iterate over pairs of property and values."""
-        for prop, values in self.properties.items():
-            for value in values:
+        for prop, values in sorted(self.properties.items()):
+            for value in sorted(values):
                 yield prop, value
 
     def iterate_obo_lines(self, *, ontology, typedefs) -> Iterable[str]:

--- a/src/pyobo/struct/typedef.py
+++ b/src/pyobo/struct/typedef.py
@@ -291,7 +291,14 @@ editor_note = TypeDef.from_triple(prefix=IAO_PREFIX, identifier="0000116", name=
 is_immediately_transformed_from = TypeDef.from_triple(
     prefix=SIO_PREFIX, identifier="000658", name="is immediately transformed from"
 )
-enables = TypeDef.from_triple(prefix="RO", identifier="0002327", name="enables")
+
+_enables_reference = Reference(prefix=RO_PREFIX, identifier="0002327", name="enables")
+_enabled_by_reference = Reference(prefix=RO_PREFIX, identifier="0002333", name="enabled by")
+enables = TypeDef(reference=_enables_reference, inverse=_enabled_by_reference)
+enabled_by = TypeDef(reference=_enabled_by_reference, inverse=_enables_reference)
+
+has_input = TypeDef.from_triple(prefix=RO_PREFIX, identifier="0002233", name="has input")
+has_output = TypeDef.from_triple(prefix=RO_PREFIX, identifier="0002234", name="has output")
 
 """ChEBI"""
 

--- a/src/pyobo/struct/typedef.py
+++ b/src/pyobo/struct/typedef.py
@@ -48,6 +48,10 @@ __all__ = [
 ]
 
 
+def _bool_to_obo(v: bool) -> str:
+    return "true" if v else "false"
+
+
 @dataclass
 class TypeDef(Referenced):
     """A type definition in OBO.
@@ -88,7 +92,7 @@ class TypeDef(Referenced):
             yield f'def: "{self.definition}"'
 
         if self.is_metadata_tag is not None:
-            yield f'is_metadata_tag: {"true" if self.is_metadata_tag else "false"}'
+            yield f"is_metadata_tag: {_bool_to_obo(self.is_metadata_tag)}"
 
         if self.namespace:
             yield f"namespace: {self.namespace}"
@@ -113,6 +117,10 @@ class TypeDef(Referenced):
             yield f"holds_over_chain: {_chain} ! {_names}"
         if self.inverse:
             yield f"inverse_of: {self.inverse}"
+        if self.domain:
+            yield f"domain: {self.domain}"
+        if self.range:
+            yield f"range: {self.range}"
 
     @classmethod
     def from_triple(cls, prefix: str, identifier: str, name: Optional[str] = None) -> "TypeDef":
@@ -161,13 +169,19 @@ species_specific = TypeDef(
     "species with RO:0002162 (in taxon)",
 )
 has_left_to_right_reaction = TypeDef(
-    Reference(prefix="debio", identifier="0000007", name="has left-to-right reaction")
+    Reference(prefix="debio", identifier="0000007", name="has left-to-right reaction"),
+    is_metadata_tag=True,
 )
 has_right_to_left_reaction = TypeDef(
-    Reference(prefix="debio", identifier="0000008", name="has right-to-left reaction")
+    Reference(prefix="debio", identifier="0000008", name="has right-to-left reaction"),
+    is_metadata_tag=True,
 )
 has_bidirectional_reaction = TypeDef(
-    Reference(prefix="debio", identifier="0000009", name="has bi-directional reaction")
+    Reference(prefix="debio", identifier="0000009", name="has bi-directional reaction"),
+    is_metadata_tag=True,
+)
+reaction_enabled_by_molecular_function = TypeDef(
+    Reference(prefix="debio", identifier="0000047", name="reaction enabled by molecular function")
 )
 
 


### PR DESCRIPTION
Closes #167

1. Add "has participant" relations between the "master" and "bidirected" reaction and ChEBI identifiers
2. Add has input / has output relations between directional reactions and ChEBI identifiers
3. Adds "enabled by" for UniProt and EC xrefs
4. Adds GO relations with newly minted `debio:0000047` (as a placeholder for the maybe results of https://github.com/oborel/obo-relations/issues/783)
5. Adds programmatically generated names for left-to-right, right-to-left, and bi-directed reactions

Example output:

```
[Term]
[Term]
id: rhea:11880
name: \(S\)-6-hydroxynicotine + H2O + O2 = 6-hydroxypseudooxynicotine + H2O2
relationship: RO:0000057 CHEBI:15377 ! has participant water
relationship: RO:0000057 CHEBI:15379 ! has participant dioxygen
relationship: RO:0000057 CHEBI:16240 ! has participant hydrogen peroxide
relationship: RO:0000057 CHEBI:58182 ! has participant (S)-6-hydroxynicotinium(1+)
relationship: RO:0000057 CHEBI:58682 ! has participant 6-hydroxypseudooxynicotinium(1+)
relationship: RO:0002333 eccode:1.5.3.5 ! enabled by
relationship: RO:0002333 uniprot:A0A075BSX9 ! enabled by
relationship: RO:0002333 uniprot:Q93NH4 ! enabled by
relationship: debio:0000007 rhea:11881 ! has left-to-right reaction (S)-6-hydroxynicotine + H2O + O2 => 6-hydroxypseudooxynicotine + H2O2
relationship: debio:0000008 rhea:11882 ! has right-to-left reaction 6-hydroxypseudooxynicotine + H2O2 => (S)-6-hydroxynicotine + H2O + O2
relationship: debio:0000009 rhea:11883 ! has bi-directional reaction (S)-6-hydroxynicotine + H2O + O2 <=> 6-hydroxypseudooxynicotine + H2O2
relationship: debio:0000047 GO:0018531 ! reaction enabled by molecular function

[Term]
id: rhea:11881
name: \(S\)-6-hydroxynicotine + H2O + O2 => 6-hydroxypseudooxynicotine + H2O2
xref: metacyc.compound:S-6-HYDROXYNICOTINE-OXIDASE-RXN
is_a: rhea:11880 ! (S)-6-hydroxynicotine + H2O + O2 = 6-hydroxypseudooxynicotine + H2O2
relationship: RO:0002233 CHEBI:15377 ! has input water
relationship: RO:0002233 CHEBI:15379 ! has input dioxygen
relationship: RO:0002233 CHEBI:58182 ! has input (S)-6-hydroxynicotinium(1+)
relationship: RO:0002234 CHEBI:16240 ! has output hydrogen peroxide
relationship: RO:0002234 CHEBI:58682 ! has output 6-hydroxypseudooxynicotinium(1+)
relationship: RO:0002333 uniprot:A0A075BSX9 ! enabled by
relationship: RO:0002333 uniprot:Q93NH4 ! enabled by

[Term]
id: rhea:11882
name: 6-hydroxypseudooxynicotine + H2O2 => \(S\)-6-hydroxynicotine + H2O + O2
is_a: rhea:11880 ! (S)-6-hydroxynicotine + H2O + O2 = 6-hydroxypseudooxynicotine + H2O2
relationship: RO:0002233 CHEBI:16240 ! has input hydrogen peroxide
relationship: RO:0002233 CHEBI:58682 ! has input 6-hydroxypseudooxynicotinium(1+)
relationship: RO:0002234 CHEBI:15377 ! has output water
relationship: RO:0002234 CHEBI:15379 ! has output dioxygen
relationship: RO:0002234 CHEBI:58182 ! has output (S)-6-hydroxynicotinium(1+)

[Term]
id: rhea:11883
name: \(S\)-6-hydroxynicotine + H2O + O2 <=> 6-hydroxypseudooxynicotine + H2O2
xref: kegg.reaction:R03202
is_a: rhea:11880 ! (S)-6-hydroxynicotine + H2O + O2 = 6-hydroxypseudooxynicotine + H2O2
relationship: RO:0000057 CHEBI:15377 ! has participant water
relationship: RO:0000057 CHEBI:15379 ! has participant dioxygen
relationship: RO:0000057 CHEBI:16240 ! has participant hydrogen peroxide
relationship: RO:0000057 CHEBI:58182 ! has participant (S)-6-hydroxynicotinium(1+)
relationship: RO:0000057 CHEBI:58682 ! has participant 6-hydroxypseudooxynicotinium(1+)

```