### PR TITLE
Extend UniProt export

### DIFF
--- a/src/pyobo/sources/uniprot/uniprot.py
+++ b/src/pyobo/sources/uniprot/uniprot.py
@@ -13,7 +13,7 @@ from pyobo import Obo, Reference
 from pyobo.constants import RAW_MODULE
 from pyobo.identifier_utils import standardize_ec
 from pyobo.struct import Term, derives_from, enables, from_species, participates_in
-from pyobo.struct.typedef import gene_product_of, molecularly_interacts_with
+from pyobo.struct.typedef import gene_product_of, located_in, molecularly_interacts_with
 from pyobo.utils.io import open_reader
 
 PREFIX = "uniprot"
@@ -110,8 +110,7 @@ def iter_terms(version: Optional[str] = None) -> Iterable[Term]:
             for go_function_ref in _parse_go(go_functions):
                 term.append_relationship(enables, go_function_ref)
             for go_component_ref in _parse_go(go_components):
-                # FIXME this needs a different relationship than participates_in
-                term.append_relationship(..., go_component_ref)
+                term.append_relationship(located_in, go_component_ref)
 
             if proteome:
                 uniprot_proteome_id = proteome.split(":")[0]
@@ -123,9 +122,9 @@ def iter_terms(version: Optional[str] = None) -> Iterable[Term]:
             if rhea_curies:
                 for rhea_curie in rhea_curies.split(" "):
                     term.append_relationship(
-                        # FIXME this needs a different relation than participates_in
+                        # FIXME this needs a different relation than enables
                         #  see https://github.com/biopragmatics/pyobo/pull/168#issuecomment-1918680152
-                        ...,
+                        enables,
                         cast(Reference, Reference.from_curie(rhea_curie, strict=True)),
                     )
 

--- a/src/pyobo/sources/uniprot/uniprot.py
+++ b/src/pyobo/sources/uniprot/uniprot.py
@@ -70,7 +70,7 @@ def iter_terms(version: Optional[str] = None) -> Iterable[Term]:
             uniprot_id,
             accession,
             taxonomy_id,
-            name,
+            _name,  # this field should have the name, but it's a mismatch of random name annotations
             ecs,
             pubmeds,
             pdbs,
@@ -117,7 +117,7 @@ def iter_terms(version: Optional[str] = None) -> Iterable[Term]:
                         # FIXME this needs a different relation,
                         #  see https://github.com/biopragmatics/pyobo/pull/168#issuecomment-1918680152
                         participates_in,
-                        Reference.from_curie(rhea_curie),
+                        Reference(prefix="rhea", identifier=rhea_curie.removeprefix("RHEA:")),
                     )
 
             if bindings:

--- a/src/pyobo/sources/uniprot/uniprot.py
+++ b/src/pyobo/sources/uniprot/uniprot.py
@@ -100,9 +100,9 @@ def iter_terms(version: Optional[str] = None) -> Iterable[Term]:
                 term.append_relationship(participates_in, go_process_ref)
             for go_function_ref in _parse_go(go_functions):
                 term.append_relationship(enables, go_function_ref)
-            for _go_component_ref in _parse_go(go_components):
-                pass  # TODO what is the right relation?
-                # term.append_relationship(..., go_component_ref)
+            for go_component_ref in _parse_go(go_components):
+                # FIXME this needs a different relationship than participates_in
+                term.append_relationship(..., go_component_ref)
 
             if proteome:
                 uniprot_proteome_id = proteome.split(":")[0]
@@ -114,9 +114,9 @@ def iter_terms(version: Optional[str] = None) -> Iterable[Term]:
             if rhea_curies:
                 for rhea_curie in rhea_curies.split(" "):
                     term.append_relationship(
-                        # FIXME this needs a different relation,
+                        # FIXME this needs a different relation than participates_in
                         #  see https://github.com/biopragmatics/pyobo/pull/168#issuecomment-1918680152
-                        participates_in,
+                        ...,
                         cast(Reference, Reference.from_curie(rhea_curie, strict=True)),
                     )
 

--- a/src/pyobo/sources/uniprot/uniprot.py
+++ b/src/pyobo/sources/uniprot/uniprot.py
@@ -90,6 +90,8 @@ def iter_terms(version: Optional[str] = None) -> Iterable[Term]:
             bindings,
             description,
         ) in tqdm(reader, desc="Mapping UniProt", unit_scale=True):
+            if description:
+                description = description.removeprefix("FUNCTION: ")
             term = Term(
                 reference=Reference(prefix=PREFIX, identifier=uniprot_id, name=accession),
                 definition=description or None,

--- a/src/pyobo/sources/uniprot/uniprot.py
+++ b/src/pyobo/sources/uniprot/uniprot.py
@@ -50,7 +50,14 @@ class UniProtGetter(Obo):
     """An ontology representation of the UniProt database."""
 
     bioversions_key = ontology = PREFIX
-    typedefs = [from_species, enables, participates_in, gene_product_of, molecularly_interacts_with]
+    typedefs = [
+        from_species,
+        enables,
+        participates_in,
+        gene_product_of,
+        molecularly_interacts_with,
+        derives_from,
+    ]
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""

--- a/src/pyobo/sources/uniprot/uniprot.py
+++ b/src/pyobo/sources/uniprot/uniprot.py
@@ -4,7 +4,7 @@
 
 from operator import attrgetter
 from pathlib import Path
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, cast
 
 import bioversions
 from tqdm.auto import tqdm
@@ -117,7 +117,7 @@ def iter_terms(version: Optional[str] = None) -> Iterable[Term]:
                         # FIXME this needs a different relation,
                         #  see https://github.com/biopragmatics/pyobo/pull/168#issuecomment-1918680152
                         participates_in,
-                        Reference(prefix="rhea", identifier=rhea_curie.removeprefix("RHEA:")),
+                        cast(Reference, Reference.from_curie(rhea_curie, strict=True)),
                     )
 
             if bindings:
@@ -125,9 +125,10 @@ def iter_terms(version: Optional[str] = None) -> Iterable[Term]:
                 for part in bindings.split(";"):
                     part = part.strip()
                     if part.startswith("/ligand_id"):
-                        print(part)
                         curie = part.removeprefix('/ligand_id="').rstrip('"')
-                        binding_references.add(Reference.from_curie(curie))
+                        binding_references.add(
+                            cast(Reference, Reference.from_curie(curie, strict=True))
+                        )
                 for binding_reference in sorted(binding_references, key=attrgetter("curie")):
                     term.append_relationship(molecularly_interacts_with, binding_reference)
 

--- a/src/pyobo/struct/typedef.py
+++ b/src/pyobo/struct/typedef.py
@@ -208,6 +208,9 @@ has_participant = TypeDef(
 derives_from = TypeDef(
     reference=Reference(prefix=RO_PREFIX, identifier="0001000", name="derives from"),
 )
+molecularly_interacts_with = TypeDef(
+    reference=Reference(prefix=RO_PREFIX, identifier="0002436", name="molecularly interacts with"),
+)
 exact_match = TypeDef(
     reference=Reference(prefix="skos", identifier="exactMatch", name="exact match"),
 )

--- a/src/pyobo/struct/typedef.py
+++ b/src/pyobo/struct/typedef.py
@@ -211,6 +211,9 @@ derives_from = TypeDef(
 molecularly_interacts_with = TypeDef(
     reference=Reference(prefix=RO_PREFIX, identifier="0002436", name="molecularly interacts with"),
 )
+located_in = TypeDef(
+    reference=Reference(prefix=RO_PREFIX, identifier="0001025", name="located in"),
+)
 exact_match = TypeDef(
     reference=Reference(prefix="skos", identifier="exactMatch", name="exact match"),
 )


### PR DESCRIPTION
Closes #172

This PR adds several additional fields to the uniprot export:

1. `ft_binding` - binding interactions
2. `xref_proteomes` - the `uniprot.proteome` reference(s?) from which a record is derived
3. `cc_function` a nice high-level description of the function of the protein
4. `go` GO terms associated with the protein (from all 3 hierarchies)
5. `xref_geneid` - NCBI Gene term from which a protein is produced

It also refactors the way the query URLs are constructed to be more easily extensible