### PR TITLE
Enable passing version to name getter

### DIFF
--- a/src/pyobo/api/names.py
+++ b/src/pyobo/api/names.py
@@ -30,11 +30,11 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-def get_name_by_curie(curie: str) -> Optional[str]:
+def get_name_by_curie(curie: str, *, version: Optional[str] = None) -> Optional[str]:
     """Get the name for a CURIE, if possible."""
     prefix, identifier = normalize_curie(curie)
     if prefix and identifier:
-        return get_name(prefix, identifier)
+        return get_name(prefix, identifier, version=version)
     return None
 
 
@@ -74,9 +74,9 @@ def _help_get(
 
 
 @wrap_norm_prefix
-def get_name(prefix: str, identifier: str) -> Optional[str]:
+def get_name(prefix: str, identifier: str, *, version: Optional[str] = None) -> Optional[str]:
     """Get the name for an entity."""
-    return _help_get(get_id_name_mapping, prefix, identifier)
+    return _help_get(get_id_name_mapping, prefix, identifier, version=version)
 
 
 @lru_cache()


### PR DESCRIPTION
This PR adds the ability to specify the version when passing names to `pyobo.get_name` and `pyobo.get_name_by_curie`.

Therefore, if you want to make a name getter that uses pinned versions, you can do something like this:

```python
import pyobo

VERSION_PINS = {"mesh": 2023}

def pinned_get_name_by_curie(curie: str) -> str | None:
    prefix = curie.split(":")[0]
    version = VERSION_PINS.get(prefix)
    return pyobo.get_name_by_curie(curie, version=version)
```