### PR TITLE
Enable use of enviornmental variable version pin dictionary

### DIFF
--- a/src/pyobo/api/names.py
+++ b/src/pyobo/api/names.py
@@ -32,6 +32,8 @@ logger = logging.getLogger(__name__)
 
 def get_name_by_curie(curie: str, *, version: Optional[str] = None) -> Optional[str]:
     """Get the name for a CURIE, if possible."""
+    if version is None:
+        version = get_version(curie.split(":")[0])
     prefix, identifier = normalize_curie(curie)
     if prefix and identifier:
         return get_name(prefix, identifier, version=version)

--- a/src/pyobo/api/utils.py
+++ b/src/pyobo/api/utils.py
@@ -7,8 +7,8 @@ from typing import Optional
 
 import bioversions
 
-from ..utils.path import prefix_directory_join
 from ..constants import VERSION_PINS
+from ..utils.path import prefix_directory_join
 
 __all__ = [
     "get_version",

--- a/src/pyobo/api/utils.py
+++ b/src/pyobo/api/utils.py
@@ -8,6 +8,7 @@ from typing import Optional
 import bioversions
 
 from ..utils.path import prefix_directory_join
+from ..constants import VERSION_PINS
 
 __all__ = [
     "get_version",
@@ -25,6 +26,10 @@ def get_version(prefix: str) -> Optional[str]:
     :param prefix: the resource name
     :return: The version if available else None
     """
+    # Prioritize loaded environmental variable VERSION_PINS dictionary
+    version = VERSION_PINS.get(prefix)
+    if version:
+        return version
     try:
         version = bioversions.get_version(prefix)
     except KeyError:

--- a/src/pyobo/cli/lookup.py
+++ b/src/pyobo/cli/lookup.py
@@ -282,7 +282,7 @@ def ancestors(prefix: str, identifier: str, force: bool, version: Optional[str])
     """Look up ancestors."""
     curies = get_ancestors(prefix=prefix, identifier=identifier, force=force, version=version)
     for curie in sorted(curies or []):
-        click.echo(f"{curie}\t{get_name_by_curie(curie, version)}")
+        click.echo(f"{curie}\t{get_name_by_curie(curie, version=version)}")
 
 
 @lookup.command()
@@ -295,7 +295,7 @@ def descendants(prefix: str, identifier: str, force: bool, version: Optional[str
     """Look up descendants."""
     curies = get_descendants(prefix=prefix, identifier=identifier, force=force, version=version)
     for curie in sorted(curies or []):
-        click.echo(f"{curie}\t{get_name_by_curie(curie, version)}")
+        click.echo(f"{curie}\t{get_name_by_curie(curie, version=version)}")
 
 
 @lookup.command()

--- a/src/pyobo/cli/lookup.py
+++ b/src/pyobo/cli/lookup.py
@@ -282,7 +282,7 @@ def ancestors(prefix: str, identifier: str, force: bool, version: Optional[str])
     """Look up ancestors."""
     curies = get_ancestors(prefix=prefix, identifier=identifier, force=force, version=version)
     for curie in sorted(curies or []):
-        click.echo(f"{curie}\t{get_name_by_curie(curie)}")
+        click.echo(f"{curie}\t{get_name_by_curie(curie, version)}")
 
 
 @lookup.command()
@@ -295,7 +295,7 @@ def descendants(prefix: str, identifier: str, force: bool, version: Optional[str
     """Look up descendants."""
     curies = get_descendants(prefix=prefix, identifier=identifier, force=force, version=version)
     for curie in sorted(curies or []):
-        click.echo(f"{curie}\t{get_name_by_curie(curie)}")
+        click.echo(f"{curie}\t{get_name_by_curie(curie, version)}")
 
 
 @lookup.command()

--- a/src/pyobo/constants.py
+++ b/src/pyobo/constants.py
@@ -2,20 +2,15 @@
 
 """Constants for PyOBO."""
 
-import logging
-import re
-import os
 import json
-import click
+import logging
+import os
+import re
 
+import click
 import pystow
 
-__all__ = [
-    "RAW_DIRECTORY",
-    "DATABASE_DIRECTORY",
-    "SPECIES_REMAPPING",
-    "VERSION_PINS"
-]
+__all__ = ["RAW_DIRECTORY", "DATABASE_DIRECTORY", "SPECIES_REMAPPING", "VERSION_PINS"]
 
 logger = logging.getLogger(__name__)
 
@@ -112,18 +107,20 @@ try:
         VERSION_PINS = json.loads(VERSION_PINS_STR)
         for k, v in VERSION_PINS.items():
             if not isinstance(k, str) or not isinstance(v, str):
-                logger.error("The prefix and version name must both be "
-                                 "strings")
+                logger.error("The prefix and version name must both be " "strings")
             VERSION_PINS = {}
             break
 except ValueError as e:
-    logger.error("The value for the environment variable VERSION_PINS"
-                     " must be a valid JSON string")
+    logger.error(
+        "The value for the environment variable VERSION_PINS" " must be a valid JSON string"
+    )
     VERSION_PINS = {}
 
-click.echo(f"These are the resource versions that are pinned.\n{VERSION_PINS}. "
-           f"\nPyobo will download the latest version of a resource if it's "
-           f"not pinned.\nIf you want to use a specific version of a "
-           f"resource, edit your VERSION_PINS environmental "
-           f"variable which is a JSON string to include a prefix and version "
-           f"name.")
+click.echo(
+    f"These are the resource versions that are pinned.\n{VERSION_PINS}. "
+    f"\nPyobo will download the latest version of a resource if it's "
+    f"not pinned.\nIf you want to use a specific version of a "
+    f"resource, edit your VERSION_PINS environmental "
+    f"variable which is a JSON string to include a prefix and version "
+    f"name."
+)

--- a/src/pyobo/constants.py
+++ b/src/pyobo/constants.py
@@ -112,11 +112,14 @@ try:
         VERSION_PINS = json.loads(VERSION_PINS_STR)
         for k, v in VERSION_PINS.items():
             if not isinstance(k, str) or not isinstance(v, str):
-                raise ValueError("The prefix and version name must both be "
+                logger.error("The prefix and version name must both be "
                                  "strings")
-except Exception as e:
-    raise ValueError("The value for the environment variable VERSION_PINS"
-                     " must be a valid JSON string") from e
+            VERSION_PINS = {}
+            break
+except ValueError as e:
+    logger.error("The value for the environment variable VERSION_PINS"
+                     " must be a valid JSON string")
+    VERSION_PINS = {}
 
 click.echo(f"These are the resource versions that are pinned.\n{VERSION_PINS}. "
            f"\nPyobo will download the latest version of a resource if it's "

--- a/src/pyobo/constants.py
+++ b/src/pyobo/constants.py
@@ -6,6 +6,7 @@ import logging
 import re
 import os
 import json
+import click
 
 import pystow
 
@@ -116,3 +117,10 @@ try:
 except Exception as e:
     raise ValueError("The value for the environment variable VERSION_PINS"
                      " must be a valid JSON string") from e
+
+click.echo(f"These are the resource versions that are pinned.\n{VERSION_PINS}. "
+           f"\nPyobo will download the latest version of a resource if it's "
+           f"not pinned.\nIf you want to use a specific version of a "
+           f"resource, edit your VERSION_PINS environmental "
+           f"variable which is a JSON string to include a prefix and version "
+           f"name.")

--- a/src/pyobo/constants.py
+++ b/src/pyobo/constants.py
@@ -112,7 +112,7 @@ try:
             break
 except ValueError as e:
     logger.error(
-        "The value for the environment variable VERSION_PINS" " must be a valid JSON string"
+        "The value for the environment variable VERSION_PINS must be a valid JSON string: %s" % e
     )
     VERSION_PINS = {}
 

--- a/src/pyobo/constants.py
+++ b/src/pyobo/constants.py
@@ -4,6 +4,8 @@
 
 import logging
 import re
+import os
+import json
 
 import pystow
 
@@ -11,6 +13,7 @@ __all__ = [
     "RAW_DIRECTORY",
     "DATABASE_DIRECTORY",
     "SPECIES_REMAPPING",
+    "VERSION_PINS"
 ]
 
 logger = logging.getLogger(__name__)
@@ -80,7 +83,6 @@ TYPEDEFS_FILE = "typedefs.tsv.gz"
 SPECIES_RECORD = "5334738"
 SPECIES_FILE = "species.tsv.gz"
 
-
 NCBITAXON_PREFIX = "NCBITaxon"
 DATE_FORMAT = "%d:%m:%Y %H:%M"
 PROVENANCE_PREFIXES = {
@@ -99,3 +101,18 @@ PROVENANCE_PREFIXES = {
     "isbn",
     "issn",
 }
+
+# Load version pin dictionary from the environmental variable VERSION_PINS
+try:
+    VERSION_PINS_STR = os.getenv("VERSION_PINS")
+    if not VERSION_PINS_STR:
+        VERSION_PINS = {}
+    else:
+        VERSION_PINS = json.loads(VERSION_PINS_STR)
+        for k, v in VERSION_PINS.items():
+            if not isinstance(k, str) or not isinstance(v, str):
+                raise ValueError("The prefix and version name must both be "
+                                 "strings")
+except Exception as e:
+    raise ValueError("The value for the environment variable VERSION_PINS"
+                     " must be a valid JSON string") from e

--- a/src/pyobo/sources/antibodyregistry.py
+++ b/src/pyobo/sources/antibodyregistry.py
@@ -10,8 +10,8 @@ from bioregistry.utils import removeprefix
 from tqdm.auto import tqdm
 
 from pyobo import Obo, Term
-from pyobo.utils.path import ensure_df
 from pyobo.api.utils import get_version
+from pyobo.utils.path import ensure_df
 
 __all__ = [
     "AntibodyRegistryGetter",

--- a/src/pyobo/sources/antibodyregistry.py
+++ b/src/pyobo/sources/antibodyregistry.py
@@ -5,13 +5,13 @@
 import logging
 from typing import Iterable, Mapping, Optional
 
-import bioversions
 import pandas as pd
 from bioregistry.utils import removeprefix
 from tqdm.auto import tqdm
 
 from pyobo import Obo, Term
 from pyobo.utils.path import ensure_df
+from pyobo.api.utils import get_version
 
 __all__ = [
     "AntibodyRegistryGetter",
@@ -27,7 +27,7 @@ CHUNKSIZE = 20_000
 def get_chunks(*, force: bool = False, version: Optional[str] = None) -> pd.DataFrame:
     """Get the BioGRID identifiers mapping dataframe."""
     if version is None:
-        version = bioversions.get_version(PREFIX)
+        version = get_version(PREFIX)
     df = ensure_df(
         PREFIX,
         url=URL,

--- a/src/pyobo/sources/biogrid.py
+++ b/src/pyobo/sources/biogrid.py
@@ -5,12 +5,12 @@
 from functools import partial
 from typing import Mapping, Optional
 
-import bioversions
 import pandas as pd
 
 from pyobo.resources.ncbitaxon import get_ncbitaxon_id
 from pyobo.utils.cache import cached_mapping
 from pyobo.utils.path import ensure_df, prefix_directory_join
+from pyobo.api.utils import get_version
 
 PREFIX = "biogrid"
 BASE_URL = "https://downloads.thebiogrid.org/Download/BioGRID/Release-Archive"
@@ -52,7 +52,7 @@ def _lookup(name: str) -> Optional[str]:
 
 def get_df() -> pd.DataFrame:
     """Get the BioGRID identifiers mapping dataframe."""
-    version = bioversions.get_version("biogrid")
+    version = get_version("biogrid")
     url = f"{BASE_URL}/BIOGRID-{version}/BIOGRID-IDENTIFIERS-{version}.tab.zip"
     df = ensure_df(PREFIX, url=url, skiprows=28, dtype=str, version=version)
     df["taxonomy_id"] = df["ORGANISM_OFFICIAL_NAME"].map(_lookup)
@@ -65,7 +65,7 @@ def get_df() -> pd.DataFrame:
         "cache",
         "xrefs",
         name="ncbigene.tsv",
-        version=partial(bioversions.get_version, PREFIX),
+        version=partial(get_version, PREFIX),
     ),
     header=["biogrid_id", "ncbigene_id"],
 )

--- a/src/pyobo/sources/biogrid.py
+++ b/src/pyobo/sources/biogrid.py
@@ -7,10 +7,10 @@ from typing import Mapping, Optional
 
 import pandas as pd
 
+from pyobo.api.utils import get_version
 from pyobo.resources.ncbitaxon import get_ncbitaxon_id
 from pyobo.utils.cache import cached_mapping
 from pyobo.utils.path import ensure_df, prefix_directory_join
-from pyobo.api.utils import get_version
 
 PREFIX = "biogrid"
 BASE_URL = "https://downloads.thebiogrid.org/Download/BioGRID/Release-Archive"

--- a/src/pyobo/sources/hgnc.py
+++ b/src/pyobo/sources/hgnc.py
@@ -10,7 +10,7 @@ from collections import Counter, defaultdict
 from operator import attrgetter
 from typing import DefaultDict, Dict, Iterable, Optional
 
-import bioversions
+
 from tabulate import tabulate
 from tqdm.auto import tqdm
 
@@ -29,6 +29,7 @@ from pyobo.struct import (
 )
 from pyobo.struct.typedef import exact_match
 from pyobo.utils.path import ensure_path, prefix_directory_join
+from pyobo.api.utils import get_version
 
 __all__ = [
     "HGNCGetter",
@@ -241,7 +242,7 @@ def get_obo(*, force: bool = False) -> Obo:
 def get_terms(version: Optional[str] = None, force: bool = False) -> Iterable[Term]:  # noqa:C901
     """Get HGNC terms."""
     if version is None:
-        version = bioversions.get_version("hgnc")
+        version = get_version("hgnc")
     unhandled_entry_keys: typing.Counter[str] = Counter()
     unhandle_locus_types: DefaultDict[str, Dict[str, Term]] = defaultdict(dict)
     path = ensure_path(

--- a/src/pyobo/sources/hgnc.py
+++ b/src/pyobo/sources/hgnc.py
@@ -10,10 +10,10 @@ from collections import Counter, defaultdict
 from operator import attrgetter
 from typing import DefaultDict, Dict, Iterable, Optional
 
-
 from tabulate import tabulate
 from tqdm.auto import tqdm
 
+from pyobo.api.utils import get_version
 from pyobo.struct import (
     Obo,
     Reference,
@@ -29,7 +29,6 @@ from pyobo.struct import (
 )
 from pyobo.struct.typedef import exact_match
 from pyobo.utils.path import ensure_path, prefix_directory_join
-from pyobo.api.utils import get_version
 
 __all__ = [
     "HGNCGetter",

--- a/src/pyobo/sources/mesh.py
+++ b/src/pyobo/sources/mesh.py
@@ -333,6 +333,7 @@ def get_mesh_category_curies(
     """
     if version is None:
         version = get_version("mesh")
+        assert version is not None
     tree_to_mesh = get_tree_to_mesh_id(version=version)
     rv = []
     for i in range(1, 100):

--- a/src/pyobo/sources/mesh.py
+++ b/src/pyobo/sources/mesh.py
@@ -11,12 +11,12 @@ from xml.etree.ElementTree import Element
 
 from tqdm.auto import tqdm
 
+from pyobo.api.utils import get_version
 from pyobo.identifier_utils import standardize_ec
 from pyobo.struct import Obo, Reference, Synonym, Term
 from pyobo.utils.cache import cached_json, cached_mapping
 from pyobo.utils.io import parse_xml_gz
 from pyobo.utils.path import ensure_path, prefix_directory_join
-from pyobo.api.utils import get_version
 
 __all__ = [
     "MeSHGetter",

--- a/src/pyobo/sources/mesh.py
+++ b/src/pyobo/sources/mesh.py
@@ -16,6 +16,7 @@ from pyobo.struct import Obo, Reference, Synonym, Term
 from pyobo.utils.cache import cached_json, cached_mapping
 from pyobo.utils.io import parse_xml_gz
 from pyobo.utils.path import ensure_path, prefix_directory_join
+from pyobo.api.utils import get_version
 
 __all__ = [
     "MeSHGetter",
@@ -331,9 +332,7 @@ def get_mesh_category_curies(
     .. seealso:: https://meshb.nlm.nih.gov/treeView
     """
     if version is None:
-        import bioversions
-
-        version = bioversions.get_version("mesh")
+        version = get_version("mesh")
     tree_to_mesh = get_tree_to_mesh_id(version=version)
     rv = []
     for i in range(1, 100):

--- a/src/pyobo/sources/pubchem.py
+++ b/src/pyobo/sources/pubchem.py
@@ -5,16 +5,15 @@
 import logging
 from typing import Iterable, Mapping, Optional
 
-
 import pandas as pd
 from bioregistry.utils import removeprefix
 from tqdm.auto import tqdm
 
 from ..api import get_name_id_mapping
+from ..api.utils import get_version
 from ..struct import Obo, Reference, Synonym, Term
 from ..utils.iter import iterate_gzips_together
 from ..utils.path import ensure_df, ensure_path
-from ..api.utils import get_version
 
 __all__ = [
     "PubChemCompoundGetter",

--- a/src/pyobo/sources/pubchem.py
+++ b/src/pyobo/sources/pubchem.py
@@ -5,7 +5,7 @@
 import logging
 from typing import Iterable, Mapping, Optional
 
-import bioversions
+
 import pandas as pd
 from bioregistry.utils import removeprefix
 from tqdm.auto import tqdm
@@ -14,6 +14,7 @@ from ..api import get_name_id_mapping
 from ..struct import Obo, Reference, Synonym, Term
 from ..utils.iter import iterate_gzips_together
 from ..utils.path import ensure_df, ensure_path
+from ..api.utils import get_version
 
 __all__ = [
     "PubChemCompoundGetter",
@@ -26,7 +27,7 @@ PREFIX = "pubchem.compound"
 
 def _get_pubchem_extras_url(version: Optional[str], end: str) -> str:
     if version is None:
-        version = bioversions.get_version("pubchem")
+        version = get_version("pubchem")
     return f"ftp://ftp.ncbi.nlm.nih.gov/pubchem/Compound/Monthly/{version}/Extras/{end}"
 
 
@@ -100,7 +101,7 @@ def get_pubchem_id_to_mesh_id(version: str) -> Mapping[str, str]:
 
 def _ensure_cid_name_path(*, version: Optional[str] = None, force: bool = False) -> str:
     if version is None:
-        version = bioversions.get_version("pubchem")
+        version = get_version("pubchem")
     # 2 tab-separated columns: compound_id, name
     cid_name_url = _get_pubchem_extras_url(version, "CID-Title.gz")
     cid_name_path = ensure_path(PREFIX, url=cid_name_url, version=version, force=force)

--- a/src/pyobo/sources/rhea.py
+++ b/src/pyobo/sources/rhea.py
@@ -5,7 +5,6 @@
 import logging
 from typing import TYPE_CHECKING, Dict, Iterable, Optional
 
-import bioversions
 import pystow
 
 from pyobo.struct import Obo, Reference, Term
@@ -21,6 +20,7 @@ from pyobo.struct.typedef import (
     reaction_enabled_by_molecular_function,
 )
 from pyobo.utils.path import ensure_df
+from pyobo.api.utils import get_version
 
 if TYPE_CHECKING:
     import rdflib
@@ -63,7 +63,7 @@ def ensure_rhea_rdf(version: Optional[str] = None, force: bool = False) -> "rdfl
     """Get the Rhea RDF graph."""
     # see docs: https://ftp.expasy.org/databases/rhea/rdf/rhea_rdf_documentation.pdf
     if version is None:
-        version = bioversions.get_version(PREFIX)
+        version = get_version(PREFIX)
     return pystow.ensure_rdf(
         "pyobo",
         "raw",

--- a/src/pyobo/sources/rhea.py
+++ b/src/pyobo/sources/rhea.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Dict, Iterable, Optional
 
 import pystow
 
+from pyobo.api.utils import get_version
 from pyobo.struct import Obo, Reference, Term
 from pyobo.struct.typedef import (
     TypeDef,
@@ -20,7 +21,6 @@ from pyobo.struct.typedef import (
     reaction_enabled_by_molecular_function,
 )
 from pyobo.utils.path import ensure_df
-from pyobo.api.utils import get_version
 
 if TYPE_CHECKING:
     import rdflib

--- a/src/pyobo/sources/uniprot/uniprot.py
+++ b/src/pyobo/sources/uniprot/uniprot.py
@@ -9,12 +9,12 @@ from typing import Iterable, List, Optional, cast
 from tqdm.auto import tqdm
 
 from pyobo import Obo, Reference
+from pyobo.api.utils import get_version
 from pyobo.constants import RAW_MODULE
 from pyobo.identifier_utils import standardize_ec
 from pyobo.struct import Term, derives_from, enables, from_species, participates_in
 from pyobo.struct.typedef import gene_product_of, located_in, molecularly_interacts_with
 from pyobo.utils.io import open_reader
-from pyobo.api.utils import get_version
 
 PREFIX = "uniprot"
 BASE_URL = "https://rest.uniprot.org/uniprotkb/stream"

--- a/src/pyobo/sources/uniprot/uniprot.py
+++ b/src/pyobo/sources/uniprot/uniprot.py
@@ -6,7 +6,6 @@ from operator import attrgetter
 from pathlib import Path
 from typing import Iterable, List, Optional, cast
 
-import bioversions
 from tqdm.auto import tqdm
 
 from pyobo import Obo, Reference
@@ -15,6 +14,7 @@ from pyobo.identifier_utils import standardize_ec
 from pyobo.struct import Term, derives_from, enables, from_species, participates_in
 from pyobo.struct.typedef import gene_product_of, located_in, molecularly_interacts_with
 from pyobo.utils.io import open_reader
+from pyobo.api.utils import get_version
 
 PREFIX = "uniprot"
 BASE_URL = "https://rest.uniprot.org/uniprotkb/stream"
@@ -166,7 +166,7 @@ def _parse_go(go_terms) -> List[Reference]:
 def ensure(version: Optional[str] = None, force: bool = False) -> Path:
     """Ensure the reviewed uniprot names are available."""
     if version is None:
-        version = bioversions.get_version("uniprot")
+        version = get_version("uniprot")
     return RAW_MODULE.ensure(
         PREFIX,
         version,

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -56,6 +56,7 @@ from .typedef import (
     term_replaced_by,
 )
 from .utils import comma_separate, obo_escape_slim
+from ..api.utils import get_version
 from ..constants import (
     DATE_FORMAT,
     NCBITAXON_PREFIX,
@@ -68,7 +69,6 @@ from ..identifier_utils import normalize_curie
 from ..utils.io import multidict, write_iterable_tsv
 from ..utils.misc import obo_to_owl
 from ..utils.path import get_prefix_obo_path, prefix_directory_join
-from ..api.utils import get_version
 
 __all__ = [
     "Synonym",

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -68,6 +68,7 @@ from ..identifier_utils import normalize_curie
 from ..utils.io import multidict, write_iterable_tsv
 from ..utils.misc import obo_to_owl
 from ..utils.path import get_prefix_obo_path, prefix_directory_join
+from ..api.utils import get_version
 
 __all__ = [
     "Synonym",
@@ -583,10 +584,8 @@ class Obo:
 
     def _get_version(self) -> Optional[str]:
         if self.bioversions_key:
-            import bioversions
-
             try:
-                return bioversions.get_version(self.bioversions_key)
+                return get_version(self.bioversions_key)
             except KeyError:
                 logger.warning(f"[{self.bioversions_key}] bioversions doesn't list this resource ")
             except IOError:

--- a/src/pyobo/utils/path.py
+++ b/src/pyobo/utils/path.py
@@ -25,7 +25,7 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-VersionHint = Union[None, str, Callable[[], str]]
+VersionHint = Union[None, str, Callable[[], Optional[str]]]
 
 requests_ftp.monkeypatch_session()
 
@@ -46,6 +46,7 @@ def prefix_directory_join(
         logger.info("[%s] got version %s", prefix, version)
     elif not isinstance(version, str):
         raise TypeError(f"Invalid type: {version} ({type(version)})")
+    assert version is not None
     version = cleanup_version(version, prefix=prefix)
     if version is not None and "/" in version:
         raise ValueError(f"[{prefix}] Can not have slash in version: {version}")

--- a/src/pyobo/xrefdb/sources/chembl.py
+++ b/src/pyobo/xrefdb/sources/chembl.py
@@ -4,7 +4,6 @@
 
 from typing import Optional
 
-import bioversions
 import pandas as pd
 
 from pyobo.constants import (
@@ -16,6 +15,7 @@ from pyobo.constants import (
     XREF_COLUMNS,
 )
 from pyobo.utils.path import ensure_df
+from pyobo.api.utils import get_version
 
 CHEMBL_COMPOUND_PREFIX = "chembl.compound"
 CHEMBL_TARGET_PREFIX = "chembl.target"
@@ -26,7 +26,7 @@ def get_chembl_compound_equivalences_raw(
 ) -> pd.DataFrame:
     """Get the chemical representations raw dataframe."""
     if version is None:
-        version = bioversions.get_version("chembl")
+        version = get_version("chembl")
 
     base_url = f"ftp://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBLdb/releases/chembl_{version}"
     url = f"{base_url}/chembl_{version}_chemreps.txt.gz"
@@ -36,7 +36,7 @@ def get_chembl_compound_equivalences_raw(
 def get_chembl_compound_equivalences(version: Optional[str] = None) -> pd.DataFrame:
     """Get ChEMBL chemical equivalences."""
     if version is None:
-        version = bioversions.get_version("chembl")
+        version = get_version("chembl")
 
     df = get_chembl_compound_equivalences_raw(version=version)
     rows = []
@@ -55,7 +55,7 @@ def get_chembl_compound_equivalences(version: Optional[str] = None) -> pd.DataFr
 def get_chembl_protein_equivalences(version: Optional[str] = None) -> pd.DataFrame:
     """Get ChEMBL protein equivalences."""
     if version is None:
-        version = bioversions.get_version("chembl")
+        version = get_version("chembl")
 
     url = f"ftp://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBLdb/releases/chembl_{version}/chembl_uniprot_mapping.txt"
     df = ensure_df(
@@ -75,7 +75,7 @@ def get_chembl_protein_equivalences(version: Optional[str] = None) -> pd.DataFra
 def get_chembl_xrefs_df(version: Optional[str] = None) -> pd.DataFrame:
     """Get all ChEBML equivalences."""
     if version is None:
-        version = bioversions.get_version("chembl")
+        version = get_version("chembl")
 
     return pd.concat(
         [

--- a/src/pyobo/xrefdb/sources/chembl.py
+++ b/src/pyobo/xrefdb/sources/chembl.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import pandas as pd
 
+from pyobo.api.utils import get_version
 from pyobo.constants import (
     PROVENANCE,
     SOURCE_ID,
@@ -15,7 +16,6 @@ from pyobo.constants import (
     XREF_COLUMNS,
 )
 from pyobo.utils.path import ensure_df
-from pyobo.api.utils import get_version
 
 CHEMBL_COMPOUND_PREFIX = "chembl.compound"
 CHEMBL_TARGET_PREFIX = "chembl.target"

--- a/src/pyobo/xrefdb/sources/pubchem.py
+++ b/src/pyobo/xrefdb/sources/pubchem.py
@@ -4,11 +4,11 @@
 
 from typing import Optional
 
-import bioversions
 import pandas as pd
 
 from ...constants import XREF_COLUMNS
 from ...sources.pubchem import _get_pubchem_extras_url, get_pubchem_id_to_mesh_id
+from ...api.utils import get_version
 
 __all__ = [
     "get_pubchem_mesh_df",
@@ -18,7 +18,7 @@ __all__ = [
 def get_pubchem_mesh_df(version: Optional[str] = None) -> pd.DataFrame:
     """Get PubChem Compound-MeSH xrefs."""
     if version is None:
-        version = bioversions.get_version("pubchem")
+        version = get_version("pubchem")
     cid_mesh_url = _get_pubchem_extras_url(version, "CID-MeSH")
     return pd.DataFrame(
         [

--- a/src/pyobo/xrefdb/sources/pubchem.py
+++ b/src/pyobo/xrefdb/sources/pubchem.py
@@ -19,6 +19,7 @@ def get_pubchem_mesh_df(version: Optional[str] = None) -> pd.DataFrame:
     """Get PubChem Compound-MeSH xrefs."""
     if version is None:
         version = get_version("pubchem")
+        assert version is not None
     cid_mesh_url = _get_pubchem_extras_url(version, "CID-MeSH")
     return pd.DataFrame(
         [

--- a/src/pyobo/xrefdb/sources/pubchem.py
+++ b/src/pyobo/xrefdb/sources/pubchem.py
@@ -6,9 +6,9 @@ from typing import Optional
 
 import pandas as pd
 
+from ...api.utils import get_version
 from ...constants import XREF_COLUMNS
 from ...sources.pubchem import _get_pubchem_extras_url, get_pubchem_id_to_mesh_id
-from ...api.utils import get_version
 
 __all__ = [
     "get_pubchem_mesh_df",


### PR DESCRIPTION
This draft PR enables users to define a prefix to version mapping stored in an environmental variable: `VERSION_PINS` which will allow users to define the configured version they would like to use for a resource to avoid downloading new versions of the resource. The problem with the current argument-based approach is that in many settings PyOBO is being accessed indirectly so it would be very inconvenient to control versions via function arguments.

Places in the code where `bioversions.get_versions` is used has been replaced by `pyobo.api.utils.get_version` as we call `bioversions.get_versions` in  `pyobo.api.utils.get_version`.  Please let me know if this change is not needed. 