### PR TITLE
Fix version pins

### DIFF
--- a/src/pyobo/api/utils.py
+++ b/src/pyobo/api/utils.py
@@ -31,7 +31,7 @@ def get_version(prefix: str) -> Optional[str]:
     :param prefix: the resource name
     :return: The version if available else None
     """
-    # Prioritize loaded environmental variable VERSION_PINS dictionary
+    # Prioritize loaded environment variable PYOBO_VERSION_PINS dictionary
     version = get_version_pins().get(prefix)
     if version:
         return version
@@ -75,7 +75,8 @@ def get_version_pins() -> dict[str, str]:
             version_pins = json.loads(version_pins_str)
         except ValueError as e:
             logger.error(
-                "The value for the environment variable VERSION_PINS must be a valid JSON string: %s"
+                "The value for the environment variable PYOBO_VERSION_PINS "
+                "must be a valid JSON string: %s"
                 % e
             )
             version_pins = {}

--- a/src/pyobo/api/utils.py
+++ b/src/pyobo/api/utils.py
@@ -93,7 +93,7 @@ def get_version_pins() -> dict[str, str]:
             f"{version_pins}. "
             f"\nPyobo will download the latest version of a resource if it's "
             f"not pinned.\nIf you want to use a specific version of a "
-            f"resource, edit your VERSION_PINS environmental "
+            f"resource, edit your PYOBO_VERSION_PINS environmental "
             f"variable which is a JSON string to include a prefix and version "
             f"name."
         )

--- a/src/pyobo/api/utils.py
+++ b/src/pyobo/api/utils.py
@@ -3,17 +3,21 @@
 """Utilities for high-level API."""
 
 import json
+import logging
+import os
 from typing import Optional
 
 import bioversions
 
-from ..constants import VERSION_PINS
 from ..utils.path import prefix_directory_join
 
 __all__ = [
     "get_version",
+    "get_version_pins",
     "VersionError",
 ]
+
+logger = logging.getLogger(__name__)
 
 
 class VersionError(ValueError):
@@ -27,7 +31,7 @@ def get_version(prefix: str) -> Optional[str]:
     :return: The version if available else None
     """
     # Prioritize loaded environmental variable VERSION_PINS dictionary
-    version = VERSION_PINS.get(prefix)
+    version = get_version_pins().get(prefix)
     if version:
         return version
     try:
@@ -46,3 +50,40 @@ def get_version(prefix: str) -> Optional[str]:
         return data["version"]
 
     return None
+
+
+def get_version_pins():
+    """Retrieve the resource version pins."""
+    try:
+        version_pins_str = os.getenv("VERSION_PINS")
+        if not version_pins_str:
+            version_pins = {}
+        else:
+            version_pins = json.loads(version_pins_str)
+            invalid_prefixes = []
+            for prefix, version in version_pins.items():
+                if not isinstance(prefix, str) or not isinstance(version, str):
+                    logger.error(
+                        f"The prefix:{prefix} and version:{version} name must both be strings"
+                    )
+                    invalid_prefixes.append(prefix)
+            for prefix in invalid_prefixes:
+                version_pins.pop(prefix)
+    except ValueError as e:
+        logger.error(
+            "The value for the environment variable VERSION_PINS must be a valid JSON string: %s"
+            % e
+        )
+        version_pins = {}
+
+    if version_pins:
+        logger.debug(
+            f"These are the resource versions that are pinned.\n"
+            f"{version_pins}. "
+            f"\nPyobo will download the latest version of a resource if it's "
+            f"not pinned.\nIf you want to use a specific version of a "
+            f"resource, edit your VERSION_PINS environmental "
+            f"variable which is a JSON string to include a prefix and version "
+            f"name."
+        )
+    return version_pins

--- a/src/pyobo/api/utils.py
+++ b/src/pyobo/api/utils.py
@@ -76,8 +76,7 @@ def get_version_pins() -> dict[str, str]:
         except ValueError as e:
             logger.error(
                 "The value for the environment variable PYOBO_VERSION_PINS "
-                "must be a valid JSON string: %s"
-                % e
+                "must be a valid JSON string: %s" % e
             )
             version_pins = {}
         invalid_prefixes = []

--- a/src/pyobo/api/utils.py
+++ b/src/pyobo/api/utils.py
@@ -55,8 +55,7 @@ def get_version(prefix: str) -> Optional[str]:
 
 @lru_cache(1)
 def get_version_pins() -> dict[str, str]:
-    """
-    Retrieve user-defined resource version pins.
+    """Retrieve user-defined resource version pins.
 
     To set your own resource pins, set your machine's environmental variable
     "PYOBO_VERSION_PINS" to a JSON string containing string resource prefixes
@@ -69,32 +68,29 @@ def get_version_pins() -> dict[str, str]:
     """
     version_pins_str = os.getenv("PYOBO_VERSION_PINS")
     if not version_pins_str:
-        version_pins = {}
-    else:
-        try:
-            version_pins = json.loads(version_pins_str)
-        except ValueError as e:
-            logger.error(
-                "The value for the environment variable PYOBO_VERSION_PINS "
-                "must be a valid JSON string: %s" % e
-            )
-            version_pins = {}
-        invalid_prefixes = []
-        for prefix, version in version_pins.items():
-            if not isinstance(prefix, str) or not isinstance(version, str):
-                logger.error(f"The prefix:{prefix} and version:{version} name must both be strings")
-                invalid_prefixes.append(prefix)
-        for prefix in invalid_prefixes:
-            version_pins.pop(prefix)
+        return {}
 
-    if version_pins:
-        logger.debug(
-            f"These are the resource versions that are pinned.\n"
-            f"{version_pins}. "
-            f"\nPyobo will download the latest version of a resource if it's "
-            f"not pinned.\nIf you want to use a specific version of a "
-            f"resource, edit your PYOBO_VERSION_PINS environmental "
-            f"variable which is a JSON string to include a prefix and version "
-            f"name."
+    try:
+        version_pins = json.loads(version_pins_str)
+    except ValueError as e:
+        logger.error(
+            "The value for the environment variable PYOBO_VERSION_PINS "
+            "must be a valid JSON string: %s" % e
         )
+        return {}
+
+    for prefix, version in list(version_pins.items()):
+        if not isinstance(prefix, str) or not isinstance(version, str):
+            logger.error(f"The prefix:{prefix} and version:{version} name must both be strings")
+            del version_pins[prefix]
+
+    logger.debug(
+        f"These are the resource versions that are pinned.\n"
+        f"{version_pins}. "
+        f"\nPyobo will download the latest version of a resource if it's "
+        f"not pinned.\nIf you want to use a specific version of a "
+        f"resource, edit your PYOBO_VERSION_PINS environmental "
+        f"variable which is a JSON string to include a prefix and version "
+        f"name."
+    )
     return version_pins

--- a/src/pyobo/api/utils.py
+++ b/src/pyobo/api/utils.py
@@ -75,7 +75,8 @@ def get_version_pins() -> dict[str, str]:
     except ValueError as e:
         logger.error(
             "The value for the environment variable PYOBO_VERSION_PINS "
-            "must be a valid JSON string: %s" % e
+            "must be a valid JSON string: %s",
+            e,
         )
         return {}
 

--- a/src/pyobo/constants.py
+++ b/src/pyobo/constants.py
@@ -2,9 +2,7 @@
 
 """Constants for PyOBO."""
 
-import json
 import logging
-import os
 import re
 
 import pystow
@@ -13,8 +11,6 @@ __all__ = [
     "RAW_DIRECTORY",
     "DATABASE_DIRECTORY",
     "SPECIES_REMAPPING",
-    "VERSION_PINS",
-    "get_version_pins",
 ]
 
 logger = logging.getLogger(__name__)
@@ -102,43 +98,3 @@ PROVENANCE_PREFIXES = {
     "isbn",
     "issn",
 }
-
-
-def get_version_pins():
-    """Retrieve the resource version pins."""
-    try:
-        version_pins_str = os.getenv("VERSION_PINS")
-        if not version_pins_str:
-            version_pins = {}
-        else:
-            version_pins = json.loads(version_pins_str)
-            invalid_prefixes = []
-            for prefix, version in version_pins.items():
-                if not isinstance(prefix, str) or not isinstance(version, str):
-                    logger.error(
-                        f"The prefix:{prefix} and version:{version} name must both be strings"
-                    )
-                    invalid_prefixes.append(prefix)
-            for prefix in invalid_prefixes:
-                version_pins.pop(prefix)
-    except ValueError as e:
-        logger.error(
-            "The value for the environment variable VERSION_PINS must be a valid JSON string: %s"
-            % e
-        )
-        version_pins = {}
-
-    if version_pins:
-        logger.debug(
-            f"These are the resource versions that are pinned.\n"
-            f"{version_pins}. "
-            f"\nPyobo will download the latest version of a resource if it's "
-            f"not pinned.\nIf you want to use a specific version of a "
-            f"resource, edit your VERSION_PINS environmental "
-            f"variable which is a JSON string to include a prefix and version "
-            f"name."
-        )
-    return version_pins
-
-
-VERSION_PINS = get_version_pins()

--- a/src/pyobo/constants.py
+++ b/src/pyobo/constants.py
@@ -111,9 +111,9 @@ try:
         VERSION_PINS = json.loads(VERSION_PINS_STR)
         for k, v in VERSION_PINS.items():
             if not isinstance(k, str) or not isinstance(v, str):
-                logger.error("The prefix and version name must both be " "strings")
-            VERSION_PINS = {}
-            break
+                logger.error(
+                    f"The prefix: {k} and version: {v} name must both be strings")
+                VERSION_PINS.pop(k)
 except ValueError as e:
     logger.error(
         "The value for the environment variable VERSION_PINS must be a valid JSON string: %s" % e

--- a/src/pyobo/constants.py
+++ b/src/pyobo/constants.py
@@ -16,6 +16,7 @@ __all__ = [
     "VERSION_PINS",
 ]
 
+
 logger = logging.getLogger(__name__)
 
 PYOBO_MODULE = pystow.module("pyobo")
@@ -112,8 +113,7 @@ try:
         invalid_prefixes = []
         for prefix, version in VERSION_PINS.items():
             if not isinstance(prefix, str) or not isinstance(version, str):
-                logger.error(
-                    f"The prefix:{prefix} and version:{version} name must both be strings")
+                logger.error(f"The prefix:{prefix} and version:{version} name must both be strings")
                 invalid_prefixes.append(prefix)
         for prefix in invalid_prefixes:
             VERSION_PINS.pop(prefix)

--- a/src/pyobo/constants.py
+++ b/src/pyobo/constants.py
@@ -14,8 +14,8 @@ __all__ = [
     "DATABASE_DIRECTORY",
     "SPECIES_REMAPPING",
     "VERSION_PINS",
+    "get_version_pins",
 ]
-
 
 logger = logging.getLogger(__name__)
 
@@ -103,32 +103,42 @@ PROVENANCE_PREFIXES = {
     "issn",
 }
 
-# Load version pin dictionary from the environmental variable VERSION_PINS
-try:
-    VERSION_PINS_STR = os.getenv("VERSION_PINS")
-    if not VERSION_PINS_STR:
-        VERSION_PINS = {}
-    else:
-        VERSION_PINS = json.loads(VERSION_PINS_STR)
-        invalid_prefixes = []
-        for prefix, version in VERSION_PINS.items():
-            if not isinstance(prefix, str) or not isinstance(version, str):
-                logger.error(f"The prefix:{prefix} and version:{version} name must both be strings")
-                invalid_prefixes.append(prefix)
-        for prefix in invalid_prefixes:
-            VERSION_PINS.pop(prefix)
-except ValueError as e:
-    logger.error(
-        "The value for the environment variable VERSION_PINS must be a valid JSON string: %s" % e
-    )
-    VERSION_PINS = {}
 
-if VERSION_PINS:
-    logger.debug(
-        f"These are the resource versions that are pinned.\n{VERSION_PINS}. "
-        f"\nPyobo will download the latest version of a resource if it's "
-        f"not pinned.\nIf you want to use a specific version of a "
-        f"resource, edit your VERSION_PINS environmental "
-        f"variable which is a JSON string to include a prefix and version "
-        f"name."
-    )
+def get_version_pins():
+    """Retrieve the resource version pins."""
+    try:
+        version_pins_str = os.getenv("VERSION_PINS")
+        if not version_pins_str:
+            version_pins = {}
+        else:
+            version_pins = json.loads(version_pins_str)
+            invalid_prefixes = []
+            for prefix, version in version_pins.items():
+                if not isinstance(prefix, str) or not isinstance(version, str):
+                    logger.error(
+                        f"The prefix:{prefix} and version:{version} name must both be strings"
+                    )
+                    invalid_prefixes.append(prefix)
+            for prefix in invalid_prefixes:
+                version_pins.pop(prefix)
+    except ValueError as e:
+        logger.error(
+            "The value for the environment variable VERSION_PINS must be a valid JSON string: %s"
+            % e
+        )
+        version_pins = {}
+
+    if version_pins:
+        logger.debug(
+            f"These are the resource versions that are pinned.\n"
+            f"{version_pins}. "
+            f"\nPyobo will download the latest version of a resource if it's "
+            f"not pinned.\nIf you want to use a specific version of a "
+            f"resource, edit your VERSION_PINS environmental "
+            f"variable which is a JSON string to include a prefix and version "
+            f"name."
+        )
+    return version_pins
+
+
+VERSION_PINS = get_version_pins()

--- a/src/pyobo/constants.py
+++ b/src/pyobo/constants.py
@@ -109,11 +109,14 @@ try:
         VERSION_PINS = {}
     else:
         VERSION_PINS = json.loads(VERSION_PINS_STR)
-        for k, v in VERSION_PINS.items():
-            if not isinstance(k, str) or not isinstance(v, str):
+        invalid_prefixes = []
+        for prefix, version in VERSION_PINS.items():
+            if not isinstance(prefix, str) or not isinstance(version, str):
                 logger.error(
-                    f"The prefix: {k} and version: {v} name must both be strings")
-                VERSION_PINS.pop(k)
+                    f"The prefix:{prefix} and version:{version} name must both be strings")
+                invalid_prefixes.append(prefix)
+        for prefix in invalid_prefixes:
+            VERSION_PINS.pop(prefix)
 except ValueError as e:
     logger.error(
         "The value for the environment variable VERSION_PINS must be a valid JSON string: %s" % e

--- a/tests/test_version_pins.py
+++ b/tests/test_version_pins.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-"""Tests for PyOBO VERSION_PINS."""
+"""Tests for PyOBO version pins."""
 import os
 import unittest
 from unittest import mock

--- a/tests/test_version_pins.py
+++ b/tests/test_version_pins.py
@@ -12,7 +12,7 @@ MOCK_PYOBO_VERSION_PINS = '{"ncbitaxon": "2024-07-03", "vo":"2024-04-09", "chebi
 
 @mock.patch.dict(os.environ, {"PYOBO_VERSION_PINS": MOCK_PYOBO_VERSION_PINS})
 class TestVersionPins(unittest.TestCase):
-    """Test using VERSION_PINS."""
+    """Test using user-defined version pins."""
 
     def test_correct_version_pin_types(self):
         """Test resource and version type."""

--- a/tests/test_version_pins.py
+++ b/tests/test_version_pins.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for PyOBO VERSION_PINS."""
+
+import unittest
+
+from pyobo.api.utils import get_version
+from pyobo.constants import VERSION_PINS
+
+
+class TestVersionPins(unittest.TestCase):
+    """Test using VERSION_PINS."""
+
+    def test_correct_version_pin_types(self):
+        """Test resource and version type."""
+        for resource_prefix, version in VERSION_PINS.items():
+            self.assertIsInstance(resource_prefix, str)
+            self.assertIsInstance(version, str)
+
+    def test_use_correct_version_pin(self):
+        """Tests correct resource version is used."""
+        for resource_prefix, version in VERSION_PINS.items():
+            self.assertEqual(get_version(resource_prefix), version)

--- a/tests/test_version_pins.py
+++ b/tests/test_version_pins.py
@@ -14,6 +14,10 @@ MOCK_PYOBO_VERSION_PINS = '{"ncbitaxon": "2024-07-03", "vo":"2024-04-09", "chebi
 class TestVersionPins(unittest.TestCase):
     """Test using user-defined version pins."""
 
+    def setUp(self):
+        """Clear the cache before each test case."""
+        get_version_pins.cache_clear()
+
     def test_correct_version_pin_types(self):
         """Test resource and version type."""
         version_pins = get_version_pins()

--- a/tests/test_version_pins.py
+++ b/tests/test_version_pins.py
@@ -8,6 +8,7 @@ from unittest import mock
 from pyobo.api.utils import get_version, get_version_pins
 
 MOCK_PYOBO_VERSION_PINS = '{"ncbitaxon": "2024-07-03", "vo":"2024-04-09", "chebi":"235", "bfo":5}'
+FAULTY_MOCK_PYOBO_VERSION_PINS = "{'ncbitaxon': '2024-07-03'}"
 
 
 @mock.patch.dict(os.environ, {"PYOBO_VERSION_PINS": MOCK_PYOBO_VERSION_PINS})
@@ -30,3 +31,15 @@ class TestVersionPins(unittest.TestCase):
         version_pins = get_version_pins()
         for resource_prefix, version in version_pins.items():
             self.assertEqual(get_version(resource_prefix), version)
+
+    @mock.patch.dict(os.environ, {"PYOBO_VERSION_PINS": ""})
+    def test_empty_version_pins(self):
+        """Test empty version pins are processed correctly."""
+        version_pins = get_version_pins()
+        self.assertFalse(version_pins)
+
+    @mock.patch.dict(os.environ, {"PYOBO_VERSION_PINS": FAULTY_MOCK_PYOBO_VERSION_PINS})
+    def test_incorrectly_set_version_pins(self):
+        """Test erroneously set version pins are processed correctly."""
+        version_pins = get_version_pins()
+        self.assertFalse(version_pins)

--- a/tests/test_version_pins.py
+++ b/tests/test_version_pins.py
@@ -7,10 +7,10 @@ from unittest import mock
 
 from pyobo.api.utils import get_version, get_version_pins
 
-MOCK_VERSION_PINS = '{"ncbitaxon": "2024-07-03", "vo":"2024-04-09", ' '"chebi":"235", "bfo":5}'
+MOCK_PYOBO_VERSION_PINS = '{"ncbitaxon": "2024-07-03", "vo":"2024-04-09", "chebi":"235", "bfo":5}'
 
 
-@mock.patch.dict(os.environ, {"VERSION_PINS": MOCK_VERSION_PINS})
+@mock.patch.dict(os.environ, {"PYOBO_VERSION_PINS": MOCK_PYOBO_VERSION_PINS})
 class TestVersionPins(unittest.TestCase):
     """Test using VERSION_PINS."""
 

--- a/tests/test_version_pins.py
+++ b/tests/test_version_pins.py
@@ -5,10 +5,9 @@ import os
 import unittest
 from unittest import mock
 
-from pyobo.api.utils import get_version
-from pyobo.constants import get_version_pins
+from pyobo.api.utils import get_version, get_version_pins
 
-MOCK_VERSION_PINS = '{"ncbitaxon": "2024-05-08", "vo":"2024-04-09", ' '"chebi":"235", "bfo":5}'
+MOCK_VERSION_PINS = '{"ncbitaxon": "2024-07-03", "vo":"2024-04-09", ' '"chebi":"235", "bfo":5}'
 
 
 @mock.patch.dict(os.environ, {"VERSION_PINS": MOCK_VERSION_PINS})

--- a/tests/test_version_pins.py
+++ b/tests/test_version_pins.py
@@ -1,23 +1,29 @@
 # -*- coding: utf-8 -*-
 
 """Tests for PyOBO VERSION_PINS."""
-
+import os
 import unittest
+from unittest import mock
 
 from pyobo.api.utils import get_version
-from pyobo.constants import VERSION_PINS
+from pyobo.constants import get_version_pins
+
+MOCK_VERSION_PINS = '{"ncbitaxon": "2024-05-08", "vo":"2024-04-09", ' '"chebi":"235", "bfo":5}'
 
 
+@mock.patch.dict(os.environ, {"VERSION_PINS": MOCK_VERSION_PINS})
 class TestVersionPins(unittest.TestCase):
     """Test using VERSION_PINS."""
 
     def test_correct_version_pin_types(self):
         """Test resource and version type."""
-        for resource_prefix, version in VERSION_PINS.items():
+        version_pins = get_version_pins()
+        for resource_prefix, version in version_pins.items():
             self.assertIsInstance(resource_prefix, str)
             self.assertIsInstance(version, str)
 
     def test_use_correct_version_pin(self):
         """Tests correct resource version is used."""
-        for resource_prefix, version in VERSION_PINS.items():
+        version_pins = get_version_pins()
+        for resource_prefix, version in version_pins.items():
             self.assertEqual(get_version(resource_prefix), version)


### PR DESCRIPTION
This PR fixes a bug where `VERSION_PINS` is always set to an empty dictionary due to a misaligned indent. We also handle invalid prefixes and version datatypes more gracefully and make the logger more informative. 