### PR TITLE
Update path utilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
     "humanize",
     "tabulate",
     "cachier",
-    "pystow>=0.2.7",
+    "pystow>=0.6.0",
     "bioversions>=0.5.535",
     "bioregistry>=0.11.23",
     "bioontologies>=0.4.0",

--- a/src/pyobo/getters.py
+++ b/src/pyobo/getters.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import TypeVar
 
 import bioregistry
+import pystow.utils
 from bioontologies import robot
 from tqdm.auto import tqdm
 
@@ -143,8 +144,8 @@ def _ensure_ontology_path(prefix: str, force, version) -> tuple[str, Path] | tup
     ]:
         if url is not None:
             try:
-                path = Path(ensure_path(prefix, url=url, force=force, version=version))
-            except urllib.error.HTTPError:
+                path = ensure_path(prefix, url=url, force=force, version=version)
+            except (urllib.error.HTTPError, pystow.utils.DownloadError):
                 continue
             else:
                 return ontology_format, path

--- a/src/pyobo/sources/gwascentral_phenotype.py
+++ b/src/pyobo/sources/gwascentral_phenotype.py
@@ -49,7 +49,7 @@ def iter_terms(version: str, force: bool = False) -> Iterable[Term]:
         except OSError as e:
             tqdm.write(f"{n}: {e}")
             continue
-        with open(path) as file:
+        with path.open() as file:
             j = json.load(file)
 
         description = j.get("description")

--- a/src/pyobo/sources/gwascentral_phenotype.py
+++ b/src/pyobo/sources/gwascentral_phenotype.py
@@ -43,6 +43,8 @@ def iter_terms(version: str, force: bool = False) -> Iterable[Term]:
                 url=f"https://www.gwascentral.org/phenotype/HGVPM{n}?format=json",
                 name=f"HGVPM{n}.json",
                 force=force,
+                backend="requests",
+                timeout=1,
             )
         except OSError as e:
             tqdm.write(f"{n}: {e}")

--- a/src/pyobo/sources/hgnc.py
+++ b/src/pyobo/sources/hgnc.py
@@ -250,7 +250,7 @@ def get_terms(version: str | None = None, force: bool = False) -> Iterable[Term]
         version=version,
         name="hgnc_complete_set.json",
     )
-    with open(path) as file:
+    with path.open() as file:
         entries = json.load(file)["response"]["docs"]
 
     yield Term.from_triple("NCBITaxon", "9606", "Homo sapiens")

--- a/src/pyobo/sources/interpro.py
+++ b/src/pyobo/sources/interpro.py
@@ -91,7 +91,7 @@ def get_interpro_tree(version: str, force: bool = False):
     """Get InterPro Data source."""
     url = f"https://ftp.ebi.ac.uk/pub/databases/interpro/releases/{version}/ParentChildTreeFile.txt"
     path = ensure_path(PREFIX, url=url, version=version, force=force)
-    with open(path) as f:
+    with path.open() as f:
         return _parse_tree_helper(f)
 
 

--- a/src/pyobo/sources/kegg/api.py
+++ b/src/pyobo/sources/kegg/api.py
@@ -86,22 +86,14 @@ def ensure_list_genome(kegg_genome_id: str, *, version: str) -> str:
     )
 
 
-def ensure_conv_genome_uniprot(
-    kegg_genome_id: str, *, version: str, error_on_missing: bool = False
-) -> str | None:
+def ensure_conv_genome_uniprot(kegg_genome_id: str, *, version: str) -> str | None:
     """Get the KEGG-UniProt protein map for the given organism."""
-    return _ensure_conv_genome_helper(
-        kegg_genome_id, "uniprot", version=version, error_on_missing=error_on_missing
-    )
+    return _ensure_conv_genome_helper(kegg_genome_id, "uniprot", version=version)
 
 
-def ensure_conv_genome_ncbigene(
-    kegg_genome_id: str, *, version: str, error_on_missing: bool = False
-) -> str | None:
+def ensure_conv_genome_ncbigene(kegg_genome_id: str, *, version: str) -> str | None:
     """Get the KEGG-NCBIGENE protein map for the given organism."""
-    return _ensure_conv_genome_helper(
-        kegg_genome_id, "ncbi-geneid", version=version, error_on_missing=error_on_missing
-    )
+    return _ensure_conv_genome_helper(kegg_genome_id, "ncbi-geneid", version=version)
 
 
 def _ensure_conv_genome_helper(
@@ -109,7 +101,6 @@ def _ensure_conv_genome_helper(
     target_database: str,
     *,
     version: str,
-    error_on_missing: bool = False,
 ) -> str | None:
     """Get the KEGG-external protein map for the given organism/database."""
     name = f"{kegg_genome_id}.tsv"
@@ -119,7 +110,6 @@ def _ensure_conv_genome_helper(
             f"conv_{target_database}",
             url=f"{BASE}/conv/{target_database}/{kegg_genome_id}",
             name=name,
-            error_on_missing=error_on_missing,
             version=version,
         )
     except urllib.error.HTTPError:
@@ -138,35 +128,23 @@ def _ensure_conv_genome_helper(
         return rv
 
 
-def ensure_link_pathway_genome(
-    kegg_genome_id: str, *, version: str, error_on_missing: bool = False
-) -> str:
-    """Get the protein-pathway links for the given organism.
-
-    :raises: FileNotFoundError
-    """
+def ensure_link_pathway_genome(kegg_genome_id: str, *, version: str) -> str:
+    """Get the protein-pathway links for the given organism."""
     return ensure_path(
         KEGG_PATHWAY_PREFIX,
         "link_pathway",
         url=f"{BASE}/link/pathway/{kegg_genome_id}",
         name=f"{kegg_genome_id}.tsv",
-        error_on_missing=error_on_missing,
         version=version,
     )
 
 
-def ensure_list_pathway_genome(
-    kegg_genome_id: str, *, version: str, error_on_missing: bool = False
-) -> str:
-    """Get the list of pathways for the given organism.
-
-    :raises: FileNotFoundError
-    """
+def ensure_list_pathway_genome(kegg_genome_id: str, *, version: str) -> str:
+    """Get the list of pathways for the given organism."""
     return ensure_path(
         KEGG_PATHWAY_PREFIX,
         "pathways",
         url=f"{BASE}/list/pathway/{kegg_genome_id}",
         name=f"{kegg_genome_id}.tsv",
-        error_on_missing=error_on_missing,
         version=version,
     )

--- a/src/pyobo/sources/kegg/api.py
+++ b/src/pyobo/sources/kegg/api.py
@@ -3,6 +3,7 @@
 import urllib.error
 from collections.abc import Mapping
 from dataclasses import dataclass
+from pathlib import Path
 
 from pyobo import Reference, Term, ensure_path
 from pyobo.struct import from_species
@@ -51,7 +52,7 @@ class KEGGGenome:
         )
 
 
-def ensure_list_genomes(version: str) -> str:
+def ensure_list_genomes(version: str) -> Path:
     """Ensure the KEGG Genome file is downloaded."""
     return ensure_path(
         KEGG_GENOME_PREFIX,
@@ -75,7 +76,7 @@ def ensure_list_pathways(version: str) -> Mapping[str, str]:
 """GENOME SPECIFIC"""
 
 
-def ensure_list_genome(kegg_genome_id: str, *, version: str) -> str:
+def ensure_list_genome(kegg_genome_id: str, *, version: str) -> Path:
     """Get the list of genes for the given organism."""
     return ensure_path(
         KEGG_GENES_PREFIX,
@@ -86,12 +87,12 @@ def ensure_list_genome(kegg_genome_id: str, *, version: str) -> str:
     )
 
 
-def ensure_conv_genome_uniprot(kegg_genome_id: str, *, version: str) -> str | None:
+def ensure_conv_genome_uniprot(kegg_genome_id: str, *, version: str) -> Path | None:
     """Get the KEGG-UniProt protein map for the given organism."""
     return _ensure_conv_genome_helper(kegg_genome_id, "uniprot", version=version)
 
 
-def ensure_conv_genome_ncbigene(kegg_genome_id: str, *, version: str) -> str | None:
+def ensure_conv_genome_ncbigene(kegg_genome_id: str, *, version: str) -> Path | None:
     """Get the KEGG-NCBIGENE protein map for the given organism."""
     return _ensure_conv_genome_helper(kegg_genome_id, "ncbi-geneid", version=version)
 
@@ -101,7 +102,7 @@ def _ensure_conv_genome_helper(
     target_database: str,
     *,
     version: str,
-) -> str | None:
+) -> Path | None:
     """Get the KEGG-external protein map for the given organism/database."""
     name = f"{kegg_genome_id}.tsv"
     try:
@@ -121,14 +122,14 @@ def _ensure_conv_genome_helper(
         )
         with path_rv.open("w") as file:
             print(file=file)
-        return path_rv.as_posix()
+        return path_rv
     except FileNotFoundError:
         return None
     else:
         return rv
 
 
-def ensure_link_pathway_genome(kegg_genome_id: str, *, version: str) -> str:
+def ensure_link_pathway_genome(kegg_genome_id: str, *, version: str) -> Path:
     """Get the protein-pathway links for the given organism."""
     return ensure_path(
         KEGG_PATHWAY_PREFIX,
@@ -139,7 +140,7 @@ def ensure_link_pathway_genome(kegg_genome_id: str, *, version: str) -> str:
     )
 
 
-def ensure_list_pathway_genome(kegg_genome_id: str, *, version: str) -> str:
+def ensure_list_pathway_genome(kegg_genome_id: str, *, version: str) -> Path:
     """Get the list of pathways for the given organism."""
     return ensure_path(
         KEGG_PATHWAY_PREFIX,

--- a/src/pyobo/sources/kegg/genes.py
+++ b/src/pyobo/sources/kegg/genes.py
@@ -5,6 +5,7 @@ Run with ``python -m pyobo.sources.kegg.genes``
 
 import logging
 from collections.abc import Iterable
+from pathlib import Path
 
 import click
 from more_click import verbose_option
@@ -71,9 +72,9 @@ def iter_terms(version: str) -> Iterable[Term]:
 
 def _make_terms(
     kegg_genome: KEGGGenome,
-    list_genome_path: str,
-    conv_uniprot_path: str | None = None,
-    conv_ncbigene_path: str | None = None,
+    list_genome_path: Path,
+    conv_uniprot_path: Path | None = None,
+    conv_ncbigene_path: Path | None = None,
 ) -> Iterable[Term]:
     uniprot_conv = _load_conv(conv_uniprot_path, "up:") if conv_uniprot_path else {}
     ncbigene_conv = _load_conv(conv_ncbigene_path, "ncbi-geneid:") if conv_ncbigene_path else {}
@@ -110,7 +111,7 @@ def _make_terms(
             yield term
 
 
-def _load_conv(path, value_prefix):
+def _load_conv(path: Path, value_prefix):
     m = open_map_tsv(path)
     m = {k: v[len(value_prefix) :] for k, v in m.items()}
     return m

--- a/src/pyobo/sources/kegg/genome.py
+++ b/src/pyobo/sources/kegg/genome.py
@@ -94,7 +94,7 @@ def iter_kegg_genomes(version: str, desc: str) -> Iterable[KEGGGenome]:
     """Iterate over all KEGG genomes."""
     # since old kegg versions go away forever, do NOT add a force option
     path = ensure_list_genomes(version=version)
-    with open(path) as file:
+    with path.open() as file:
         lines = [line.strip() for line in file]
     it = tqdm(lines, desc=desc, unit_scale=True, unit="genome")
     for line in it:

--- a/src/pyobo/sources/mirbase.py
+++ b/src/pyobo/sources/mirbase.py
@@ -54,7 +54,7 @@ def get_terms(version: str, force: bool = False) -> list[Term]:
 
     file_handle = (
         gzip.open(definitions_path, "rt")
-        if definitions_path.endswith(".gz")
+        if definitions_path.suffix.endswith(".gz")
         else open(definitions_path)
     )
     with file_handle as file:

--- a/src/pyobo/sources/pubchem.py
+++ b/src/pyobo/sources/pubchem.py
@@ -2,6 +2,7 @@
 
 import logging
 from collections.abc import Iterable, Mapping
+from pathlib import Path
 
 import pandas as pd
 from bioregistry.utils import removeprefix
@@ -96,7 +97,7 @@ def get_pubchem_id_to_mesh_id(version: str) -> Mapping[str, str]:
     return dict(df.values)
 
 
-def _ensure_cid_name_path(*, version: str | None = None, force: bool = False) -> str:
+def _ensure_cid_name_path(*, version: str | None = None, force: bool = False) -> Path:
     if version is None:
         version = get_version("pubchem")
     # 2 tab-separated columns: compound_id, name

--- a/src/pyobo/sources/sgd.py
+++ b/src/pyobo/sources/sgd.py
@@ -3,8 +3,10 @@
 from collections.abc import Iterable
 from urllib.parse import unquote_plus
 
+from pystow.utils import read_tarfile_csv
+
 from ..struct import Obo, Reference, Synonym, Term, from_species
-from ..utils.path import ensure_tar_df
+from ..utils.path import ensure_path
 
 __all__ = [
     "SGDGetter",
@@ -38,17 +40,15 @@ def get_obo(force: bool = False) -> Obo:
 
 def get_terms(ontology: Obo, force: bool = False) -> Iterable[Term]:
     """Get SGD terms."""
-    df = ensure_tar_df(
-        prefix=PREFIX,
-        url=URL,
+    path = ensure_path(PREFIX, url=URL, version=ontology._version_or_raise, force=force)
+    df = read_tarfile_csv(
+        path,
         inner_path=INNER_PATH,
         sep="\t",
         skiprows=18,
         header=None,
         names=HEADER,
-        force=force,
         dtype=str,
-        version=ontology._version_or_raise,
     )
     df = df[df["feature"] == "gene"]
     for data in df["data"]:

--- a/src/pyobo/sources/utils.py
+++ b/src/pyobo/sources/utils.py
@@ -2,6 +2,7 @@
 
 import logging
 from collections.abc import Mapping
+from pathlib import Path
 
 from ..utils.io import multisetdict
 
@@ -13,9 +14,9 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-def get_go_mapping(path: str, prefix: str) -> Mapping[str, set[tuple[str, str]]]:
+def get_go_mapping(path: Path, prefix: str) -> Mapping[str, set[tuple[str, str]]]:
     """Get a GO mapping file."""
-    with open(path) as file:
+    with path.open() as file:
         return multisetdict(
             process_go_mapping_line(line.strip(), prefix=prefix) for line in file if line[0] != "!"
         )

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -53,7 +53,7 @@ from ..constants import (
 from ..identifier_utils import normalize_curie
 from ..utils.io import multidict, write_iterable_tsv
 from ..utils.misc import obo_to_owl
-from ..utils.path import get_prefix_obo_path, prefix_directory_join
+from ..utils.path import prefix_directory_join
 
 __all__ = [
     "Synonym",
@@ -812,7 +812,7 @@ class Obo:
 
     @property
     def _obo_path(self) -> Path:
-        return get_prefix_obo_path(self.ontology, version=self.data_version)
+        return self._cache(name=f"{self.ontology}.obo")
 
     @property
     def _obograph_path(self) -> Path:

--- a/src/pyobo/utils/io.py
+++ b/src/pyobo/utils/io.py
@@ -156,9 +156,9 @@ def write_iterable_tsv(
         writer.writerows(it)
 
 
-def parse_xml_gz(path: str | Path) -> Element:
+def parse_xml_gz(path: Path) -> Element:
     """Parse an XML file from a path to a GZIP file."""
-    path = Path(path).resolve()
+    path = path.resolve()
     t = time.time()
     logger.info("parsing xml from %s", path)
     tree = etree.parse(path.as_posix())  # type:ignore

--- a/src/pyobo/utils/io.py
+++ b/src/pyobo/utils/io.py
@@ -4,16 +4,13 @@ import collections.abc
 import csv
 import gzip
 import logging
-import time
 from collections import defaultdict
 from collections.abc import Iterable, Mapping
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TypeVar
-from xml.etree.ElementTree import Element
 
 import pandas as pd
-from lxml import etree
 from tqdm.auto import tqdm
 
 __all__ = [
@@ -24,7 +21,6 @@ __all__ = [
     "write_map_tsv",
     "write_multimap_tsv",
     "write_iterable_tsv",
-    "parse_xml_gz",
     "get_writer",
     "open_reader",
     "get_reader",
@@ -154,13 +150,3 @@ def write_iterable_tsv(
         if header is not None:
             writer.writerow(header)
         writer.writerows(it)
-
-
-def parse_xml_gz(path: Path) -> Element:
-    """Parse an XML file from a path to a GZIP file."""
-    path = path.resolve()
-    t = time.time()
-    logger.info("parsing xml from %s", path)
-    tree = etree.parse(path.as_posix())  # type:ignore
-    logger.info("parsed xml in %.2f seconds", time.time() - t)
-    return tree.getroot()

--- a/src/pyobo/utils/path.py
+++ b/src/pyobo/utils/path.py
@@ -7,7 +7,6 @@ from typing import Any, Literal
 import pandas as pd
 import requests_ftp
 from pystow import VersionHint
-from pystow.utils import read_tarfile_csv
 
 from ..constants import RAW_MODULE
 
@@ -16,7 +15,6 @@ __all__ = [
     "prefix_cache_join",
     "ensure_path",
     "ensure_df",
-    "ensure_tar_df",
 ]
 
 logger = logging.getLogger(__name__)
@@ -50,7 +48,7 @@ def ensure_path(
     backend: Literal["requests", "urllib"] = "urllib",
     verify: bool = True,
     **download_kwargs: Any,
-) -> str:
+) -> Path:
     """Download a file if it doesn't exist."""
     if verify:
         download_kwargs = {"backend": backend}
@@ -67,7 +65,7 @@ def ensure_path(
         version=version,
         download_kwargs=download_kwargs,
     )
-    return path.as_posix()
+    return path
 
 
 def ensure_df(
@@ -95,21 +93,6 @@ def ensure_df(
         backend=backend,
     )
     return pd.read_csv(_path, sep=sep, dtype=dtype, **kwargs)
-
-
-def ensure_tar_df(
-    prefix: str,
-    *parts: str,
-    url: str,
-    inner_path: str,
-    version: VersionHint = None,
-    path: str | None = None,
-    force: bool = False,
-    **kwargs,
-) -> pd.DataFrame:
-    """Download a tar file and open as a dataframe."""
-    path = ensure_path(prefix, *parts, url=url, version=version, name=path, force=force)
-    return read_tarfile_csv(path, inner_path=inner_path, **kwargs)
 
 
 def prefix_cache_join(prefix: str, *parts, name: str | None, version: VersionHint) -> Path:

--- a/src/pyobo/utils/path.py
+++ b/src/pyobo/utils/path.py
@@ -1,30 +1,25 @@
 """Utilities for building paths."""
 
 import logging
-from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Literal, TypeAlias
+from typing import Any, Literal
 
 import pandas as pd
 import requests_ftp
-from pystow.utils import download, name_from_url, read_tarfile_csv
+from pystow import VersionHint
+from pystow.utils import read_tarfile_csv
 
-from .misc import cleanup_version
 from ..constants import RAW_MODULE
 
 __all__ = [
     "prefix_directory_join",
-    "prefix_directory_join",
     "prefix_cache_join",
-    "get_prefix_obo_path",
     "ensure_path",
     "ensure_df",
     "ensure_tar_df",
 ]
 
 logger = logging.getLogger(__name__)
-
-VersionHint: TypeAlias = None | str | Callable[[], str | None]
 
 requests_ftp.monkeypatch_session()
 
@@ -37,25 +32,12 @@ def prefix_directory_join(
     ensure_exists: bool = True,
 ) -> Path:
     """Join in the prefix directory."""
-    if version is None:
-        return RAW_MODULE.join(prefix, *parts, name=name, ensure_exists=ensure_exists)
-    if callable(version):
-        logger.info("[%s] looking up version", prefix)
-        version = version()
-        logger.info("[%s] got version %s", prefix, version)
-    elif not isinstance(version, str):
-        raise TypeError(f"Invalid type: {version} ({type(version)})")
-    if version is None:
-        raise AssertionError
-    version = cleanup_version(version, prefix=prefix)
-    if version is not None and "/" in version:
-        raise ValueError(f"[{prefix}] Can not have slash in version: {version}")
-    return RAW_MODULE.join(prefix, version, *parts, name=name, ensure_exists=ensure_exists)
-
-
-def get_prefix_obo_path(prefix: str, version: VersionHint = None, ext: str = "obo") -> Path:
-    """Get the canonical path to the OBO file."""
-    return prefix_directory_join(prefix, name=f"{prefix}.{ext}", version=version)
+    return RAW_MODULE.module(prefix).join(
+        *parts,
+        name=name,
+        ensure_exists=ensure_exists,
+        version=version,
+    )
 
 
 def ensure_path(
@@ -65,32 +47,25 @@ def ensure_path(
     version: VersionHint = None,
     name: str | None = None,
     force: bool = False,
-    error_on_missing: bool = False,
     backend: Literal["requests", "urllib"] = "urllib",
     verify: bool = True,
+    **download_kwargs: Any,
 ) -> str:
     """Download a file if it doesn't exist."""
-    if name is None:
-        name = name_from_url(url)
-
-    path = prefix_directory_join(prefix, *parts, name=name, version=version)
-
-    if not path.exists() and error_on_missing:
-        raise FileNotFoundError
-
-    kwargs: dict[str, Any]
     if verify:
-        kwargs = {"backend": backend}
+        download_kwargs = {"backend": backend}
     else:
         if backend != "requests":
             logger.warning("using requests since verify=False")
-        kwargs = {"backend": "requests", "verify": False}
+        download_kwargs = {"backend": "requests", "verify": False}
 
-    download(
+    path = RAW_MODULE.module(prefix).ensure(
+        *parts,
         url=url,
-        path=path,
+        name=name,
         force=force,
-        **kwargs,
+        version=version,
+        download_kwargs=download_kwargs,
     )
     return path.as_posix()
 


### PR DESCRIPTION
This PR does the following:

1. Updates to pystow 0.6.0, which upstreams handling of versions
2. Switches the `pyobo.utils.paths` functions to return `pathlib.Path`, and updates any code that that affected to use path objects instead of strings
3. Does some reorganizing of the KEGG code. It seems to be the case that the API isn't available without authorization anymore, so this isn't worth a lot of time to test
4. Moves an io function that's only used when handling mesh out of `pyobo.utils.io` and into the mesh source module
5. Gets rid of `pyobo.utils.paths.get_prefix_obo_path`, which is only used once
6. Gets rid of `pyobo.utils.paths.ensure_tar_df`, which is used only once