### PR TITLE
Reuse external robot wrapper

### DIFF
--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -913,7 +913,7 @@ class Obo:
         if write_owl and (not self._owl_path.exists() or force):
             import bioontologies.robot
 
-            bioontologies.robot.convert(self._obo_path, self._owl_path, fmt="ofn")
+            bioontologies.robot.convert(self._obo_path, self._owl_path)
         if write_obonet and (not self._obonet_gz_path.exists() or force):
             logger.debug("writing obonet to %s", self._obonet_gz_path)
             self.write_obonet_gz(self._obonet_gz_path)

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -52,7 +52,6 @@ from ..constants import (
 )
 from ..identifier_utils import normalize_curie
 from ..utils.io import multidict, write_iterable_tsv
-from ..utils.misc import obo_to_owl
 from ..utils.path import get_prefix_obo_path, prefix_directory_join
 
 __all__ = [
@@ -912,7 +911,9 @@ class Obo:
         if write_obograph and (not self._obograph_path.exists() or force):
             self.write_obograph(self._obograph_path)
         if write_owl and (not self._owl_path.exists() or force):
-            obo_to_owl(self._obo_path, self._owl_path)
+            import bioontologies.robot
+
+            bioontologies.robot.convert(self._obo_path, self._owl_path, fmt="ofn")
         if write_obonet and (not self._obonet_gz_path.exists() or force):
             logger.debug("writing obonet to %s", self._obonet_gz_path)
             self.write_obonet_gz(self._obonet_gz_path)

--- a/src/pyobo/utils/misc.py
+++ b/src/pyobo/utils/misc.py
@@ -1,39 +1,13 @@
 """Miscellaneous utilities."""
 
-import gzip
 import logging
-import os
 from datetime import datetime
-from subprocess import check_output
 
 __all__ = [
-    "obo_to_obograph",
-    "obo_to_owl",
     "cleanup_version",
 ]
 
-
 logger = logging.getLogger(__name__)
-
-
-def obo_to_obograph(obo_path, obograph_path) -> None:
-    """Convert an OBO file to OBO Graph file with pronto."""
-    import pronto
-
-    ontology = pronto.Ontology(obo_path)
-    with gzip.open(obograph_path, "wb") as file:
-        ontology.dump(file, format="json")
-
-
-def obo_to_owl(obo_path, owl_path, owl_format: str = "ofn"):
-    """Convert an OBO file to an OWL file with ROBOT."""
-    args = ["robot", "convert", "-i", obo_path, "-o", owl_path, "--format", owl_format]
-    ret = check_output(  # noqa:S603
-        args,
-        cwd=os.path.dirname(__file__),
-    )
-    return ret.decode()
-
 
 BIZARRE_LOGGED = set()
 


### PR DESCRIPTION
This PR removes code from the `pyobo.utils.misc` module that has since been replaced by calls to `bioontologies.robot`