### PR TITLE
Implement GOC standardization

### DIFF
--- a/src/pyobo/registries/metaregistry.py
+++ b/src/pyobo/registries/metaregistry.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import bioregistry
 
 from ..constants import GLOBAL_SKIP, RAW_DIRECTORY
+from ..resources.goc import load_goc_map
 
 HERE = Path(__file__).parent.resolve()
 CURATED_REGISTRY_PATH = HERE.joinpath("metaregistry.json")
@@ -96,7 +97,9 @@ def get_xrefs_blacklist() -> set[str]:
 @lru_cache(maxsize=1)
 def get_remappings_full() -> Mapping[str, str]:
     """Get the remappings for xrefs based on the entire xref database."""
-    return CURATED_REGISTRY["remappings"]["full"]
+    rv = CURATED_REGISTRY["remappings"]["full"]
+    rv.update(load_goc_map())
+    return rv
 
 
 def remap_full(x: str) -> str:

--- a/src/pyobo/resources/goc.py
+++ b/src/pyobo/resources/goc.py
@@ -60,7 +60,7 @@ def main() -> None:
                     tqdm.write(f"Could not guess ORCID for {nickname}")
                     continue
 
-                tqdm.write(f'Check if https://orcid.org/{nn} is correct for {nickname}')
+                tqdm.write(f"Check if https://orcid.org/{orcid} is correct for {nickname}")
                 guessed = True
 
             print(goc_curie, nickname, orcid, guessed, sep="\t", file=file)

--- a/src/pyobo/resources/goc.py
+++ b/src/pyobo/resources/goc.py
@@ -1,0 +1,70 @@
+"""Get GOC to ORCID CURIE mappings.
+
+Due to historical reasons, the Gene Ontology and related resources
+use an internal curator identifier space ``GOC`` instead of ORCID.
+This namespace is partially mapped to ORCID and is version controlled
+`here <https://raw.githubusercontent.com/geneontology/go-site/refs/heads/master/metadata/users.yaml>`_.
+
+This module loads that namespace and uses :mod:`orcid_downloader` to try
+and add additional ORCID groundings. Then, this module is loaded in PyOBO's
+custom CURIE upgrade system so GOC CURIEs are seamlessly replaced with ORCID
+CURIEs, when possible.
+
+.. seealso:: https://github.com/geneontology/go-ontology/issues/22551
+"""
+
+import csv
+from pathlib import Path
+
+__all__ = ["load_goc_map"]
+
+URL = "https://raw.githubusercontent.com/geneontology/go-site/refs/heads/master/metadata/users.yaml"
+
+HERE = Path(__file__).parent.resolve()
+PATH = HERE.joinpath("goc.tsv")
+
+
+def load_goc_map() -> dict[str, str]:
+    """Get GOC to ORCID mappings."""
+    with PATH.open() as f:
+        return {row[0]: f"orcid:{row[2]}" for row in csv.reader(f, delimiter="\t")}
+
+
+def main() -> None:
+    """Generate GOC to ORCID mappings."""
+    import orcid_downloader
+    import requests
+    import yaml
+    from tqdm import tqdm
+
+    columns = ["curie", "name", "orcid", "guessed"]
+    res = requests.get(URL, timeout=5)
+    records = yaml.safe_load(res.text)
+    with PATH.open("w") as file:
+        print(*columns, sep="\t", file=file)
+        for record in tqdm(records, unit="person"):
+            goc_curie = record.get("xref")
+            if goc_curie is None or not goc_curie.startswith("GOC:"):
+                continue
+
+            guessed = False
+            nickname = record["nickname"]
+            uri = record.get("uri", "")
+            if not uri:
+                continue
+            if "orcid.org" in uri:
+                orcid = uri.removeprefix("https://orcid.org/").removeprefix("https://orcid.org/")
+            if "orcid.org" not in uri:
+                orcid = orcid_downloader.ground_researcher_unambiguous(nickname)
+                if not orcid:
+                    tqdm.write(f"Could not guess ORCID for {nickname}")
+                    continue
+
+                tqdm.write(f'Check if https://orcid.org/{nn} is correct for {nickname}')
+                guessed = True
+
+            print(goc_curie, nickname, orcid, guessed, sep="\t", file=file)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pyobo/resources/goc.tsv
+++ b/src/pyobo/resources/goc.tsv
@@ -1,0 +1,188 @@
+curie	name	orcid	guessed
+GOC:jk	Jim Knowles	0009-0009-5100-2472	True
+GOC:amu	Anushya Muruganujan	0000-0001-7169-5864	True
+GOC:pt	Paul Thomas	0000-0002-9074-3507	False
+GOC:hm	Huaiyu Mi	0000-0001-8721-202X	False
+GOC:sjc	Seth Carbon	0000-0001-8244-1536	False
+GOC:jnx	Jeremy Nguyen Xuan	0000-0002-4301-0968	True
+GOC:anm	Anna Melidoni	0000-0002-2535-883X	True
+GOC:ml2	Mike Livstone	0000-0001-5386-5823	True
+GOC:hd	Heiko Dietze	0000-0003-0234-1688	False
+GOC:dp	Dexter Pratt	0000-0002-1471-9513	True
+GOC:di	Diane Inglis	0000-0003-3166-4638	False
+GOC:cy	Courtland Yockey	0000-0003-4917-3490	True
+GOC:hal	Hadil Alrohaif	0000-0002-6980-6972	True
+GOC:jbu	Jessica Buxton	0000-0002-0918-9335	False
+GOC:kom	Klaus Mitchell	0000-0001-9510-5320	False
+GOC:nc	Nancy Campbell	0000-0001-9995-0839	False
+GOC:rl	Ruth Lovering	0000-0002-9791-0064	False
+GOC:vk	Varsha Khodiyar	0000-0002-2743-6918	True
+GOC:amm	Anna Maria Masci	0000-0003-1940-6740	True
+GOC:dsd	David S. Dougall	0000-0002-9043-2709	True
+GOC:pf	Petra Fey	0000-0002-4532-2703	False
+GOC:pg	Pascale Gaudet	0000-0003-1813-6857	False
+GOC:rjd	Robert Dodson	0000-0002-2757-5950	False
+GOC:jh2	Jim Hu	0000-0001-9016-2684	False
+GOC:nv	Nicole Vasilevsky	0000-0001-5208-3432	True
+GOC:ha	Helen Attrill	0000-0003-3212-6364	False
+GOC:hb	Heather Butler	0000-0003-4454-4889	True
+GOC:mc	Marta Costa	0000-0001-5948-3092	False
+GOC:ma	Michael Ashburner	0000-0002-6962-2807	False
+GOC:dos	David Osumi-Sutherland	0000-0002-7073-9172	False
+GOC:sart	Susan Tweedie	0000-0003-1818-8243	False
+GOC:mb	Matt Berriman	0000-0002-9581-0377	False
+GOC:bf	Rebecca Foulger	0000-0001-8682-8754	False
+GOC:ceb	Cath Brooksbank	0000-0001-9395-7001	False
+GOC:jid	Jennifer Deegan (nee Clark)	0000-0001-9227-417X	False
+GOC:jl	Jane Lomax	0000-0001-8865-4321	False
+GOC:mec	Melanie Courtot	0000-0002-9551-6370	False
+GOC:pr	Paola Roncaglia	0000-0002-2825-0621	False
+GOC:als	Alice Dashow	0000-0003-3829-1600	False
+GOC:es	Elena Speretta	0000-0003-1506-7438	False
+GOC:gg	George Georghiou	0000-0001-5067-3199	False
+GOC:hbye	Hema Bye-A-Jee	0000-0003-2464-7688	False
+GOC:pm	Prudence Mutowo	0000-0002-4646-4172	True
+GOC:rph	Rachael Huntley	0000-0001-6718-3559	False
+GOC:yaf	Yasmin Alam-Faruque	0000-0001-8902-0232	True
+GOC:bhm	Birgit Meldal	0000-0003-4062-6158	False
+GOC:imk	Ingrid Keseler	0000-0003-1738-6117	True
+GOC:dph	David Hill	0000-0001-7476-6306	False
+GOC:tfm	Terry Meehan	0000-0003-1980-3228	True
+GOC:ajp	Tony Planchart	0000-0001-8691-8856	False
+GOC:dms	Dmitry Sitnikov	0000-0003-3394-9805	False
+GOC:smb	Sue Bello	0000-0003-4606-0597	False
+GOC:hjd	Harold Drabkin	0000-0003-2689-5511	False
+GOC:ln	Li Ni	0000-0002-9796-7693	False
+GOC:jab	Judith Blake	0000-0001-8522-334X	False
+GOC:crds	Claudia Rato da Silva	0000-0002-3971-046X	True
+GOC:tw	Trish Whetzel	0000-0002-3458-4839	True
+GOC:rv	Randi Vita	0000-0001-8957-7612	True
+GOC:ml	Magdalen Lindeberg	0000-0001-6386-4066	True
+GOC:gvg	George Gkoutos	0000-0002-2061-091X	True
+GOC:al	Antonia Lock	0000-0003-1179-5999	False
+GOC:jb	Jurg Bahler	0000-0003-4036-1532	True
+GOC:mah	Midori Harris	0000-0003-4148-4606	False
+GOC:vw	Val Wood	0000-0001-6330-7526	False
+GOC:lc	Laurel Cooper	0000-0002-6379-8932	False
+GOC:rw	Ramona Walls	0000-0001-8815-0078	True
+GOC:cna	Cecilia Arighi	0000-0002-0803-4817	True
+GOC:bj	Bijay Jassal	0000-0002-5039-5405	True
+GOC:mg2	Marc Gillespie	0000-0002-5766-1702	True
+GOC:pde	Peter D'Eustachio	0000-0002-5494-626X	False
+GOC:phg	Phani Garapati	0000-0003-0941-2207	False
+GOC:sj	Steven Jupe	0000-0001-5807-0069	True
+GOC:vs	Veronica Shamovsky	0000-0002-2187-2241	True
+GOC:jsg	John Garavelli	0000-0002-4131-735X	True
+GOC:sjw	Shur-Jen Wang	0000-0001-5256-8683	True
+GOC:sl	Stan Laulederkind	0000-0001-5356-4174	False
+GOC:st	Simon Twigger	0000-0001-5659-3632	True
+GOC:vp	Victoria Petri	0000-0002-5540-8498	True
+GOC:cb	Colin Batchelor	0000-0001-5985-7429	True
+GOC:cjm	Chris Mungall	0000-0002-6601-2165	False
+GOC:clt	Chandra Theesfeld	0000-0002-8379-6600	False
+GOC:dgf	Dianna Fisk	0000-0003-4929-9472	False
+GOC:ew	Edith Wong	0000-0001-9799-5523	False
+GOC:elh	Eurie Hong	0000-0002-1775-4998	False
+GOC:jd	Janos Demeter	0000-0002-7301-8055	False
+GOC:jh	Jodi Hirschman	0000-0001-8850-9925	False
+GOC:krc	Karen Christie	0000-0001-5501-853X	False
+GOC:mcc	Maria Costanzo	0000-0001-9043-693X	False
+GOC:rb	Rama Balakrishnan	0000-0003-2468-9933	False
+GOC:rn	Rob Nash	0000-0002-3726-7441	False
+GOC:se	Stacia Engel	0000-0001-5472-917X	False
+GOC:ssd	Selina Dwight	0000-0002-8546-7798	False
+GOC:dw	Dani Welter	0000-0003-1058-2668	False
+GOC:ask	A. S. Karthikeyan	0000-0003-0065-0217	True
+GOC:ct	Christopher Tissier	0000-0002-0693-3202	True
+GOC:dhl	Donghui Li	0000-0003-3335-4537	False
+GOC:ds	David Swarbreck	0000-0002-5453-1013	True
+GOC:kad	Kate Dreher	0000-0003-4652-4398	False
+GOC:tb	Tanya Berardini	0000-0002-3837-8864	False
+GOC:dh	Dan Haft	0000-0001-8101-4938	True
+GOC:lh	Linda Hannick	0000-0002-8018-8466	False
+GOC:ef	Erika Feltrin	0000-0002-9899-7456	False
+GOC:lm	Lorenza Mittempergher	0000-0003-3425-3965	True
+GOC:ar	Alan Ruttenberg	0000-0002-1604-3078	True
+GOC:hw	Heather Wick	0000-0003-0961-0377	True
+GOC:pad	Paul Denny	0000-0003-4659-6893	False
+GOC:mat	Mathew Tata	0000-0002-0960-5677	True
+GOC:aa	Andrea Auchincloss	0000-0002-5297-5390	True
+GOC:ae	Anne Estreicher	0000-0001-6828-2508	True
+GOC:ab	Alan Bridge	0000-0003-2148-9135	False
+GOC:ans	Andre Stutz	0000-0002-7175-2168	True
+GOC:ag	Arnaud Gos	0000-0002-5018-1378	True
+GOC:cr2	Catherine Rivoire	0000-0002-5979-8382	True
+GOC:ch	Chantal Hulo	0000-0001-8176-7999	True
+GOC:dl2	Damien Lieberherr	0000-0002-9724-1710	True
+GOC:ecu	Elena Cibrian-Uhalte	0000-0002-0987-9862	False
+GOC:fj	Florence Jungo	0000-0002-7456-8390	True
+GOC:gc	Gayatri Chavali	0000-0001-8575-1847	True
+GOC:gk	Guillaume Keller	0000-0001-9497-8269	True
+GOC:ip	Ivo Pedruzzi	0000-0001-8561-7170	True
+GOC:kd	Kirill Degtyarenko	0000-0003-0058-650X	True
+GOC:klp	Klemens Pichler	0000-0001-6099-8931	False
+GOC:ka	Kristian Axelsen	0000-0003-3889-2879	True
+GOC:mf	Marc Feuermann	0000-0002-4187-2863	False
+GOC:mt	Michael Tognolli	0000-0002-5278-3321	True
+GOC:mm2	Michele Magrane	0000-0003-3544-996X	True
+GOC:pm2	Patrick Masson	0000-0001-7646-0052	False
+GOC:pdr	Paula Duek Roggli	0000-0002-0819-0473	True
+GOC:pga	Penelope Garmiri	0000-0002-2283-2575	False
+GOC:plm	Philippe Le Mercier	0000-0001-8528-090X	True
+GOC:reh	Reija Hieta	0000-0001-5724-6253	True
+GOC:so	Sandra Orchard	0000-0002-8878-3972	True
+GOC:sp	Sylvain Poux	0000-0001-7299-6685	False
+GOC:ss	Shyamala Sundaram	0000-0003-4209-460X	True
+GOC:uh	Ursula Hinz	0000-0002-2365-2234	True
+GOC:wmc	Wei Mun Chan	0000-0002-9971-813X	True
+GOC:nhn	Nevila Hyka-Nouspikel	0000-0001-7855-209X	True
+GOC:jc	Jonas Cicenas	0000-0002-9365-1843	True
+GOC:gap	Ghislaine Argoud-Puy	0000-0002-2979-8613	False
+GOC:ppm	Pablo Porras Millan	0000-0002-8429-8793	True
+GOC:dsz	Dora Szakonyi	0000-0002-9189-629X	True
+GOC:dr	Daniela Raciti	0000-0002-4945-5837	False
+GOC:kmv	Kimberly Van Auken	0000-0002-1706-4196	False
+GOC:rk	Ranjana Kishore	0000-0002-1478-7671	False
+GOC:dgh	Doug Howe	0000-0001-5831-7439	False
+GOC:dsf	David Fashena	0000-0001-9656-0683	False
+GOC:cvs	Ceri Van Slyke	0000-0002-2244-7917	False
+GOC:sr	Sridhar Ramachandran	0000-0002-2246-3722	False
+GOC:ymb	Yvonne M Bradford	0000-0002-9900-7880	False
+GOC:sat	Sabrina Toro	0000-0002-4142-7153	False
+GOC:ksf	Ken Frazer	0000-0002-6889-0711	False
+GOC:lrz	Leyla Ruzicka	0000-0002-1009-339X	False
+GOC:ejs	Erik Segerdell	0000-0002-9611-1279	True
+GOC:lb	Lionel Breuza	0000-0002-8075-8625	False
+GOC:mh	Melissa Haendel	0000-0001-9114-8737	False
+GOC:mag	Marion Gremse	0000-0003-0350-6392	True
+GOC:hp	Helen Parkinson	0000-0003-3035-4195	True
+GOC:sk	Scott Kalberer	0000-0003-2101-2484	True
+GOC:md	Mickael Desvaux	0000-0003-2986-6417	True
+GOC:expert_db	Dominique Bergmann	0000-0003-0873-3543	True
+GOC:expert_ks	Kevin Struhl	0000-0002-4181-7856	True
+GOC:expert_jwt	Jeremy Thorner	0000-0002-2583-500X	True
+GOC:expert_mm	Michael Melkonian	0000-0002-5911-6548	True
+GOC:expert_pt	Philippa Talmud	0000-0002-5560-1933	True
+GOC:expert_rsh	R. Scott Hawley	0000-0002-6478-0494	True
+GOC:expert_tf	Tim Formosa	0000-0002-8477-2483	True
+GOC:jal	Jamie A. Lee	0000-0001-6182-2372	True
+GOC:mmt	Monica Munoz-Torres	0000-0001-8430-6039	False
+GOC:at	Anne Thessen	0000-0002-2908-3327	False
+GOC:ga	Giulia Antonazzo	0000-0003-0086-5621	False
+GOC:ani	Anne Niknejad	0000-0003-3308-6245	True
+GOC:pvn	Pim van Nierop	0000-0003-0593-3443	False
+GOC:add	Alexander Diehl	0000-0001-9990-8331	False
+GOC:pj	Pankaj Jaiswal	0000-0002-1005-8383	False
+GOC:rz	Rossana Zaru	0000-0002-3358-4423	False
+GOC:lr	Leonore Reiser	0000-0003-0073-0858	False
+GOC:mcc2	Marcus Chibucos	0000-0001-9586-0780	False
+GOC:das	Debby Siegele	0000-0001-8935-0696	False
+GOC:bc	Barbara Kramarz	0000-0002-3898-1727	False
+GOC:lnp	Livia Perfetto	0000-0003-4392-8725	False
+GOC:ach	Achchuthan Shanmugasundram	0000-0003-2349-6929	False
+GOC:mch	Marie-Claire Harrison	0000-0002-3013-9906	False
+GOC:mlg	Michelle Gwinn Giglio	0000-0001-7628-5565	False
+GOC:jja	Josh Jaffery	0000-0002-1965-6945	True
+GOC:tc	Teresa Chu	0000-0003-4172-1966	True
+GOC:apd	Allan P Davis	0000-0002-5741-7128	False
+GOC:sjm	Steven Marygold	0000-0003-2759-266X	False

--- a/tox.ini
+++ b/tox.ini
@@ -116,6 +116,7 @@ deps =
     pydantic
     types-tabulate
     types-requests
+    types-PyYAML
 skip_install = true
 commands = mypy --install-types --non-interactive --ignore-missing-imports src/
 # TODO make strict! remove skip_install


### PR DESCRIPTION
Due to historical reasons, the Gene Ontology and related resources use an internal curator identifier space ``GOC`` instead of ORCID. This namespace is partially mapped to ORCID and is version controlled [here](https://raw.githubusercontent.com/geneontology/go-site/refs/heads/master/metadata/users.yaml>).

This module loads that namespace and uses :mod:`orcid_downloader` to try and add additional ORCID groundings. Then, this module is loaded in PyOBO's custom CURIE upgrade system so GOC CURIEs are seamlessly replaced with ORCID CURIEs, when possible.

See also https://github.com/geneontology/go-ontology/issues/22551