### PR TITLE
Add resource-specific remappings

### DIFF
--- a/src/pyobo/identifier_utils.py
+++ b/src/pyobo/identifier_utils.py
@@ -66,11 +66,14 @@ def _normalize_prefix(prefix: str, *, curie=None, xref=None, strict: bool = True
 BAD_CURIES = set()
 
 
-def normalize_curie(curie: str, *, strict: bool = True) -> tuple[str, str] | tuple[None, None]:
+def normalize_curie(
+    curie: str, *, strict: bool = True, ontology: str | None = None
+) -> tuple[str, str] | tuple[None, None]:
     """Parse a string that looks like a CURIE.
 
     :param curie: A compact uniform resource identifier (CURIE)
     :param strict: Should an exception be thrown if the CURIE can not be parsed w.r.t. the Bioregistry?
+    :param ontology: The ontology in which the CURIE appears
     :return: A parse tuple or a tuple of None, None if not able to parse and not strict
 
     - Normalizes the namespace
@@ -87,7 +90,7 @@ def normalize_curie(curie: str, *, strict: bool = True) -> tuple[str, str] | tup
     curie = remap_full(curie)
 
     # Remap node's prefix (if necessary)
-    curie = remap_prefix(curie)
+    curie = remap_prefix(curie, ontology_prefix=ontology)
 
     try:
         head_ns, identifier = curie.split(":", 1)

--- a/src/pyobo/registries/metaregistry.json
+++ b/src/pyobo/registries/metaregistry.json
@@ -502,6 +502,22 @@
       "vo/ontorat/PR:": "PR:",
       "DC:0000": "diseaseclass:0000",
       "TS-": "caloha:"
+    },
+    "resource_prefix": {
+      "enm": {
+        "Thesaurus:C": "NCIT:C"
+      },
+      "idocovid19": {"UniProtKN:":  "uniprot:"},
+      "ito": {
+        "format:": "edam.format:",
+        "topic:": "edam.topic:",
+        "operation:": "edam.operation:"
+      },
+      "mcro": {
+        "format:": "edam.format:",
+        "topic:": "edam.topic:",
+        "operation:": "edam.operation:"
+      }
     }
   }
 }

--- a/src/pyobo/registries/metaregistry.py
+++ b/src/pyobo/registries/metaregistry.py
@@ -113,8 +113,17 @@ def get_remappings_prefix() -> Mapping[str, str]:
     return CURATED_REGISTRY["remappings"]["prefix"]
 
 
-def remap_prefix(curie: str) -> str:
+@lru_cache
+def _get_resource_specific_map(ontology_prefix: str) -> Mapping[str, str]:
+    return CURATED_REGISTRY["remappings"]["resource_prefix"].get(ontology_prefix, {})
+
+
+def remap_prefix(curie: str, ontology_prefix: str | None = None) -> str:
     """Remap a prefix."""
+    if ontology_prefix is not None:
+        for old_prefix, new_prefix in _get_resource_specific_map(ontology_prefix).items():
+            if curie.startswith(old_prefix):
+                return new_prefix + curie[len(old_prefix) :]
     for old_prefix, new_prefix in get_remappings_prefix().items():
         if curie.startswith(old_prefix):
             return new_prefix + curie[len(old_prefix) :]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,6 +23,10 @@ class TestStringUtils(unittest.TestCase):
         self.assertEqual(("pubmed", "1234"), normalize_curie("pmid:1234"))
         self.assertEqual(("pubmed", "1234"), normalize_curie("PMID:1234"))
 
+        # Test resource-specific remapping
+        self.assertEqual((None, None), normalize_curie("Thesaurus:C1234", strict=False))
+        self.assertEqual(("ncit", "C1234"), normalize_curie("Thesaurus:C1234", ontology="enm"))
+
     def test_parse_eccode_transfer(self):
         """Test parse_eccode_transfer."""
         self.assertEqual(


### PR DESCRIPTION
This adds additional configuration into `metaregistry.json` that allows for resource-specific rules to be added. This is useful since there might be non-generally applicable transformations that are desired. For example, eNanoMapper ontology uses `Thesaurus:` as the prefix for `NCIT:`.