### PR TITLE
Improve annotation and object property adders

### DIFF
--- a/src/pyobo/sources/chembl.py
+++ b/src/pyobo/sources/chembl.py
@@ -66,9 +66,9 @@ def iter_terms(version: str) -> Iterable[Term]:
                 # TODO add xrefs?
                 term = Term.from_triple(prefix=PREFIX, identifier=chembl_id, name=name)
                 if smiles:
-                    term.append_property(has_smiles, smiles)
+                    term.annotate_literal(has_smiles, smiles)
                 if inchi:
-                    term.append_property(has_inchi, inchi)
+                    term.annotate_literal(has_inchi, inchi)
                 if inchi_key:
                     term.append_exact_match(Reference(prefix="inchikey", identifier=inchi_key))
                 yield term

--- a/src/pyobo/sources/complexportal.py
+++ b/src/pyobo/sources/complexportal.py
@@ -244,7 +244,7 @@ def get_terms(version: str, force: bool = False) -> Iterable[Term]:
         term.set_species(identifier=taxonomy_id, name=taxonomy_name)
 
         for reference, _count in members:
-            term.append_relationship(has_part, reference)
+            term.annotate_object(has_part, reference)
 
         yield term
 

--- a/src/pyobo/sources/cvx.py
+++ b/src/pyobo/sources/cvx.py
@@ -80,9 +80,9 @@ def iter_terms() -> Iterable[Term]:
             if replacement_identifier:
                 term.append_replaced_by(Reference(prefix=PREFIX, identifier=replacement_identifier))
         if pd.notna(status):
-            term.append_property("status", status)
+            term.annotate_literal("status", status)
         if pd.notna(nonvaccine):
-            term.append_property("nonvaccine", nonvaccine)
+            term.annotate_literal("nonvaccine", nonvaccine)
         terms[cvx] = term
 
     for child, parents in dd.items():

--- a/src/pyobo/sources/drugbank.py
+++ b/src/pyobo/sources/drugbank.py
@@ -123,10 +123,10 @@ def _make_term(drug_info: Mapping[str, Any]) -> Term:
     for prop, debio_curie in [("smiles", has_smiles), ("inchi", has_inchi)]:
         identifier = drug_info.get(prop)
         if identifier:
-            term.append_property(debio_curie, identifier)
+            term.annotate_literal(debio_curie, identifier)
 
     for salt in drug_info.get("salts", []):
-        term.append_relationship(
+        term.annotate_object(
             has_salt,
             Reference(
                 prefix="drugbank.salt",

--- a/src/pyobo/sources/drugcentral.py
+++ b/src/pyobo/sources/drugcentral.py
@@ -92,9 +92,9 @@ def iter_terms() -> Iterable[Term]:
         if inchi_key:
             term.append_exact_match(Reference(prefix="inchikey", identifier=inchi_key))
         if smiles:
-            term.append_property(has_smiles, smiles)
+            term.annotate_literal(has_smiles, smiles)
         if inchi:
-            term.append_property(has_inchi, inchi)
+            term.annotate_literal(has_inchi, inchi)
         if cas:
             term.append_exact_match(Reference(prefix="cas", identifier=cas))
         yield term

--- a/src/pyobo/sources/expasy.py
+++ b/src/pyobo/sources/expasy.py
@@ -111,9 +111,7 @@ def get_terms(version: str, force: bool = False) -> Iterable[Term]:
                 reference=Reference(prefix=PREFIX, identifier=ec_code), is_obsolete=True
             )
             for transfer_id in transfer_ids:
-                term.append_relationship(
-                    term_replaced_by, Reference(prefix=PREFIX, identifier=transfer_id)
-                )
+                term.append_replaced_by(Reference(prefix=PREFIX, identifier=transfer_id))
             continue
 
         parent_ec_code = data["parent"]["identifier"]
@@ -144,14 +142,14 @@ def get_terms(version: str, force: bool = False) -> Iterable[Term]:
             synonyms=synonyms,
         )
         for domain in data.get("domains", []):
-            term.append_relationship(
+            term.annotate_object(
                 has_member,
                 Reference.model_validate(
                     {"prefix": domain["namespace"], "identifier": domain["identifier"]},
                 ),
             )
         for protein in data.get("proteins", []):
-            term.append_relationship(
+            term.annotate_object(
                 has_member,
                 Reference(
                     prefix=protein["namespace"],
@@ -160,9 +158,7 @@ def get_terms(version: str, force: bool = False) -> Iterable[Term]:
                 ),
             )
         for go_id, go_name in ec2go.get(ec_code, []):
-            term.append_relationship(
-                enables, Reference(prefix="GO", identifier=go_id, name=go_name)
-            )
+            term.annotate_object(enables, Reference(prefix="GO", identifier=go_id, name=go_name))
 
     return terms.values()
 

--- a/src/pyobo/sources/famplex.py
+++ b/src/pyobo/sources/famplex.py
@@ -119,20 +119,18 @@ def get_terms(version: str, force: bool = False) -> Iterable[Term]:
             term.append_xref(xref_reference)
 
         for r, t in out_edges.get(reference, []):
-            if r == "isa" and t.prefix == "fplx":
+            if r == "isa":
                 term.append_parent(t)
-            elif r == "isa":
-                term.append_relationship(is_a, t)
             elif r == "partof":
-                term.append_relationship(part_of, t)
+                term.annotate_object(part_of, t)
             else:
                 logging.warning("unhandled relation %s", r)
 
         for r, h in in_edges.get(reference, []):
             if r == "isa":
-                term.append_relationship(has_member, h)
+                term.annotate_object(has_member, h)
             elif r == "partof":
-                term.append_relationship(has_part, h)
+                term.annotate_object(has_part, h)
             else:
                 logging.warning("unhandled relation %s", r)
         yield term

--- a/src/pyobo/sources/flybase.py
+++ b/src/pyobo/sources/flybase.py
@@ -158,7 +158,7 @@ def get_terms(version: str, force: bool = False) -> Iterable[Term]:
             if hgnc_ortholog is None:
                 tqdm.write(f"[{PREFIX}] {identifier} had invalid ortholog: {hgnc_curie}")
             else:
-                term.append_relationship(orthologous, hgnc_ortholog)
+                term.annotate_object(orthologous, hgnc_ortholog)
         taxonomy_id = abbr_to_taxonomy.get(organism)
         if taxonomy_id is not None:
             term.set_species(taxonomy_id)

--- a/src/pyobo/sources/geonames.py
+++ b/src/pyobo/sources/geonames.py
@@ -80,7 +80,7 @@ def get_code_to_country(*, force: bool = False) -> Mapping[str, Term]:
             term.append_synonym(fips)
         if pd.notna(iso3):
             term.append_synonym(iso3)
-        term.append_property("code", code)
+        term.annotate_literal("code", code)
         code_to_country[code] = term
     logger.info(f"got {len(code_to_country):,} country records")
     return code_to_country
@@ -107,7 +107,7 @@ def get_code_to_admin1(
         term = Term.from_triple(
             "geonames", identifier, name if pd.notna(name) else None, type="Instance"
         )
-        term.append_property("code", code)
+        term.annotate_literal("code", code)
         code_to_admin1[code] = term
 
         country_code = code.split(".")[0]
@@ -135,7 +135,7 @@ def get_code_to_admin2(
         term = Term.from_triple(
             "geonames", identifier, name if pd.notna(name) else None, type="Instance"
         )
-        term.append_property("code", code)
+        term.annotate_literal("code", code)
         code_to_admin2[code] = term
         admin1_code = code.rsplit(".", 1)[0]
         admin1_term = code_to_admin1.get(admin1_code)

--- a/src/pyobo/sources/hgnc.py
+++ b/src/pyobo/sources/hgnc.py
@@ -412,7 +412,7 @@ def get_terms(version: str | None = None, force: bool = False) -> Iterable[Term]
         for prop in ["location"]:
             value = entry.pop(prop, None)
             if value:
-                term.append_property(prop, value)
+                term.annotate_literal(prop, value)
 
         locus_type = entry.pop("locus_type")
         locus_group = entry.pop("locus_group")
@@ -424,8 +424,8 @@ def get_terms(version: str | None = None, force: bool = False) -> Iterable[Term]
                 Reference(prefix="SO", identifier="0000704", name=get_so_name("0000704"))
             )  # gene
             unhandle_locus_types[locus_type][identifier] = term
-            term.append_property("locus_type", locus_type)
-            term.append_property("locus_group", locus_group)
+            term.annotate_literal("locus_type", locus_type)
+            term.annotate_literal("locus_group", locus_group)
 
         term.set_species(identifier="9606", name="Homo sapiens")
 

--- a/src/pyobo/sources/icd10.py
+++ b/src/pyobo/sources/icd10.py
@@ -82,7 +82,7 @@ def _extract_icd10(res_json: Mapping[str, Any]) -> Term:
         parents=parents,
     )
 
-    rv.append_property("class_kind", res_json["classKind"])
+    rv.annotate_literal("class_kind", res_json["classKind"])
 
     return rv
 

--- a/src/pyobo/sources/interpro.py
+++ b/src/pyobo/sources/interpro.py
@@ -74,7 +74,7 @@ def iter_terms(*, version: str, proteins: bool = False, force: bool = False) -> 
             term.append_relationship(
                 enables, Reference(prefix="go", identifier=go_id, name=go_name)
             )
-        term.append_property("type", entry_type)
+        term.annotate_literal("type", entry_type)
         for uniprot_id in interpro_to_proteins.get(identifier, []):
             term.append_relationship(has_member, Reference(prefix="uniprot", identifier=uniprot_id))
         yield term

--- a/src/pyobo/sources/kegg/genes.py
+++ b/src/pyobo/sources/kegg/genes.py
@@ -101,7 +101,7 @@ def _make_terms(
 
             uniprot_xref = uniprot_conv.get(identifier)
             if uniprot_xref is not None:
-                term.append_relationship(has_gene_product, Reference("uniprot", uniprot_xref))
+                term.annotate_object(has_gene_product, Reference("uniprot", uniprot_xref))
 
             ncbigene_xref = ncbigene_conv.get(identifier)
             if ncbigene_xref is not None:

--- a/src/pyobo/sources/kegg/pathway.py
+++ b/src/pyobo/sources/kegg/pathway.py
@@ -135,7 +135,7 @@ def _iter_genome_terms(
             tqdm.write(f"could not find kegg.pathway:{pathway_id} for {kegg_genome.name}")
             continue
         for protein_id in protein_ids:
-            pathway_term.append_relationship(
+            pathway_term.annotate_object(
                 has_participant,
                 Reference(
                     prefix=KEGG_GENES_PREFIX,

--- a/src/pyobo/sources/mirbase.py
+++ b/src/pyobo/sources/mirbase.py
@@ -157,7 +157,8 @@ def _process_definitions_lines(
 
         species_identifier, species_name = organisms[species_code]
         term.set_species(species_identifier, species_name)
-        term.extend_relationship(has_mature, matures)
+        for mature in matures:
+            term.append_relationship(has_mature, mature)
 
         yield term
 

--- a/src/pyobo/sources/msigdb.py
+++ b/src/pyobo/sources/msigdb.py
@@ -88,7 +88,7 @@ def iter_terms(version: str, force: bool = False) -> Iterable[Term]:
         ]:
             value = attrib[key].strip()
             if value:
-                term.append_property(key.lower(), value)
+                term.annotate_literal(key.lower(), value)
 
         term.set_species(tax_id)
 

--- a/src/pyobo/sources/pathbank.py
+++ b/src/pyobo/sources/pathbank.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from collections.abc import Iterable, Mapping
+from itertools import chain
 
 import pandas as pd
 from tqdm.auto import tqdm
@@ -165,9 +166,9 @@ def iter_terms(version: str, force: bool = False) -> Iterable[Term]:
             #  but there are weird parser errors
         )
         term.append_exact_match(Reference(prefix="smpdb", identifier=smpdb_id))
-        term.append_property(has_category, subject.lower().replace(" ", "_"))
-        term.extend_relationship(has_participant, smpdb_id_to_proteins[smpdb_id])
-        term.extend_relationship(has_participant, smpdb_id_to_metabolites[smpdb_id])
+        term.annotate_literal(has_category, subject.lower().replace(" ", "_"))
+        for participant in chain(smpdb_id_to_proteins[smpdb_id], smpdb_id_to_metabolites[smpdb_id]):
+            term.append_relationship(has_participant, participant)
         yield term
 
 

--- a/src/pyobo/sources/pombase.py
+++ b/src/pyobo/sources/pombase.py
@@ -89,7 +89,7 @@ def get_terms(version: str, force: bool = False) -> Iterable[Term]:
             name=symbol if pd.notna(symbol) else None,
             definition=name if pd.notna(name) else None,
         )
-        term.append_property("chromosome", chromosome[len("chromosome_") :])
+        term.annotate_literal("chromosome", chromosome[len("chromosome_") :])
         term.append_parent(so[gtype])
         term.set_species(identifier="4896", name="Schizosaccharomyces pombe")
         for hgnc_id in identifier_to_hgnc_ids.get(identifier, []):

--- a/src/pyobo/sources/ror.py
+++ b/src/pyobo/sources/ror.py
@@ -109,7 +109,7 @@ def iterate_ror_terms(*, force: bool = False) -> Iterable[Term]:
         #     term.append_parent(ORG_PARENTS[organization_type])
 
         for link in record.get("links", []):
-            term.append_property(has_homepage, link)
+            term.annotate_literal(has_homepage, link, Reference(prefix="xsd", identifier="anyURI"))
 
         if name.startswith("The "):
             term.append_synonym(name.removeprefix("The "))

--- a/src/pyobo/sources/slm.py
+++ b/src/pyobo/sources/slm.py
@@ -90,18 +90,18 @@ def iter_terms(version: str, force: bool = False):
             raise ValueError(identifier)
         term = Term.from_triple(PREFIX, identifier, name)
         if pd.notna(level):
-            term.append_property("level", level)
+            term.annotate_literal("level", level)
         if pd.notna(abbreviation):
             term.append_synonym(abbreviation, type=abbreviation_typedef)
         if pd.notna(synonyms):
             for synonym in synonyms.split("|"):
                 term.append_synonym(synonym.strip())
         if pd.notna(smiles):
-            term.append_property(has_smiles, smiles)
+            term.annotate_literal(has_smiles, smiles)
         if pd.notna(inchi) and inchi != "InChI=none":
             if inchi.startswith("InChI="):
                 inchi = inchi[len("InChI=") :]
-            term.append_property(has_inchi, inchi)
+            term.annotate_literal(has_inchi, inchi)
         if pd.notna(inchikey):
             inchikey = inchikey.removeprefix("InChIKey=").strip()
             if inchikey and inchikey != "none":

--- a/src/pyobo/sources/uniprot/uniprot.py
+++ b/src/pyobo/sources/uniprot/uniprot.py
@@ -99,19 +99,18 @@ def iter_terms(version: str | None = None) -> Iterable[Term]:
             term.set_species(taxonomy_id)
             if gene_ids:
                 for gene_id in gene_ids.split(";"):
-                    term.append_relationship(
+                    term.annotate_object(
                         gene_product_of, Reference(prefix="ncbigene", identifier=gene_id.strip())
                     )
 
-            # TODO add type=Reference(prefix="xsd", identifier="boolean")
-            term.append_property("reviewed", "true")
+            term.annotate_boolean("reviewed", True)
 
             for go_process_ref in _parse_go(go_processes):
-                term.append_relationship(participates_in, go_process_ref)
+                term.annotate_object(participates_in, go_process_ref)
             for go_function_ref in _parse_go(go_functions):
-                term.append_relationship(enables, go_function_ref)
+                term.annotate_object(enables, go_function_ref)
             for go_component_ref in _parse_go(go_components):
-                term.append_relationship(located_in, go_component_ref)
+                term.annotate_object(located_in, go_component_ref)
 
             if proteome:
                 uniprot_proteome_id = proteome.split(":")[0]
@@ -122,7 +121,7 @@ def iter_terms(version: str | None = None) -> Iterable[Term]:
 
             if rhea_curies:
                 for rhea_curie in rhea_curies.split(" "):
-                    term.append_relationship(
+                    term.annotate_object(
                         # FIXME this needs a different relation than enables
                         #  see https://github.com/biopragmatics/pyobo/pull/168#issuecomment-1918680152
                         enables,
@@ -139,11 +138,11 @@ def iter_terms(version: str | None = None) -> Iterable[Term]:
                             cast(Reference, Reference.from_curie(curie, strict=True))
                         )
                 for binding_reference in sorted(binding_references, key=attrgetter("curie")):
-                    term.append_relationship(molecularly_interacts_with, binding_reference)
+                    term.annotate_object(molecularly_interacts_with, binding_reference)
 
             if ecs:
                 for ec in ecs.split(";"):
-                    term.append_relationship(
+                    term.annotate_object(
                         enables, Reference(prefix="eccode", identifier=standardize_ec(ec))
                     )
             for pubmed in pubmeds.split(";"):

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -347,6 +347,10 @@ class Term(Referenced):
         """Append a relationship."""
         self.relationships[typedef].append(_ensure_ref(reference))
 
+    def annotate_object(self, typedef: TypeDef, reference: ReferenceHint) -> None:
+        """Append a relationship."""
+        self.append_relationship(typedef, reference)
+
     def set_species(self, identifier: str, name: str | None = None):
         """Append the from_species relation."""
         if name is None:
@@ -382,6 +386,16 @@ class Term(Referenced):
         if isinstance(value, Reference | Referenced):
             value = value.preferred_curie
         self.properties[prop].append(value)
+
+    def annotate_literal(
+        self, prop: str | Reference | Referenced, value: str, dtype: Any = None
+    ) -> None:
+        """Append a property."""
+        self.append_property(prop, value)
+
+    def annotate_boolean(self, prop: str | Reference | Referenced, value: bool) -> None:
+        """Append a property."""
+        self.annotate_literal(prop, str(value))
 
     def _definition_fp(self) -> str:
         if self.definition is None:


### PR DESCRIPTION
Right now, PyOBO uses object properties for everything, even when it should be using annotation properties. This PR adds a new interface for better annotating when annotation properties have a CURIE reference as their object. It doesn't yet change any functionality - that will come in a subsequent PR.