### PR TITLE
Enable passing a flag for reprocessing

### DIFF
--- a/src/pyobo/api/alts.py
+++ b/src/pyobo/api/alts.py
@@ -27,7 +27,7 @@ NO_ALTS = {
 @lru_cache
 @wrap_norm_prefix
 def get_id_to_alts(
-    prefix: str, *, force: bool = False, version: str | None = None
+    prefix: str, *, force: bool = False, version: str | None = None, force_process: bool = False
 ) -> Mapping[str, list[str]]:
     """Get alternate identifiers."""
     if prefix in NO_ALTS:
@@ -38,13 +38,13 @@ def get_id_to_alts(
     path = prefix_cache_join(prefix, name="alt_ids.tsv", version=version)
     header = [f"{prefix}_id", "alt_id"]
 
-    @cached_multidict(path=path, header=header, force=force)
+    @cached_multidict(path=path, header=header, force=force or force_process)
     def _get_mapping() -> Mapping[str, list[str]]:
         if force:
             logger.info(f"[{prefix}] forcing reload for alts")
         else:
             logger.info("[%s] no cached alts found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force, version=version)
+        ontology = get_ontology(prefix, force=force, version=version, rewrite=force_process)
         return ontology.get_id_alts_mapping()
 
     return _get_mapping()
@@ -53,12 +53,14 @@ def get_id_to_alts(
 @lru_cache
 @wrap_norm_prefix
 def get_alts_to_id(
-    prefix: str, *, force: bool = False, version: str | None = None
+    prefix: str, *, force: bool = False, version: str | None = None, force_process: bool = False
 ) -> Mapping[str, str]:
     """Get alternative id to primary id mapping."""
     return {
         alt: primary
-        for primary, alts in get_id_to_alts(prefix, force=force, version=version).items()
+        for primary, alts in get_id_to_alts(
+            prefix, force=force, version=version, force_process=force_process
+        ).items()
         for alt in alts
     }
 

--- a/src/pyobo/api/metadata.py
+++ b/src/pyobo/api/metadata.py
@@ -20,20 +20,20 @@ logger = logging.getLogger(__name__)
 @lru_cache
 @wrap_norm_prefix
 def get_metadata(
-    prefix: str, *, force: bool = False, version: str | None = None
+    prefix: str, *, force: bool = False, version: str | None = None, force_process: bool = False
 ) -> Mapping[str, str]:
     """Get metadata for the ontology."""
     if version is None:
         version = get_version(prefix)
     path = prefix_cache_join(prefix, name="metadata.json", version=version)
 
-    @cached_json(path=path, force=force)
+    @cached_json(path=path, force=force or force_process)
     def _get_json() -> Mapping[str, str]:
         if force:
             logger.debug("[%s] forcing reload for metadata", prefix)
         else:
             logger.debug("[%s] no cached metadata found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force, version=version)
+        ontology = get_ontology(prefix, force=force, version=version, rewrite=force_process)
         return ontology.get_metadata()
 
     return _get_json()

--- a/src/pyobo/api/names.py
+++ b/src/pyobo/api/names.py
@@ -98,7 +98,12 @@ def get_name(
 @lru_cache
 @wrap_norm_prefix
 def get_ids(
-    prefix: str, *, force: bool = False, strict: bool = False, version: str | None = None
+    prefix: str,
+    *,
+    force: bool = False,
+    strict: bool = False,
+    version: str | None = None,
+    force_process: bool = False,
 ) -> set[str]:
     """Get the set of identifiers for this prefix."""
     if prefix == "ncbigene":
@@ -113,7 +118,7 @@ def get_ids(
         version = get_version(prefix)
     path = prefix_cache_join(prefix, name="ids.tsv", version=version)
 
-    @cached_collection(path=path, force=force)
+    @cached_collection(path=path, force=force or force_process)
     def _get_ids() -> set[str]:
         if force:
             logger.info("[%s v%s] forcing reload for names", prefix, version)
@@ -121,7 +126,9 @@ def get_ids(
             logger.debug(
                 "[%s v%s] no cached identifiers found. getting from OBO loader", prefix, version
             )
-        ontology = get_ontology(prefix, force=force, strict=strict, version=version)
+        ontology = get_ontology(
+            prefix, force=force, strict=strict, version=version, rewrite=force_process
+        )
         return ontology.get_ids()
 
     return set(_get_ids())
@@ -130,7 +137,12 @@ def get_ids(
 @lru_cache
 @wrap_norm_prefix
 def get_id_name_mapping(
-    prefix: str, *, force: bool = False, strict: bool = False, version: str | None = None
+    prefix: str,
+    *,
+    force: bool = False,
+    strict: bool = False,
+    version: str | None = None,
+    force_process: bool = False,
 ) -> Mapping[str, str]:
     """Get an identifier to name mapping for the OBO file."""
     if prefix == "ncbigene":
@@ -145,13 +157,15 @@ def get_id_name_mapping(
         version = get_version(prefix)
     path = prefix_cache_join(prefix, name="names.tsv", version=version)
 
-    @cached_mapping(path=path, header=[f"{prefix}_id", "name"], force=force)
+    @cached_mapping(path=path, header=[f"{prefix}_id", "name"], force=force or force_process)
     def _get_id_name_mapping() -> Mapping[str, str]:
         if force:
             logger.debug("[%s v%s] forcing reload for names", prefix, version)
         else:
             logger.debug("[%s v%s] no cached names found. getting from OBO loader", prefix, version)
-        ontology = get_ontology(prefix, force=force, strict=strict, version=version)
+        ontology = get_ontology(
+            prefix, force=force, strict=strict, version=version, rewrite=force_process
+        )
         return ontology.get_id_name_mapping()
 
     try:
@@ -167,10 +181,12 @@ def get_id_name_mapping(
 @lru_cache
 @wrap_norm_prefix
 def get_name_id_mapping(
-    prefix: str, *, force: bool = False, version: str | None = None
+    prefix: str, *, force: bool = False, version: str | None = None, force_process: bool = False
 ) -> Mapping[str, str]:
     """Get a name to identifier mapping for the OBO file."""
-    id_name = get_id_name_mapping(prefix=prefix, force=force, version=version)
+    id_name = get_id_name_mapping(
+        prefix=prefix, force=force, version=version, force_process=force_process
+    )
     return {v: k for k, v in id_name.items()}
 
 
@@ -190,18 +206,21 @@ def get_id_definition_mapping(
     force: bool = False,
     strict: bool = False,
     version: str | None = None,
+    force_process: bool = False,
 ) -> Mapping[str, str]:
     """Get a mapping of descriptions."""
     if version is None:
         version = get_version(prefix)
     path = prefix_cache_join(prefix, name="definitions.tsv", version=version)
 
-    @cached_mapping(path=path, header=[f"{prefix}_id", "definition"], force=force)
+    @cached_mapping(path=path, header=[f"{prefix}_id", "definition"], force=force or force_process)
     def _get_mapping() -> Mapping[str, str]:
         logger.info(
             "[%s v%s] no cached descriptions found. getting from OBO loader", prefix, version
         )
-        ontology = get_ontology(prefix, force=force, strict=strict, version=version)
+        ontology = get_ontology(
+            prefix, force=force, strict=strict, version=version, rewrite=force_process
+        )
         return ontology.get_id_definition_mapping()
 
     return _get_mapping()
@@ -213,15 +232,18 @@ def get_obsolete(
     force: bool = False,
     strict: bool = False,
     version: str | None = None,
+    force_process: bool = False,
 ) -> set[str]:
     """Get the set of obsolete local unique identifiers."""
     if version is None:
         version = get_version(prefix)
     path = prefix_cache_join(prefix, name="obsolete.tsv", version=version)
 
-    @cached_collection(path=path, force=force)
+    @cached_collection(path=path, force=force or force_process)
     def _get_obsolete() -> set[str]:
-        ontology = get_ontology(prefix, force=force, strict=strict, version=version)
+        ontology = get_ontology(
+            prefix, force=force, strict=strict, version=version, rewrite=force_process
+        )
         return ontology.get_obsolete()
 
     return set(_get_obsolete())
@@ -240,16 +262,19 @@ def get_id_synonyms_mapping(
     force: bool = False,
     strict: bool = False,
     version: str | None = None,
+    force_process: bool = False,
 ) -> Mapping[str, list[str]]:
     """Get the OBO file and output a synonym dictionary."""
     if version is None:
         version = get_version(prefix)
     path = prefix_cache_join(prefix, name="synonyms.tsv", version=version)
 
-    @cached_multidict(path=path, header=[f"{prefix}_id", "synonym"], force=force)
+    @cached_multidict(path=path, header=[f"{prefix}_id", "synonym"], force=force or force_process)
     def _get_multidict() -> Mapping[str, list[str]]:
         logger.info("[%s v%s] no cached synonyms found. getting from OBO loader", prefix, version)
-        ontology = get_ontology(prefix, force=force, strict=strict, version=version)
+        ontology = get_ontology(
+            prefix, force=force, strict=strict, version=version, rewrite=force_process
+        )
         return ontology.get_id_synonyms_mapping()
 
     return _get_multidict()

--- a/src/pyobo/api/species.py
+++ b/src/pyobo/api/species.py
@@ -46,6 +46,7 @@ def get_id_species_mapping(
     force: bool = False,
     strict: bool = True,
     version: str | None = None,
+    force_process: bool = False,
 ) -> Mapping[str, str]:
     """Get an identifier to species mapping."""
     if prefix == "ncbigene":
@@ -60,10 +61,12 @@ def get_id_species_mapping(
         version = get_version(prefix)
     path = prefix_cache_join(prefix, name="species.tsv", version=version)
 
-    @cached_mapping(path=path, header=[f"{prefix}_id", "species"], force=force)
+    @cached_mapping(path=path, header=[f"{prefix}_id", "species"], force=force or force_process)
     def _get_id_species_mapping() -> Mapping[str, str]:
         logger.info("[%s] no cached species found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force, strict=strict, version=version)
+        ontology = get_ontology(
+            prefix, force=force, strict=strict, version=version, rewrite=force_process
+        )
         logger.info("[%s] loading species mappings", prefix)
         return ontology.get_id_species_mapping()
 

--- a/src/pyobo/api/typedefs.py
+++ b/src/pyobo/api/typedefs.py
@@ -20,16 +20,22 @@ logger = logging.getLogger(__name__)
 
 @lru_cache
 @wrap_norm_prefix
-def get_typedef_df(prefix: str, *, force: bool = False, version: str | None = None) -> pd.DataFrame:
+def get_typedef_df(
+    prefix: str,
+    *,
+    force: bool = False,
+    version: str | None = None,
+    force_process: bool = False,
+) -> pd.DataFrame:
     """Get an identifier to name mapping for the typedefs in an OBO file."""
     if version is None:
         version = get_version(prefix)
     path = prefix_cache_join(prefix, name="typedefs.tsv", version=version)
 
-    @cached_df(path=path, dtype=str, force=force)
+    @cached_df(path=path, dtype=str, force=force or force_process)
     def _df_getter() -> pd.DataFrame:
         logger.debug("[%s] no cached typedefs found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force, version=version)
+        ontology = get_ontology(prefix, force=force, version=version, rewrite=force_process)
         logger.debug("[%s] loading typedef mappings", prefix)
         return ontology.get_typedef_df()
 

--- a/src/pyobo/api/xrefs.py
+++ b/src/pyobo/api/xrefs.py
@@ -52,6 +52,7 @@ def get_filtered_xrefs(
     force: bool = False,
     strict: bool = False,
     version: str | None = None,
+    force_process: bool = False,
 ) -> Mapping[str, str]:
     """Get xrefs to a given target."""
     if version is None:
@@ -60,7 +61,7 @@ def get_filtered_xrefs(
     all_xrefs_path = prefix_cache_join(prefix, name="xrefs.tsv", version=version)
     header = [f"{prefix}_id", f"{xref_prefix}_id"]
 
-    @cached_mapping(path=path, header=header, use_tqdm=use_tqdm, force=force)
+    @cached_mapping(path=path, header=header, use_tqdm=use_tqdm, force=force or force_process)
     def _get_mapping() -> Mapping[str, str]:
         if all_xrefs_path.is_file():
             logger.info("[%s] loading pre-cached xrefs", prefix)
@@ -70,7 +71,9 @@ def get_filtered_xrefs(
             return dict(df.values)
 
         logger.info("[%s] no cached xrefs found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force, strict=strict, version=version)
+        ontology = get_ontology(
+            prefix, force=force, strict=strict, version=version, rewrite=force_process
+        )
         return ontology.get_filtered_xrefs_mapping(xref_prefix, use_tqdm=use_tqdm)
 
     rv = _get_mapping()
@@ -90,16 +93,19 @@ def get_xrefs_df(
     force: bool = False,
     strict: bool = False,
     version: str | None = None,
+    force_process: bool = False,
 ) -> pd.DataFrame:
     """Get all xrefs."""
     if version is None:
         version = get_version(prefix)
     path = prefix_cache_join(prefix, name="xrefs.tsv", version=version)
 
-    @cached_df(path=path, dtype=str, force=force)
+    @cached_df(path=path, dtype=str, force=force or force_process)
     def _df_getter() -> pd.DataFrame:
         logger.info("[%s] no cached xrefs found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force, strict=strict, version=version)
+        ontology = get_ontology(
+            prefix, force=force, strict=strict, version=version, rewrite=force_process
+        )
         return ontology.get_xrefs_df(use_tqdm=use_tqdm)
 
     return _df_getter()


### PR DESCRIPTION
This adds the `force_process` flag in addition to the already existing `force` flag - the `force` flag causes re-download and reprocess. `force_process` only causes reprocess, which saves a lot of time for many resources.