### PR TITLE
Improve alternative identifier lookup functions

### DIFF
--- a/tests/test_alt_ids.py
+++ b/tests/test_alt_ids.py
@@ -30,6 +30,15 @@ mock_id_names_mapping = get_mock_id_name_mapping(
 class TestAltIds(unittest.TestCase):
     """Tests for alternative identifiers."""
 
+    def test_get_primary_errors(self):
+        """Test when calling get_primary_identifier incorrectly."""
+        with self.assertRaises(ValueError):
+            get_primary_identifier("go")
+
+        self.assertIsNone(get_primary_curie("nope:nope", strict=False))
+        with self.assertRaises(ValueError):
+            get_primary_curie("nope:nope", strict=True)
+
     @mock_id_alts_mapping
     @mock_id_names_mapping
     def test_get_primary(self, _, __):
@@ -70,6 +79,14 @@ class TestAltIds(unittest.TestCase):
         name = get_name(Reference(prefix="go", identifier="0003700"))
         self.assertIsNotNone(name)
         self.assertEqual("DNA-binding transcription factor activity", name)
+
+    @mock_id_alts_mapping
+    @mock_id_names_mapping
+    def test_get_primary_on_reference(self, _, __):
+        """Test when you give a primary id."""
+        self.assertEqual(
+            "0003700", get_primary_identifier(Reference(prefix="go", identifier="0001071"))
+        )
 
     @mock_id_alts_mapping
     @mock_id_names_mapping


### PR DESCRIPTION
This PR starts moving away from using the `normalize_curie` function in alt id lookup. It also does a bit of refactoring and adds additional tests