### PR TITLE
Streamline relation string handling

### DIFF
--- a/src/pyobo/api/relations.py
+++ b/src/pyobo/api/relations.py
@@ -1,7 +1,6 @@
 """High-level API for relations."""
 
 import logging
-import os
 from collections.abc import Mapping
 from functools import lru_cache
 
@@ -87,7 +86,7 @@ def get_filtered_relations_df(
     force_process: bool = False,
 ) -> pd.DataFrame:
     """Get all the given relation."""
-    relation_prefix, relation_identifier = relation = _ensure_ref(relation).pair
+    relation = _ensure_ref(relation)
     if version is None:
         version = get_version(prefix)
 
@@ -95,16 +94,14 @@ def get_filtered_relations_df(
     if all_relations_path.is_file():
         logger.debug("[%] loading all relations from %s", prefix, all_relations_path)
         df = pd.read_csv(all_relations_path, sep="\t", dtype=str)
-        idx = (df[RELATION_PREFIX] == relation_prefix) & (
-            df[RELATION_ID] == relation_identifier
-        )
+        idx = (df[RELATION_PREFIX] == relation.prefix) & (df[RELATION_ID] == relation.identifier)
         columns = [f"{prefix}_id", TARGET_PREFIX, TARGET_ID]
         return df.loc[idx, columns]
 
     path = prefix_cache_join(
         prefix,
         "relations",
-        name=f"{relation_prefix}:{relation_identifier}.tsv",
+        name=f"{relation.curie}.tsv",
         version=version,
     )
 

--- a/src/pyobo/api/relations.py
+++ b/src/pyobo/api/relations.py
@@ -86,7 +86,7 @@ def get_filtered_relations_df(
     force_process: bool = False,
 ) -> pd.DataFrame:
     """Get all the given relation."""
-    relation = _ensure_ref(relation)
+    relation = _ensure_ref(relation, ontology_prefix=prefix)
     if version is None:
         version = get_version(prefix)
 

--- a/src/pyobo/api/relations.py
+++ b/src/pyobo/api/relations.py
@@ -20,7 +20,8 @@ from ..constants import (
 )
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
-from ..struct import Reference, RelationHint, TypeDef, get_reference_tuple
+from ..struct import Reference, TypeDef
+from ..struct.struct import ReferenceHint, _ensure_ref
 from ..utils.cache import cached_df
 from ..utils.path import prefix_cache_join
 
@@ -78,7 +79,7 @@ def get_relations_df(
 @wrap_norm_prefix
 def get_filtered_relations_df(
     prefix: str,
-    relation: RelationHint,
+    relation: ReferenceHint,
     *,
     use_tqdm: bool = False,
     force: bool = False,
@@ -86,28 +87,29 @@ def get_filtered_relations_df(
     force_process: bool = False,
 ) -> pd.DataFrame:
     """Get all the given relation."""
-    relation_prefix, relation_identifier = relation = get_reference_tuple(relation)
+    relation_prefix, relation_identifier = relation = _ensure_ref(relation).pair
     if version is None:
         version = get_version(prefix)
+
+    all_relations_path = prefix_cache_join(prefix, name="relations.tsv", version=version)
+    if all_relations_path.is_file():
+        logger.debug("[%] loading all relations from %s", prefix, all_relations_path)
+        df = pd.read_csv(all_relations_path, sep="\t", dtype=str)
+        idx = (df[RELATION_PREFIX] == relation_prefix) & (
+            df[RELATION_ID] == relation_identifier
+        )
+        columns = [f"{prefix}_id", TARGET_PREFIX, TARGET_ID]
+        return df.loc[idx, columns]
+
     path = prefix_cache_join(
         prefix,
         "relations",
         name=f"{relation_prefix}:{relation_identifier}.tsv",
         version=version,
     )
-    all_relations_path = prefix_cache_join(prefix, name="relations.tsv", version=version)
 
     @cached_df(path=path, dtype=str, force=force or force_process)
     def _df_getter() -> pd.DataFrame:
-        if os.path.exists(all_relations_path):
-            logger.debug("[%] loading all relations from %s", prefix, all_relations_path)
-            df = pd.read_csv(all_relations_path, sep="\t", dtype=str)
-            idx = (df[RELATION_PREFIX] == relation_prefix) & (
-                df[RELATION_ID] == relation_identifier
-            )
-            columns = [f"{prefix}_id", TARGET_PREFIX, TARGET_ID]
-            return df.loc[idx, columns]
-
         logger.info("[%s] no cached relations found. getting from OBO loader", prefix)
         ontology = get_ontology(prefix, force=force, version=version, rewrite=force_process)
         return ontology.get_filtered_relations_df(relation, use_tqdm=use_tqdm)
@@ -136,7 +138,7 @@ def get_id_multirelations_mapping(
 @wrap_norm_prefix
 def get_relation_mapping(
     prefix: str,
-    relation: RelationHint,
+    relation: ReferenceHint,
     target_prefix: str,
     *,
     use_tqdm: bool = False,
@@ -168,7 +170,7 @@ def get_relation_mapping(
 def get_relation(
     prefix: str,
     source_identifier: str,
-    relation: RelationHint,
+    relation: ReferenceHint,
     target_prefix: str,
     *,
     use_tqdm: bool = False,

--- a/src/pyobo/struct/__init__.py
+++ b/src/pyobo/struct/__init__.py
@@ -36,7 +36,6 @@ from .typedef import (
 __all__ = [
     "Obo",
     "Reference",
-    "RelationHint",
     "Synonym",
     "SynonymSpecificities",
     "SynonymSpecificity",

--- a/src/pyobo/struct/__init__.py
+++ b/src/pyobo/struct/__init__.py
@@ -13,13 +13,11 @@ from .struct import (
     make_ad_hoc_ontology,
 )
 from .typedef import (
-    RelationHint,
     TypeDef,
     derives_from,
     enables,
     from_species,
     gene_product_member_of,
-    get_reference_tuple,
     has_gene_product,
     has_member,
     has_part,
@@ -50,7 +48,6 @@ __all__ = [
     "enables",
     "from_species",
     "gene_product_member_of",
-    "get_reference_tuple",
     "has_gene_product",
     "has_member",
     "has_part",

--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -77,6 +77,7 @@ class Reference(curies.Reference):
         *,
         strict: bool = True,
         auto: bool = False,
+        ontology_prefix: str | None = None,
     ) -> Reference | None:
         """Get a reference from a CURIE.
 
@@ -85,7 +86,7 @@ class Reference(curies.Reference):
         :param strict: If true, raises an error if the CURIE can not be parsed.
         :param auto: Automatically look up name
         """
-        prefix, identifier = normalize_curie(curie, strict=strict)
+        prefix, identifier = normalize_curie(curie, strict=strict, ontology=ontology_prefix)
         return cls._materialize(prefix=prefix, identifier=identifier, name=name, auto=auto)
 
     @classmethod

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -144,11 +144,7 @@ def _ensure_ref(
     if isinstance(reference, Referenced):
         return reference.reference
     if isinstance(reference, str):
-        if ":" not in reference:
-            if not ontology_prefix:
-                raise ValueError
-            return default_reference(ontology_prefix, reference)
-        _rv = Reference.from_curie(reference, strict=True)
+        _rv = Reference.from_curie(reference, strict=True, ontology_prefix=ontology_prefix)
         if _rv is None:
             raise RuntimeError  # not possible, need typing for Reference.from_curie
         return _rv

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -146,7 +146,7 @@ def _ensure_ref(
     if isinstance(reference, str):
         _rv = Reference.from_curie(reference, strict=True, ontology_prefix=ontology_prefix)
         if _rv is None:
-            raise RuntimeError  # not possible, need typing for Reference.from_curie
+            raise ValueError(f"could not parse CURIE from {reference}")
         return _rv
     if isinstance(reference, tuple):
         return Reference(prefix=reference[0], identifier=reference[1])

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -48,6 +48,7 @@ from ..constants import (
     TARGET_ID,
     TARGET_PREFIX,
 )
+from ..identifier_utils import normalize_curie
 from ..utils.io import multidict, write_iterable_tsv
 from ..utils.path import prefix_directory_join
 

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from operator import attrgetter
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, ClassVar, Literal, TextIO, Union
+from typing import Any, ClassVar, Literal, TextIO, TypeAlias
 
 import bioregistry
 import click
@@ -25,13 +25,11 @@ from tqdm.auto import tqdm
 
 from .reference import Reference, Referenced
 from .typedef import (
-    RelationHint,
     TypeDef,
     comment,
     default_typedefs,
     exact_match,
     from_species,
-    get_reference_tuple,
     has_ontology_root_term,
     has_part,
     is_a,
@@ -50,12 +48,12 @@ from ..constants import (
     TARGET_ID,
     TARGET_PREFIX,
 )
-from ..identifier_utils import normalize_curie
 from ..utils.io import multidict, write_iterable_tsv
 from ..utils.path import prefix_directory_join
 
 __all__ = [
     "Obo",
+    "ReferenceHint",
     "Synonym",
     "SynonymSpecificities",
     "SynonymSpecificity",
@@ -132,18 +130,26 @@ abbreviation = SynonymTypeDef(
 )
 acronym = SynonymTypeDef(reference=Reference(prefix="omo", identifier="0003012", name="acronym"))
 
-ReferenceHint = Union[Reference, "Term", tuple[str, str], str]
+ReferenceHint: TypeAlias = Reference | Referenced | tuple[str, str] | str
 
 
-def _ensure_ref(reference: ReferenceHint) -> Reference:
+def _ensure_ref(
+    reference: ReferenceHint,
+    *,
+    ontology_prefix: str | None = None,
+) -> Reference:
     if reference is None:
         raise ValueError("can not append null reference")
-    if isinstance(reference, Term):
+    if isinstance(reference, Referenced):
         return reference.reference
     if isinstance(reference, str):
-        _rv = Reference.from_curie(reference)
+        if ":" not in reference:
+            if not ontology_prefix:
+                raise ValueError
+            return default_reference(ontology_prefix, reference)
+        _rv = Reference.from_curie(reference, strict=True)
         if _rv is None:
-            raise ValueError(f"could not parse CURIE from {reference}")
+            raise RuntimeError  # not possible, need typing for Reference.from_curie
         return _rv
     if isinstance(reference, tuple):
         return Reference(prefix=reference[0], identifier=reference[1])
@@ -1236,14 +1242,14 @@ class Obo:
 
     def iterate_filtered_relations(
         self,
-        relation: RelationHint,
+        relation: ReferenceHint,
         *,
         use_tqdm: bool = False,
     ) -> Iterable[tuple[Term, Reference]]:
         """Iterate over tuples of terms and ther targets for the given relation."""
-        _target_prefix, _target_identifier = get_reference_tuple(relation)
-        for term, typedef, reference in self.iterate_relations(use_tqdm=use_tqdm):
-            if typedef.prefix == _target_prefix and typedef.identifier == _target_identifier:
+        _pair = _ensure_ref(relation, ontology_prefix=self.ontology).pair
+        for term, predicate, reference in self.iterate_relations(use_tqdm=use_tqdm):
+            if _pair == predicate.pair:
                 yield term, reference
 
     @property
@@ -1260,7 +1266,7 @@ class Obo:
 
     def get_filtered_relations_df(
         self,
-        relation: RelationHint,
+        relation: ReferenceHint,
         *,
         use_tqdm: bool = False,
     ) -> pd.DataFrame:
@@ -1275,7 +1281,7 @@ class Obo:
 
     def iterate_filtered_relations_filtered_targets(
         self,
-        relation: RelationHint,
+        relation: ReferenceHint,
         target_prefix: str,
         *,
         use_tqdm: bool = False,
@@ -1289,7 +1295,7 @@ class Obo:
 
     def get_relation_mapping(
         self,
-        relation: RelationHint,
+        relation: ReferenceHint,
         target_prefix: str,
         *,
         use_tqdm: bool = False,
@@ -1319,7 +1325,7 @@ class Obo:
     def get_relation(
         self,
         source_identifier: str,
-        relation: RelationHint,
+        relation: ReferenceHint,
         target_prefix: str,
         *,
         use_tqdm: bool = False,
@@ -1339,7 +1345,7 @@ class Obo:
 
     def get_relation_multimapping(
         self,
-        relation: RelationHint,
+        relation: ReferenceHint,
         target_prefix: str,
         *,
         use_tqdm: bool = False,

--- a/src/pyobo/struct/typedef.py
+++ b/src/pyobo/struct/typedef.py
@@ -11,7 +11,6 @@ from .reference import Reference, Referenced
 from ..resources.ro import load_ro
 
 __all__ = [
-    "RelationHint",
     "TypeDef",
     "alternative_term",
     "default_typedefs",
@@ -21,7 +20,6 @@ __all__ = [
     "example_of_usage",
     "from_species",
     "gene_product_member_of",
-    "get_reference_tuple",
     "has_dbxref",
     "has_gene_product",
     "has_homepage",
@@ -137,24 +135,6 @@ class TypeDef(Referenced):
         if reference is None:
             raise RuntimeError
         return cls(reference=reference)
-
-
-RelationHint = Reference | TypeDef | tuple[str, str] | str
-
-
-def get_reference_tuple(relation: RelationHint) -> tuple[str, str]:
-    """Get tuple for typedef/reference."""
-    if isinstance(relation, Reference | TypeDef):
-        return relation.pair
-    elif isinstance(relation, tuple):
-        return relation
-    elif isinstance(relation, str):
-        reference = Reference.from_curie(relation, strict=True)
-        if reference is None:
-            raise ValueError(f"string given is not valid curie: {relation}")
-        return reference.pair
-    else:
-        raise TypeError(f"Relation is invalid type: {relation}")
 
 
 RO_PREFIX = "RO"

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -5,6 +5,7 @@ from operator import attrgetter
 
 import obonet
 from curies import ReferenceTuple
+
 from pyobo import Reference, Synonym, SynonymTypeDef, TypeDef, get_ontology
 from pyobo.reader import (
     _extract_definition,

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -4,8 +4,8 @@ import unittest
 from operator import attrgetter
 
 import obonet
-
-from pyobo import Reference, Synonym, SynonymTypeDef, get_ontology
+from curies import ReferenceTuple
+from pyobo import Reference, Synonym, SynonymTypeDef, TypeDef, get_ontology
 from pyobo.reader import (
     _extract_definition,
     _extract_synonym,
@@ -18,6 +18,8 @@ from pyobo.reader import (
     iterate_node_xrefs,
 )
 from pyobo.struct.struct import acronym
+from pyobo.utils.io import multidict
+
 from tests.constants import TEST_CHEBI_OBO_PATH, chebi_patch
 
 
@@ -266,3 +268,21 @@ class TestGet(unittest.TestCase):
         self.assertNotIn("C00462", id_alts_mapping)
         self.assertIn("16042", id_alts_mapping, msg="halide anion alt_id fields not parsed")
         self.assertEqual({"5605", "14384"}, set(id_alts_mapping["16042"]))
+
+    def test_iter_filtered_relations(self):
+        """Test getting filtered relations w/ upgrade."""
+        curie = "chebi:is_conjugate_base_of"
+        for inp in [
+            curie,
+            ReferenceTuple.from_curie(curie),
+            Reference.from_curie(curie),
+            TypeDef.from_curie(curie),
+        ]:
+            with self.subTest(inp=inp):
+                rr = multidict(
+                    (term.reference, target)
+                    for term, target in self.ontology.iterate_filtered_relations(inp)
+                )
+                term = Reference.from_curie("chebi:17051")
+                self.assertIn(term, rr)
+                self.assertIn(Reference.from_curie("chebi:29228"), rr[term])

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -20,7 +20,6 @@ from pyobo.reader import (
 )
 from pyobo.struct.struct import acronym
 from pyobo.utils.io import multidict
-
 from tests.constants import TEST_CHEBI_OBO_PATH, chebi_patch
 
 


### PR DESCRIPTION
This PR reduces code where there was a separate "RelationHint" that had duplicate handling for strings/references/terms