### PR TITLE
Refactor API interface

### DIFF
--- a/src/pyobo/api/alts.py
+++ b/src/pyobo/api/alts.py
@@ -7,8 +7,8 @@ from functools import lru_cache
 import curies
 from typing_extensions import Unpack
 
-from .utils import force_cache, kwargs_version
-from ..constants import SlimLookupKwargs
+from .utils import get_version_from_kwargs
+from ..constants import SlimLookupKwargs, check_should_force
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..struct.reference import Reference
@@ -36,10 +36,12 @@ def get_id_to_alts(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> Mapping[s
     if prefix in NO_ALTS:
         return {}
 
-    version = kwargs_version(prefix, kwargs)
+    version = get_version_from_kwargs(prefix, kwargs)
     path = prefix_cache_join(prefix, name="alt_ids.tsv", version=version)
 
-    @cached_multidict(path=path, header=[f"{prefix}_id", "alt_id"], force=force_cache(kwargs))
+    @cached_multidict(
+        path=path, header=[f"{prefix}_id", "alt_id"], force=check_should_force(kwargs)
+    )
     def _get_mapping() -> Mapping[str, list[str]]:
         ontology = get_ontology(prefix, **kwargs)
         return ontology.get_id_alts_mapping()

--- a/src/pyobo/api/alts.py
+++ b/src/pyobo/api/alts.py
@@ -8,7 +8,7 @@ import curies
 from typing_extensions import Unpack
 
 from .utils import get_version_from_kwargs
-from ..constants import SlimLookupKwargs, check_should_force
+from ..constants import GetOntologyKwargs, check_should_force
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..struct.reference import Reference
@@ -31,7 +31,7 @@ NO_ALTS = {
 
 @lru_cache
 @wrap_norm_prefix
-def get_id_to_alts(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> Mapping[str, list[str]]:
+def get_id_to_alts(prefix: str, **kwargs: Unpack[GetOntologyKwargs]) -> Mapping[str, list[str]]:
     """Get alternate identifiers."""
     if prefix in NO_ALTS:
         return {}
@@ -51,7 +51,7 @@ def get_id_to_alts(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> Mapping[s
 
 @lru_cache
 @wrap_norm_prefix
-def get_alts_to_id(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> Mapping[str, str]:
+def get_alts_to_id(prefix: str, **kwargs: Unpack[GetOntologyKwargs]) -> Mapping[str, str]:
     """Get alternative id to primary id mapping."""
     return {
         alt: primary for primary, alts in get_id_to_alts(prefix, **kwargs).items() for alt in alts
@@ -60,7 +60,7 @@ def get_alts_to_id(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> Mapping[s
 
 def get_primary_curie(
     curie: str,
-    **kwargs: Unpack[SlimLookupKwargs],
+    **kwargs: Unpack[GetOntologyKwargs],
 ) -> str | None:
     """Get the primary curie for an entity."""
     reference = Reference.from_curie(curie, strict=kwargs.get("strict", True))
@@ -75,7 +75,7 @@ def get_primary_identifier(
     prefix: str | curies.Reference | curies.ReferenceTuple,
     identifier: str | None = None,
     /,
-    **kwargs: Unpack[SlimLookupKwargs],
+    **kwargs: Unpack[GetOntologyKwargs],
 ) -> str:
     """Get the primary identifier for an entity.
 

--- a/src/pyobo/api/alts.py
+++ b/src/pyobo/api/alts.py
@@ -5,8 +5,10 @@ from collections.abc import Mapping
 from functools import lru_cache
 
 import curies
+from typing_extensions import Unpack
 
-from .utils import get_version
+from .utils import force_cache, kwargs_version
+from ..constants import SlimLookupKwargs
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..struct.reference import Reference
@@ -29,25 +31,17 @@ NO_ALTS = {
 
 @lru_cache
 @wrap_norm_prefix
-def get_id_to_alts(
-    prefix: str, *, force: bool = False, version: str | None = None, force_process: bool = False
-) -> Mapping[str, list[str]]:
+def get_id_to_alts(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> Mapping[str, list[str]]:
     """Get alternate identifiers."""
     if prefix in NO_ALTS:
         return {}
 
-    if version is None:
-        version = get_version(prefix)
+    version = kwargs_version(prefix, kwargs)
     path = prefix_cache_join(prefix, name="alt_ids.tsv", version=version)
-    header = [f"{prefix}_id", "alt_id"]
 
-    @cached_multidict(path=path, header=header, force=force or force_process)
+    @cached_multidict(path=path, header=[f"{prefix}_id", "alt_id"], force=force_cache(kwargs))
     def _get_mapping() -> Mapping[str, list[str]]:
-        if force:
-            logger.info(f"[{prefix}] forcing reload for alts")
-        else:
-            logger.info("[%s] no cached alts found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force, version=version, rewrite=force_process)
+        ontology = get_ontology(prefix, **kwargs)
         return ontology.get_id_alts_mapping()
 
     return _get_mapping()
@@ -55,27 +49,22 @@ def get_id_to_alts(
 
 @lru_cache
 @wrap_norm_prefix
-def get_alts_to_id(
-    prefix: str, *, force: bool = False, version: str | None = None, force_process: bool = False
-) -> Mapping[str, str]:
+def get_alts_to_id(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> Mapping[str, str]:
     """Get alternative id to primary id mapping."""
     return {
-        alt: primary
-        for primary, alts in get_id_to_alts(
-            prefix, force=force, version=version, force_process=force_process
-        ).items()
-        for alt in alts
+        alt: primary for primary, alts in get_id_to_alts(prefix, **kwargs).items() for alt in alts
     }
 
 
 def get_primary_curie(
-    curie: str, *, version: str | None = None, strict: bool = False
+    curie: str,
+    **kwargs: Unpack[SlimLookupKwargs],
 ) -> str | None:
     """Get the primary curie for an entity."""
-    reference = Reference.from_curie(curie, strict=strict)
+    reference = Reference.from_curie(curie, strict=kwargs.get("strict", True))
     if reference is None:
         return None
-    primary_identifier = get_primary_identifier(reference, version=version)
+    primary_identifier = get_primary_identifier(reference, **kwargs)
     return f"{reference.prefix}:{primary_identifier}"
 
 
@@ -84,8 +73,7 @@ def get_primary_identifier(
     prefix: str | curies.Reference | curies.ReferenceTuple,
     identifier: str | None = None,
     /,
-    *,
-    version: str | None = None,
+    **kwargs: Unpack[SlimLookupKwargs],
 ) -> str:
     """Get the primary identifier for an entity.
 
@@ -104,5 +92,5 @@ def get_primary_identifier(
     if prefix in NO_ALTS:  # TODO later expand list to other namespaces with no alts
         return identifier
 
-    alts_to_id = get_alts_to_id(prefix, version=version)
+    alts_to_id = get_alts_to_id(prefix, **kwargs)
     return alts_to_id.get(identifier, identifier)

--- a/src/pyobo/api/metadata.py
+++ b/src/pyobo/api/metadata.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 from typing_extensions import Unpack
 
 from .utils import get_version_from_kwargs
-from ..constants import SlimLookupKwargs, check_should_force
+from ..constants import GetOntologyKwargs, check_should_force
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..utils.cache import cached_json
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 @lru_cache
 @wrap_norm_prefix
-def get_metadata(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> dict[str, Any]:
+def get_metadata(prefix: str, **kwargs: Unpack[GetOntologyKwargs]) -> dict[str, Any]:
     """Get metadata for the ontology."""
     version = get_version_from_kwargs(prefix, kwargs)
     path = prefix_cache_join(prefix, name="metadata.json", version=version)

--- a/src/pyobo/api/metadata.py
+++ b/src/pyobo/api/metadata.py
@@ -6,8 +6,8 @@ from typing import Any, cast
 
 from typing_extensions import Unpack
 
-from .utils import force_cache, kwargs_version
-from ..constants import SlimLookupKwargs
+from .utils import get_version_from_kwargs
+from ..constants import SlimLookupKwargs, check_should_force
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..utils.cache import cached_json
@@ -24,10 +24,10 @@ logger = logging.getLogger(__name__)
 @wrap_norm_prefix
 def get_metadata(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> dict[str, Any]:
     """Get metadata for the ontology."""
-    version = kwargs_version(prefix, kwargs)
+    version = get_version_from_kwargs(prefix, kwargs)
     path = prefix_cache_join(prefix, name="metadata.json", version=version)
 
-    @cached_json(path=path, force=force_cache(kwargs))
+    @cached_json(path=path, force=check_should_force(kwargs))
     def _get_json() -> dict[str, Any]:
         ontology = get_ontology(prefix, **kwargs)
         return ontology.get_metadata()

--- a/src/pyobo/api/names.py
+++ b/src/pyobo/api/names.py
@@ -9,9 +9,11 @@ from functools import lru_cache
 from typing import TypeVar
 
 from curies import Reference, ReferenceTuple
+from typing_extensions import Unpack
 
 from .alts import get_primary_identifier
-from .utils import get_version
+from .utils import force_cache, get_version, kwargs_version
+from ..constants import SlimLookupKwargs
 from ..getters import NoBuildError, get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..utils.cache import cached_collection, cached_mapping, cached_multidict
@@ -51,13 +53,11 @@ def _help_get(
     f: Callable[[str], Mapping[str, X]],
     prefix: str,
     identifier: str,
-    force: bool = False,
-    strict: bool = False,
-    version: str | None = None,
+    **kwargs: Unpack[SlimLookupKwargs],
 ) -> X | None:
     """Get the result for an entity based on a mapping maker function ``f``."""
     try:
-        mapping = f(prefix, force=force, strict=strict, version=version)  # type:ignore
+        mapping = f(prefix, **kwargs)  # type:ignore
     except NoBuildError:
         if prefix not in NO_BUILD_PREFIXES:
             logger.warning("[%s] unable to look up results with %s", prefix, f)
@@ -75,7 +75,7 @@ def _help_get(
             NO_BUILD_PREFIXES.add(prefix)
         return None
 
-    primary_id = get_primary_identifier(prefix, identifier, version=version)
+    primary_id = get_primary_identifier(prefix, identifier, **kwargs)
     return mapping.get(primary_id)
 
 
@@ -84,26 +84,18 @@ def get_name(
     prefix: str | Reference | ReferenceTuple,
     identifier: str | None = None,
     /,
-    *,
-    version: str | None = None,
+    **kwargs: Unpack[SlimLookupKwargs],
 ) -> str | None:
     """Get the name for an entity."""
     if isinstance(prefix, ReferenceTuple | Reference):
         identifier = prefix.identifier
         prefix = prefix.prefix
-    return _help_get(get_id_name_mapping, prefix, identifier, version=version)  # type:ignore
+    return _help_get(get_id_name_mapping, prefix, identifier, **kwargs)
 
 
 @lru_cache
 @wrap_norm_prefix
-def get_ids(
-    prefix: str,
-    *,
-    force: bool = False,
-    strict: bool = False,
-    version: str | None = None,
-    force_process: bool = False,
-) -> set[str]:
+def get_ids(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> set[str]:
     """Get the set of identifiers for this prefix."""
     if prefix == "ncbigene":
         from ..sources.ncbigene import get_ncbigene_ids
@@ -113,21 +105,12 @@ def get_ids(
         logger.info("[%s] done loading name mappings", prefix)
         return rv
 
-    if version is None:
-        version = get_version(prefix)
+    version = kwargs_version(prefix, kwargs)
     path = prefix_cache_join(prefix, name="ids.tsv", version=version)
 
-    @cached_collection(path=path, force=force or force_process)
+    @cached_collection(path=path, force=force_cache(kwargs))
     def _get_ids() -> list[str]:
-        if force:
-            logger.info("[%s v%s] forcing reload for names", prefix, version)
-        else:
-            logger.debug(
-                "[%s v%s] no cached identifiers found. getting from OBO loader", prefix, version
-            )
-        ontology = get_ontology(
-            prefix, force=force, strict=strict, version=version, rewrite=force_process
-        )
+        ontology = get_ontology(prefix, **kwargs)
         return sorted(ontology.get_ids())
 
     return set(_get_ids())
@@ -137,11 +120,7 @@ def get_ids(
 @wrap_norm_prefix
 def get_id_name_mapping(
     prefix: str,
-    *,
-    force: bool = False,
-    strict: bool = False,
-    version: str | None = None,
-    force_process: bool = False,
+    **kwargs: Unpack[SlimLookupKwargs],
 ) -> Mapping[str, str]:
     """Get an identifier to name mapping for the OBO file."""
     if prefix == "ncbigene":
@@ -152,19 +131,12 @@ def get_id_name_mapping(
         logger.info("[%s] done loading name mappings", prefix)
         return rv
 
-    if version is None:
-        version = get_version(prefix)
+    version = kwargs_version(prefix, kwargs)
     path = prefix_cache_join(prefix, name="names.tsv", version=version)
 
-    @cached_mapping(path=path, header=[f"{prefix}_id", "name"], force=force or force_process)
+    @cached_mapping(path=path, header=[f"{prefix}_id", "name"], force=force_cache(kwargs))
     def _get_id_name_mapping() -> Mapping[str, str]:
-        if force:
-            logger.debug("[%s v%s] forcing reload for names", prefix, version)
-        else:
-            logger.debug("[%s v%s] no cached names found. getting from OBO loader", prefix, version)
-        ontology = get_ontology(
-            prefix, force=force, strict=strict, version=version, rewrite=force_process
-        )
+        ontology = get_ontology(prefix, **kwargs)
         return ontology.get_id_name_mapping()
 
     try:
@@ -180,100 +152,76 @@ def get_id_name_mapping(
 @lru_cache
 @wrap_norm_prefix
 def get_name_id_mapping(
-    prefix: str, *, force: bool = False, version: str | None = None, force_process: bool = False
+    prefix: str,
+    **kwargs: Unpack[SlimLookupKwargs],
 ) -> Mapping[str, str]:
     """Get a name to identifier mapping for the OBO file."""
-    id_name = get_id_name_mapping(
-        prefix=prefix, force=force, version=version, force_process=force_process
-    )
+    id_name = get_id_name_mapping(prefix, **kwargs)
     return {v: k for k, v in id_name.items()}
 
 
 @wrap_norm_prefix
 def get_definition(
-    prefix: str, identifier: str | None = None, *, version: str | None = None
+    prefix: str, identifier: str | None = None, **kwargs: Unpack[SlimLookupKwargs]
 ) -> str | None:
     """Get the definition for an entity."""
     if identifier is None:
         prefix, _, identifier = prefix.rpartition(":")
-    return _help_get(get_id_definition_mapping, prefix, identifier, version=version)
+    return _help_get(get_id_definition_mapping, prefix, identifier, **kwargs)
 
 
 def get_id_definition_mapping(
     prefix: str,
-    *,
-    force: bool = False,
-    strict: bool = False,
-    version: str | None = None,
-    force_process: bool = False,
+    **kwargs: Unpack[SlimLookupKwargs],
 ) -> Mapping[str, str]:
     """Get a mapping of descriptions."""
-    if version is None:
-        version = get_version(prefix)
+    version = kwargs_version(prefix, kwargs)
     path = prefix_cache_join(prefix, name="definitions.tsv", version=version)
 
-    @cached_mapping(path=path, header=[f"{prefix}_id", "definition"], force=force or force_process)
+    @cached_mapping(path=path, header=[f"{prefix}_id", "definition"], force=force_cache(kwargs))
     def _get_mapping() -> Mapping[str, str]:
         logger.info(
             "[%s v%s] no cached descriptions found. getting from OBO loader", prefix, version
         )
-        ontology = get_ontology(
-            prefix, force=force, strict=strict, version=version, rewrite=force_process
-        )
+        ontology = get_ontology(prefix, **kwargs)
         return ontology.get_id_definition_mapping()
 
     return _get_mapping()
 
 
-def get_obsolete(
-    prefix: str,
-    *,
-    force: bool = False,
-    strict: bool = False,
-    version: str | None = None,
-    force_process: bool = False,
-) -> set[str]:
+def get_obsolete(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> set[str]:
     """Get the set of obsolete local unique identifiers."""
-    if version is None:
-        version = get_version(prefix)
+    version = kwargs_version(prefix, kwargs)
     path = prefix_cache_join(prefix, name="obsolete.tsv", version=version)
 
-    @cached_collection(path=path, force=force or force_process)
+    @cached_collection(path=path, force=force_cache(kwargs))
     def _get_obsolete() -> list[str]:
-        ontology = get_ontology(
-            prefix, force=force, strict=strict, version=version, rewrite=force_process
-        )
+        ontology = get_ontology(prefix, **kwargs)
         return sorted(ontology.get_obsolete())
 
     return set(_get_obsolete())
 
 
 @wrap_norm_prefix
-def get_synonyms(prefix: str, identifier: str) -> list[str] | None:
+def get_synonyms(
+    prefix: str, identifier: str, **kwargs: Unpack[SlimLookupKwargs]
+) -> list[str] | None:
     """Get the synonyms for an entity."""
-    return _help_get(get_id_synonyms_mapping, prefix, identifier)
+    return _help_get(get_id_synonyms_mapping, prefix, identifier, **kwargs)
 
 
 @wrap_norm_prefix
 def get_id_synonyms_mapping(
-    prefix: str,
-    *,
-    force: bool = False,
-    strict: bool = False,
-    version: str | None = None,
-    force_process: bool = False,
+    prefix: str, **kwargs: Unpack[SlimLookupKwargs]
 ) -> Mapping[str, list[str]]:
     """Get the OBO file and output a synonym dictionary."""
-    if version is None:
-        version = get_version(prefix)
+    version = kwargs_version(prefix, kwargs)
     path = prefix_cache_join(prefix, name="synonyms.tsv", version=version)
 
-    @cached_multidict(path=path, header=[f"{prefix}_id", "synonym"], force=force or force_process)
+    @cached_multidict(path=path, header=[f"{prefix}_id", "synonym"], force=force_cache(kwargs))
     def _get_multidict() -> Mapping[str, list[str]]:
         logger.info("[%s v%s] no cached synonyms found. getting from OBO loader", prefix, version)
-        ontology = get_ontology(
-            prefix, force=force, strict=strict, version=version, rewrite=force_process
-        )
+        ontology = get_ontology(prefix, **kwargs)
         return ontology.get_id_synonyms_mapping()
 
     return _get_multidict()

--- a/src/pyobo/api/names.py
+++ b/src/pyobo/api/names.py
@@ -13,7 +13,7 @@ from typing_extensions import Unpack
 
 from .alts import get_primary_identifier
 from .utils import get_version, get_version_from_kwargs
-from ..constants import SlimLookupKwargs, check_should_force
+from ..constants import GetOntologyKwargs, check_should_force
 from ..getters import NoBuildError, get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..utils.cache import cached_collection, cached_mapping, cached_multidict
@@ -50,10 +50,10 @@ NO_BUILD_LOGGED: set = set()
 
 
 def _help_get(
-    f: Callable[[str, Unpack[SlimLookupKwargs]], Mapping[str, X]],
+    f: Callable[[str, Unpack[GetOntologyKwargs]], Mapping[str, X]],
     prefix: str,
     identifier: str,
-    **kwargs: Unpack[SlimLookupKwargs],
+    **kwargs: Unpack[GetOntologyKwargs],
 ) -> X | None:
     """Get the result for an entity based on a mapping maker function ``f``."""
     try:
@@ -84,7 +84,7 @@ def get_name(
     prefix: str | Reference | ReferenceTuple,
     identifier: str | None = None,
     /,
-    **kwargs: Unpack[SlimLookupKwargs],
+    **kwargs: Unpack[GetOntologyKwargs],
 ) -> str | None:
     """Get the name for an entity."""
     if isinstance(prefix, ReferenceTuple | Reference):
@@ -97,7 +97,7 @@ def get_name(
 
 @lru_cache
 @wrap_norm_prefix
-def get_ids(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> set[str]:
+def get_ids(prefix: str, **kwargs: Unpack[GetOntologyKwargs]) -> set[str]:
     """Get the set of identifiers for this prefix."""
     if prefix == "ncbigene":
         from ..sources.ncbigene import get_ncbigene_ids
@@ -122,7 +122,7 @@ def get_ids(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> set[str]:
 @wrap_norm_prefix
 def get_id_name_mapping(
     prefix: str,
-    **kwargs: Unpack[SlimLookupKwargs],
+    **kwargs: Unpack[GetOntologyKwargs],
 ) -> Mapping[str, str]:
     """Get an identifier to name mapping for the OBO file."""
     if prefix == "ncbigene":
@@ -155,7 +155,7 @@ def get_id_name_mapping(
 @wrap_norm_prefix
 def get_name_id_mapping(
     prefix: str,
-    **kwargs: Unpack[SlimLookupKwargs],
+    **kwargs: Unpack[GetOntologyKwargs],
 ) -> Mapping[str, str]:
     """Get a name to identifier mapping for the OBO file."""
     id_name = get_id_name_mapping(prefix, **kwargs)
@@ -164,7 +164,7 @@ def get_name_id_mapping(
 
 @wrap_norm_prefix
 def get_definition(
-    prefix: str, identifier: str | None = None, **kwargs: Unpack[SlimLookupKwargs]
+    prefix: str, identifier: str | None = None, **kwargs: Unpack[GetOntologyKwargs]
 ) -> str | None:
     """Get the definition for an entity."""
     if identifier is None:
@@ -176,7 +176,7 @@ def get_definition(
 
 def get_id_definition_mapping(
     prefix: str,
-    **kwargs: Unpack[SlimLookupKwargs],
+    **kwargs: Unpack[GetOntologyKwargs],
 ) -> Mapping[str, str]:
     """Get a mapping of descriptions."""
     version = get_version_from_kwargs(prefix, kwargs)
@@ -195,7 +195,7 @@ def get_id_definition_mapping(
     return _get_mapping()
 
 
-def get_obsolete(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> set[str]:
+def get_obsolete(prefix: str, **kwargs: Unpack[GetOntologyKwargs]) -> set[str]:
     """Get the set of obsolete local unique identifiers."""
     version = get_version_from_kwargs(prefix, kwargs)
     path = prefix_cache_join(prefix, name="obsolete.tsv", version=version)
@@ -210,7 +210,7 @@ def get_obsolete(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> set[str]:
 
 @wrap_norm_prefix
 def get_synonyms(
-    prefix: str, identifier: str, **kwargs: Unpack[SlimLookupKwargs]
+    prefix: str, identifier: str, **kwargs: Unpack[GetOntologyKwargs]
 ) -> list[str] | None:
     """Get the synonyms for an entity."""
     return _help_get(get_id_synonyms_mapping, prefix=prefix, identifier=identifier, **kwargs)
@@ -218,7 +218,7 @@ def get_synonyms(
 
 @wrap_norm_prefix
 def get_id_synonyms_mapping(
-    prefix: str, **kwargs: Unpack[SlimLookupKwargs]
+    prefix: str, **kwargs: Unpack[GetOntologyKwargs]
 ) -> Mapping[str, list[str]]:
     """Get the OBO file and output a synonym dictionary."""
     version = get_version_from_kwargs(prefix, kwargs)

--- a/src/pyobo/api/names.py
+++ b/src/pyobo/api/names.py
@@ -50,7 +50,7 @@ NO_BUILD_LOGGED: set = set()
 
 
 def _help_get(
-    f: Callable[[str], Mapping[str, X]],
+    f: Callable[[str, Unpack[SlimLookupKwargs]], Mapping[str, X]],
     prefix: str,
     identifier: str,
     **kwargs: Unpack[SlimLookupKwargs],
@@ -90,7 +90,9 @@ def get_name(
     if isinstance(prefix, ReferenceTuple | Reference):
         identifier = prefix.identifier
         prefix = prefix.prefix
-    return _help_get(get_id_name_mapping, prefix, identifier, **kwargs)
+    if identifier is None:
+        raise ValueError("identifier is None")
+    return _help_get(get_id_name_mapping, prefix=prefix, identifier=identifier, **kwargs)
 
 
 @lru_cache
@@ -167,7 +169,9 @@ def get_definition(
     """Get the definition for an entity."""
     if identifier is None:
         prefix, _, identifier = prefix.rpartition(":")
-    return _help_get(get_id_definition_mapping, prefix, identifier, **kwargs)
+    if identifier is None:
+        raise ValueError
+    return _help_get(get_id_definition_mapping, prefix=prefix, identifier=identifier, **kwargs)
 
 
 def get_id_definition_mapping(
@@ -207,7 +211,7 @@ def get_synonyms(
     prefix: str, identifier: str, **kwargs: Unpack[SlimLookupKwargs]
 ) -> list[str] | None:
     """Get the synonyms for an entity."""
-    return _help_get(get_id_synonyms_mapping, prefix, identifier, **kwargs)
+    return _help_get(get_id_synonyms_mapping, prefix=prefix, identifier=identifier, **kwargs)
 
 
 @wrap_norm_prefix

--- a/src/pyobo/api/properties.py
+++ b/src/pyobo/api/properties.py
@@ -6,8 +6,8 @@ from collections.abc import Mapping
 import pandas as pd
 from typing_extensions import Unpack
 
-from .utils import force_cache, kwargs_version
-from ..constants import SlimLookupKwargs
+from .utils import get_version_from_kwargs
+from ..constants import SlimLookupKwargs, check_should_force
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..utils.cache import cached_df, cached_mapping, cached_multidict
@@ -34,10 +34,10 @@ def get_properties_df(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> pd.Dat
     :param force: should the resource be re-downloaded, re-parsed, and re-cached?
     :returns: A dataframe with the properties
     """
-    version = kwargs_version(prefix, kwargs)
+    version = get_version_from_kwargs(prefix, kwargs)
     path = prefix_cache_join(prefix, name="properties.tsv", version=version)
 
-    @cached_df(path=path, dtype=str, force=force_cache(kwargs))
+    @cached_df(path=path, dtype=str, force=check_should_force(kwargs))
     def _df_getter() -> pd.DataFrame:
         ontology = get_ontology(prefix, **kwargs)
         df = ontology.get_properties_df()
@@ -63,7 +63,7 @@ def get_filtered_properties_mapping(
     # df = df[df["property"] == prop]
     # return dict(df[[f"{prefix}_id", "value"]].values)
 
-    version = kwargs_version(prefix, kwargs)
+    version = get_version_from_kwargs(prefix, kwargs)
     all_properties_path = prefix_cache_join(prefix, name="properties.tsv", version=version)
     if all_properties_path.is_file():
         logger.info("[%s] loading pre-cached properties", prefix)
@@ -74,7 +74,7 @@ def get_filtered_properties_mapping(
 
     path = prefix_cache_join(prefix, "properties", name=f"{prop}.tsv", version=version)
 
-    @cached_mapping(path=path, header=[f"{prefix}_id", prop], force=force_cache(kwargs))
+    @cached_mapping(path=path, header=[f"{prefix}_id", prop], force=check_should_force(kwargs))
     def _mapping_getter() -> Mapping[str, str]:
         logger.info("[%s] no cached properties found. getting from OBO loader", prefix)
         ontology = get_ontology(prefix, **kwargs)
@@ -95,7 +95,7 @@ def get_filtered_properties_multimapping(
     :param force: should the resource be re-downloaded, re-parsed, and re-cached?
     :returns: A mapping from identifier to property values
     """
-    version = kwargs_version(prefix, kwargs)
+    version = get_version_from_kwargs(prefix, kwargs)
     all_properties_path = prefix_cache_join(prefix, name="properties.tsv", version=version)
     if all_properties_path.is_file():
         logger.info("[%s] loading pre-cached properties", prefix)
@@ -106,7 +106,7 @@ def get_filtered_properties_multimapping(
 
     path = prefix_cache_join(prefix, "properties", name=f"{prop}.tsv", version=version)
 
-    @cached_multidict(path=path, header=[f"{prefix}_id", prop], force=force_cache(kwargs))
+    @cached_multidict(path=path, header=[f"{prefix}_id", prop], force=check_should_force(kwargs))
     def _mapping_getter() -> Mapping[str, list[str]]:
         logger.info("[%s] no cached properties found. getting from OBO loader", prefix)
         ontology = get_ontology(prefix, **kwargs)
@@ -163,7 +163,7 @@ def get_filtered_properties_df(
     :param force: should the resource be re-downloaded, re-parsed, and re-cached?
     :returns: A dataframe from identifier to property value. Columns are [<prefix>_id, value].
     """
-    version = kwargs_version(prefix, kwargs)
+    version = get_version_from_kwargs(prefix, kwargs)
     all_properties_path = prefix_cache_join(prefix, name="properties.tsv", version=version)
     if all_properties_path.is_file():
         logger.info("[%s] loading pre-cached properties", prefix)
@@ -173,7 +173,7 @@ def get_filtered_properties_df(
 
     path = prefix_cache_join(prefix, "properties", name=f"{prop}.tsv", version=version)
 
-    @cached_df(path=path, dtype=str, force=force_cache(kwargs))
+    @cached_df(path=path, dtype=str, force=check_should_force(kwargs))
     def _df_getter() -> pd.DataFrame:
         ontology = get_ontology(prefix, **kwargs)
         return ontology.get_filtered_properties_df(prop, use_tqdm=use_tqdm)

--- a/src/pyobo/api/properties.py
+++ b/src/pyobo/api/properties.py
@@ -1,13 +1,13 @@
 """High-level API for properties."""
 
 import logging
-import os
 from collections.abc import Mapping
-from typing import Any
 
 import pandas as pd
+from typing_extensions import Unpack
 
-from .utils import get_version
+from .utils import force_cache, kwargs_version
+from ..constants import SlimLookupKwargs
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..utils.cache import cached_df, cached_mapping, cached_multidict
@@ -27,26 +27,19 @@ logger = logging.getLogger(__name__)
 
 
 @wrap_norm_prefix
-def get_properties_df(
-    prefix: str, *, force: bool = False, version: str | None = None, force_process: bool = False
-) -> pd.DataFrame:
+def get_properties_df(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> pd.DataFrame:
     """Extract properties.
 
     :param prefix: the resource to load
     :param force: should the resource be re-downloaded, re-parsed, and re-cached?
     :returns: A dataframe with the properties
     """
-    if version is None:
-        version = get_version(prefix)
+    version = kwargs_version(prefix, kwargs)
     path = prefix_cache_join(prefix, name="properties.tsv", version=version)
 
-    @cached_df(path=path, dtype=str, force=force or force_process)
+    @cached_df(path=path, dtype=str, force=force_cache(kwargs))
     def _df_getter() -> pd.DataFrame:
-        if force:
-            logger.info("[%s] forcing reload for properties", prefix)
-        else:
-            logger.info("[%s] no cached properties found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force, version=version, rewrite=force_process)
+        ontology = get_ontology(prefix, **kwargs)
         df = ontology.get_properties_df()
         df.dropna(inplace=True)
         return df
@@ -56,13 +49,7 @@ def get_properties_df(
 
 @wrap_norm_prefix
 def get_filtered_properties_mapping(
-    prefix: str,
-    prop: str,
-    *,
-    use_tqdm: bool = False,
-    force: bool = False,
-    version: str | None = None,
-    force_process: bool = False,
+    prefix: str, prop: str, *, use_tqdm: bool = False, **kwargs: Unpack[SlimLookupKwargs]
 ) -> Mapping[str, str]:
     """Extract a single property for each term as a dictionary.
 
@@ -72,26 +59,25 @@ def get_filtered_properties_mapping(
     :param force: should the resource be re-downloaded, re-parsed, and re-cached?
     :returns: A mapping from identifier to property value
     """
-    df = get_properties_df(prefix=prefix, force=force, version=version)
-    df = df[df["property"] == prop]
-    return dict(df[[f"{prefix}_id", "value"]].values)
+    # df = get_properties_df(prefix=prefix, force=force, version=version)
+    # df = df[df["property"] == prop]
+    # return dict(df[[f"{prefix}_id", "value"]].values)
 
-    if version is None:
-        version = get_version(prefix)
-    path = prefix_cache_join(prefix, "properties", name=f"{prop}.tsv", version=version)
+    version = kwargs_version(prefix, kwargs)
     all_properties_path = prefix_cache_join(prefix, name="properties.tsv", version=version)
+    if all_properties_path.is_file():
+        logger.info("[%s] loading pre-cached properties", prefix)
+        df = pd.read_csv(all_properties_path, sep="\t")
+        logger.info("[%s] filtering pre-cached properties", prefix)
+        df = df.loc[df["property"] == prop, [f"{prefix}_id", "value"]]
+        return dict(df.values)
 
-    @cached_mapping(path=path, header=[f"{prefix}_id", prop], force=force or force_process)
+    path = prefix_cache_join(prefix, "properties", name=f"{prop}.tsv", version=version)
+
+    @cached_mapping(path=path, header=[f"{prefix}_id", prop], force=force_cache(kwargs))
     def _mapping_getter() -> Mapping[str, str]:
-        if os.path.exists(all_properties_path):
-            logger.info("[%s] loading pre-cached properties", prefix)
-            df = pd.read_csv(all_properties_path, sep="\t")
-            logger.info("[%s] filtering pre-cached properties", prefix)
-            df = df.loc[df["property"] == prop, [f"{prefix}_id", "value"]]
-            return dict(df.values)
-
         logger.info("[%s] no cached properties found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force, version=version, rewrite=force_process)
+        ontology = get_ontology(prefix, **kwargs)
         return ontology.get_filtered_properties_mapping(prop, use_tqdm=use_tqdm)
 
     return _mapping_getter()
@@ -99,13 +85,7 @@ def get_filtered_properties_mapping(
 
 @wrap_norm_prefix
 def get_filtered_properties_multimapping(
-    prefix: str,
-    prop: str,
-    *,
-    use_tqdm: bool = False,
-    force: bool = False,
-    version: str | None = None,
-    force_process: bool = False,
+    prefix: str, prop: str, *, use_tqdm: bool = False, **kwargs: Unpack[SlimLookupKwargs]
 ) -> Mapping[str, list[str]]:
     """Extract multiple properties for each term as a dictionary.
 
@@ -115,28 +95,29 @@ def get_filtered_properties_multimapping(
     :param force: should the resource be re-downloaded, re-parsed, and re-cached?
     :returns: A mapping from identifier to property values
     """
-    if version is None:
-        version = get_version(prefix)
-    path = prefix_cache_join(prefix, "properties", name=f"{prop}.tsv", version=version)
+    version = kwargs_version(prefix, kwargs)
     all_properties_path = prefix_cache_join(prefix, name="properties.tsv", version=version)
+    if all_properties_path.is_file():
+        logger.info("[%s] loading pre-cached properties", prefix)
+        df = pd.read_csv(all_properties_path, sep="\t")
+        logger.info("[%s] filtering pre-cached properties", prefix)
+        df = df.loc[df["property"] == prop, [f"{prefix}_id", "value"]]
+        return multidict(df.values)
 
-    @cached_multidict(path=path, header=[f"{prefix}_id", prop], force=force or force_process)
+    path = prefix_cache_join(prefix, "properties", name=f"{prop}.tsv", version=version)
+
+    @cached_multidict(path=path, header=[f"{prefix}_id", prop], force=force_cache(kwargs))
     def _mapping_getter() -> Mapping[str, list[str]]:
-        if os.path.exists(all_properties_path):
-            logger.info("[%s] loading pre-cached properties", prefix)
-            df = pd.read_csv(all_properties_path, sep="\t")
-            logger.info("[%s] filtering pre-cached properties", prefix)
-            df = df.loc[df["property"] == prop, [f"{prefix}_id", "value"]]
-            return multidict(df.values)
-
         logger.info("[%s] no cached properties found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force, version=version, rewrite=force_process)
+        ontology = get_ontology(prefix, **kwargs)
         return ontology.get_filtered_properties_multimapping(prop, use_tqdm=use_tqdm)
 
     return _mapping_getter()
 
 
-def get_property(prefix: str, identifier: str, prop: str, **kwargs: Any) -> str | None:
+def get_property(
+    prefix: str, identifier: str, prop: str, **kwargs: Unpack[SlimLookupKwargs]
+) -> str | None:
     """Extract a single property for the given entity.
 
     :param prefix: the resource to load
@@ -154,7 +135,9 @@ def get_property(prefix: str, identifier: str, prop: str, **kwargs: Any) -> str 
     return filtered_properties_mapping.get(identifier)
 
 
-def get_properties(prefix: str, identifier: str, prop: str, **kwargs: Any) -> list[str] | None:
+def get_properties(
+    prefix: str, identifier: str, prop: str, **kwargs: Unpack[SlimLookupKwargs]
+) -> list[str] | None:
     """Extract a set of properties for the given entity.
 
     :param prefix: the resource to load
@@ -170,13 +153,7 @@ def get_properties(prefix: str, identifier: str, prop: str, **kwargs: Any) -> li
 
 @wrap_norm_prefix
 def get_filtered_properties_df(
-    prefix: str,
-    prop: str,
-    *,
-    use_tqdm: bool = False,
-    force: bool = False,
-    version: str | None = None,
-    force_process: bool = False,
+    prefix: str, prop: str, *, use_tqdm: bool = False, **kwargs: Unpack[SlimLookupKwargs]
 ) -> pd.DataFrame:
     """Extract a single property for each term.
 
@@ -186,24 +163,19 @@ def get_filtered_properties_df(
     :param force: should the resource be re-downloaded, re-parsed, and re-cached?
     :returns: A dataframe from identifier to property value. Columns are [<prefix>_id, value].
     """
-    if version is None:
-        version = get_version(prefix)
-    path = prefix_cache_join(prefix, "properties", name=f"{prop}.tsv", version=version)
+    version = kwargs_version(prefix, kwargs)
     all_properties_path = prefix_cache_join(prefix, name="properties.tsv", version=version)
+    if all_properties_path.is_file():
+        logger.info("[%s] loading pre-cached properties", prefix)
+        df = pd.read_csv(all_properties_path, sep="\t")
+        logger.info("[%s] filtering pre-cached properties", prefix)
+        return df.loc[df["property"] == prop, [f"{prefix}_id", "value"]]
 
-    @cached_df(path=path, dtype=str, force=force or force_process)
+    path = prefix_cache_join(prefix, "properties", name=f"{prop}.tsv", version=version)
+
+    @cached_df(path=path, dtype=str, force=force_cache(kwargs))
     def _df_getter() -> pd.DataFrame:
-        if os.path.exists(all_properties_path):
-            logger.info("[%s] loading pre-cached properties", prefix)
-            df = pd.read_csv(all_properties_path, sep="\t")
-            logger.info("[%s] filtering pre-cached properties", prefix)
-            return df.loc[df["property"] == prop, [f"{prefix}_id", "value"]]
-
-        if force:
-            logger.info("[%s] forcing reload for properties", prefix)
-        else:
-            logger.info("[%s] no cached properties found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force, version=version, rewrite=force_process)
+        ontology = get_ontology(prefix, **kwargs)
         return ontology.get_filtered_properties_df(prop, use_tqdm=use_tqdm)
 
     return _df_getter()

--- a/src/pyobo/api/properties.py
+++ b/src/pyobo/api/properties.py
@@ -7,7 +7,7 @@ import pandas as pd
 from typing_extensions import Unpack
 
 from .utils import get_version_from_kwargs
-from ..constants import SlimLookupKwargs, check_should_force
+from ..constants import GetOntologyKwargs, check_should_force
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..utils.cache import cached_df, cached_mapping, cached_multidict
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 @wrap_norm_prefix
-def get_properties_df(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> pd.DataFrame:
+def get_properties_df(prefix: str, **kwargs: Unpack[GetOntologyKwargs]) -> pd.DataFrame:
     """Extract properties.
 
     :param prefix: the resource to load
@@ -49,7 +49,7 @@ def get_properties_df(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> pd.Dat
 
 @wrap_norm_prefix
 def get_filtered_properties_mapping(
-    prefix: str, prop: str, *, use_tqdm: bool = False, **kwargs: Unpack[SlimLookupKwargs]
+    prefix: str, prop: str, *, use_tqdm: bool = False, **kwargs: Unpack[GetOntologyKwargs]
 ) -> Mapping[str, str]:
     """Extract a single property for each term as a dictionary.
 
@@ -85,7 +85,7 @@ def get_filtered_properties_mapping(
 
 @wrap_norm_prefix
 def get_filtered_properties_multimapping(
-    prefix: str, prop: str, *, use_tqdm: bool = False, **kwargs: Unpack[SlimLookupKwargs]
+    prefix: str, prop: str, *, use_tqdm: bool = False, **kwargs: Unpack[GetOntologyKwargs]
 ) -> Mapping[str, list[str]]:
     """Extract multiple properties for each term as a dictionary.
 
@@ -116,7 +116,7 @@ def get_filtered_properties_multimapping(
 
 
 def get_property(
-    prefix: str, identifier: str, prop: str, **kwargs: Unpack[SlimLookupKwargs]
+    prefix: str, identifier: str, prop: str, **kwargs: Unpack[GetOntologyKwargs]
 ) -> str | None:
     """Extract a single property for the given entity.
 
@@ -136,7 +136,7 @@ def get_property(
 
 
 def get_properties(
-    prefix: str, identifier: str, prop: str, **kwargs: Unpack[SlimLookupKwargs]
+    prefix: str, identifier: str, prop: str, **kwargs: Unpack[GetOntologyKwargs]
 ) -> list[str] | None:
     """Extract a set of properties for the given entity.
 
@@ -153,7 +153,7 @@ def get_properties(
 
 @wrap_norm_prefix
 def get_filtered_properties_df(
-    prefix: str, prop: str, *, use_tqdm: bool = False, **kwargs: Unpack[SlimLookupKwargs]
+    prefix: str, prop: str, *, use_tqdm: bool = False, **kwargs: Unpack[GetOntologyKwargs]
 ) -> pd.DataFrame:
     """Extract a single property for each term.
 

--- a/src/pyobo/api/relations.py
+++ b/src/pyobo/api/relations.py
@@ -8,7 +8,7 @@ import networkx as nx
 import pandas as pd
 from typing_extensions import Unpack
 
-from .utils import force_cache, kwargs_version
+from .utils import get_version_from_kwargs
 from ..constants import (
     RELATION_COLUMNS,
     RELATION_ID,
@@ -18,6 +18,7 @@ from ..constants import (
     TARGET_ID,
     TARGET_PREFIX,
     SlimLookupKwargs,
+    check_should_force,
 )
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
@@ -46,10 +47,10 @@ def get_relations_df(
     prefix: str, *, use_tqdm: bool = False, wide: bool = False, **kwargs: Unpack[SlimLookupKwargs]
 ) -> pd.DataFrame:
     """Get all relations from the OBO."""
-    version = kwargs_version(prefix, kwargs)
+    version = get_version_from_kwargs(prefix, kwargs)
     path = prefix_cache_join(prefix, name="relations.tsv", version=version)
 
-    @cached_df(path=path, dtype=str, force=force_cache(kwargs))
+    @cached_df(path=path, dtype=str, force=check_should_force(kwargs))
     def _df_getter() -> pd.DataFrame:
         ontology = get_ontology(prefix, **kwargs)
         return ontology.get_relations_df(use_tqdm=use_tqdm)
@@ -74,7 +75,7 @@ def get_filtered_relations_df(
 ) -> pd.DataFrame:
     """Get all the given relation."""
     relation = _ensure_ref(relation, ontology_prefix=prefix)
-    version = kwargs_version(prefix, kwargs)
+    version = get_version_from_kwargs(prefix, kwargs)
     all_relations_path = prefix_cache_join(prefix, name="relations.tsv", version=version)
     if all_relations_path.is_file():
         logger.debug("[%] loading all relations from %s", prefix, all_relations_path)
@@ -90,7 +91,7 @@ def get_filtered_relations_df(
         version=version,
     )
 
-    @cached_df(path=path, dtype=str, force=force_cache(kwargs))
+    @cached_df(path=path, dtype=str, force=check_should_force(kwargs))
     def _df_getter() -> pd.DataFrame:
         logger.info("[%s] no cached relations found. getting from OBO loader", prefix)
         ontology = get_ontology(prefix, **kwargs)
@@ -104,7 +105,7 @@ def get_id_multirelations_mapping(
     prefix: str, typedef: TypeDef, *, use_tqdm: bool = False, **kwargs: Unpack[SlimLookupKwargs]
 ) -> Mapping[str, list[Reference]]:
     """Get the OBO file and output a synonym dictionary."""
-    kwargs["version"] = kwargs_version(prefix, kwargs)
+    kwargs["version"] = get_version_from_kwargs(prefix, kwargs)
     ontology = get_ontology(prefix, **kwargs)
     return ontology.get_id_multirelations_mapping(typedef=typedef, use_tqdm=use_tqdm)
 

--- a/src/pyobo/api/relations.py
+++ b/src/pyobo/api/relations.py
@@ -17,7 +17,7 @@ from ..constants import (
     SOURCE_PREFIX,
     TARGET_ID,
     TARGET_PREFIX,
-    SlimLookupKwargs,
+    GetOntologyKwargs,
     check_should_force,
 )
 from ..getters import get_ontology
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 @wrap_norm_prefix
 def get_relations_df(
-    prefix: str, *, use_tqdm: bool = False, wide: bool = False, **kwargs: Unpack[SlimLookupKwargs]
+    prefix: str, *, use_tqdm: bool = False, wide: bool = False, **kwargs: Unpack[GetOntologyKwargs]
 ) -> pd.DataFrame:
     """Get all relations from the OBO."""
     version = get_version_from_kwargs(prefix, kwargs)
@@ -71,7 +71,7 @@ def get_filtered_relations_df(
     relation: ReferenceHint,
     *,
     use_tqdm: bool = False,
-    **kwargs: Unpack[SlimLookupKwargs],
+    **kwargs: Unpack[GetOntologyKwargs],
 ) -> pd.DataFrame:
     """Get all the given relation."""
     relation = _ensure_ref(relation, ontology_prefix=prefix)
@@ -102,7 +102,7 @@ def get_filtered_relations_df(
 
 @wrap_norm_prefix
 def get_id_multirelations_mapping(
-    prefix: str, typedef: TypeDef, *, use_tqdm: bool = False, **kwargs: Unpack[SlimLookupKwargs]
+    prefix: str, typedef: TypeDef, *, use_tqdm: bool = False, **kwargs: Unpack[GetOntologyKwargs]
 ) -> Mapping[str, list[Reference]]:
     """Get the OBO file and output a synonym dictionary."""
     kwargs["version"] = get_version_from_kwargs(prefix, kwargs)
@@ -118,7 +118,7 @@ def get_relation_mapping(
     target_prefix: str,
     *,
     use_tqdm: bool = False,
-    **kwargs: Unpack[SlimLookupKwargs],
+    **kwargs: Unpack[GetOntologyKwargs],
 ) -> Mapping[str, str]:
     """Get relations from identifiers in the source prefix to target prefix with the given relation.
 
@@ -146,7 +146,7 @@ def get_relation(
     target_prefix: str,
     *,
     use_tqdm: bool = False,
-    **kwargs: Unpack[SlimLookupKwargs],
+    **kwargs: Unpack[GetOntologyKwargs],
 ) -> str | None:
     """Get the target identifier corresponding to the given relationship from the source prefix/identifier pair.
 
@@ -172,7 +172,7 @@ def get_relation(
 
 
 def get_graph(
-    prefix: str, use_tqdm: bool = False, wide: bool = False, **kwargs: Unpack[SlimLookupKwargs]
+    prefix: str, use_tqdm: bool = False, wide: bool = False, **kwargs: Unpack[GetOntologyKwargs]
 ) -> nx.DiGraph:
     """Get the relation graph."""
     rv = nx.MultiDiGraph()

--- a/src/pyobo/api/relations.py
+++ b/src/pyobo/api/relations.py
@@ -6,8 +6,9 @@ from functools import lru_cache
 
 import networkx as nx
 import pandas as pd
+from typing_extensions import Unpack
 
-from .utils import get_version
+from .utils import force_cache, kwargs_version
 from ..constants import (
     RELATION_COLUMNS,
     RELATION_ID,
@@ -16,10 +17,12 @@ from ..constants import (
     SOURCE_PREFIX,
     TARGET_ID,
     TARGET_PREFIX,
+    SlimLookupKwargs,
 )
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
-from ..struct import Reference, TypeDef
+from ..struct import TypeDef
+from ..struct.reference import Reference
 from ..struct.struct import ReferenceHint, _ensure_ref
 from ..utils.cache import cached_df
 from ..utils.path import prefix_cache_join
@@ -40,29 +43,15 @@ logger = logging.getLogger(__name__)
 
 @wrap_norm_prefix
 def get_relations_df(
-    prefix: str,
-    *,
-    use_tqdm: bool = False,
-    force: bool = False,
-    wide: bool = False,
-    strict: bool = True,
-    version: str | None = None,
-    force_process: bool = False,
+    prefix: str, *, use_tqdm: bool = False, wide: bool = False, **kwargs: Unpack[SlimLookupKwargs]
 ) -> pd.DataFrame:
     """Get all relations from the OBO."""
-    if version is None:
-        version = get_version(prefix)
+    version = kwargs_version(prefix, kwargs)
     path = prefix_cache_join(prefix, name="relations.tsv", version=version)
 
-    @cached_df(path=path, dtype=str, force=force or force_process)
+    @cached_df(path=path, dtype=str, force=force_cache(kwargs))
     def _df_getter() -> pd.DataFrame:
-        if force:
-            logger.info("[%s] forcing reload for relations", prefix)
-        else:
-            logger.info("[%s] no cached relations found. getting from OBO loader", prefix)
-        ontology = get_ontology(
-            prefix, force=force, version=version, strict=strict, rewrite=force_process
-        )
+        ontology = get_ontology(prefix, **kwargs)
         return ontology.get_relations_df(use_tqdm=use_tqdm)
 
     rv = _df_getter()
@@ -81,16 +70,11 @@ def get_filtered_relations_df(
     relation: ReferenceHint,
     *,
     use_tqdm: bool = False,
-    force: bool = False,
-    version: str | None = None,
-    force_process: bool = False,
-    strict: bool = True,
+    **kwargs: Unpack[SlimLookupKwargs],
 ) -> pd.DataFrame:
     """Get all the given relation."""
     relation = _ensure_ref(relation, ontology_prefix=prefix)
-    if version is None:
-        version = get_version(prefix)
-
+    version = kwargs_version(prefix, kwargs)
     all_relations_path = prefix_cache_join(prefix, name="relations.tsv", version=version)
     if all_relations_path.is_file():
         logger.debug("[%] loading all relations from %s", prefix, all_relations_path)
@@ -106,12 +90,10 @@ def get_filtered_relations_df(
         version=version,
     )
 
-    @cached_df(path=path, dtype=str, force=force or force_process)
+    @cached_df(path=path, dtype=str, force=force_cache(kwargs))
     def _df_getter() -> pd.DataFrame:
         logger.info("[%s] no cached relations found. getting from OBO loader", prefix)
-        ontology = get_ontology(
-            prefix, force=force, version=version, rewrite=force_process, strict=strict
-        )
+        ontology = get_ontology(prefix, **kwargs)
         return ontology.get_filtered_relations_df(relation, use_tqdm=use_tqdm)
 
     return _df_getter()
@@ -119,18 +101,11 @@ def get_filtered_relations_df(
 
 @wrap_norm_prefix
 def get_id_multirelations_mapping(
-    prefix: str,
-    typedef: TypeDef,
-    *,
-    use_tqdm: bool = False,
-    force: bool = False,
-    version: str | None = None,
-    force_process: bool = False,
+    prefix: str, typedef: TypeDef, *, use_tqdm: bool = False, **kwargs: Unpack[SlimLookupKwargs]
 ) -> Mapping[str, list[Reference]]:
     """Get the OBO file and output a synonym dictionary."""
-    if version is None:
-        version = get_version(prefix)
-    ontology = get_ontology(prefix, force=force, version=version, rewrite=force_process)
+    kwargs["version"] = kwargs_version(prefix, kwargs)
+    ontology = get_ontology(prefix, **kwargs)
     return ontology.get_id_multirelations_mapping(typedef=typedef, use_tqdm=use_tqdm)
 
 
@@ -142,9 +117,7 @@ def get_relation_mapping(
     target_prefix: str,
     *,
     use_tqdm: bool = False,
-    force: bool = False,
-    version: str | None = None,
-    force_process: bool = False,
+    **kwargs: Unpack[SlimLookupKwargs],
 ) -> Mapping[str, str]:
     """Get relations from identifiers in the source prefix to target prefix with the given relation.
 
@@ -158,9 +131,7 @@ def get_relation_mapping(
     >>> hgnc_mgi_orthology_mapping = pyobo.get_relation_mapping("hgnc", "ro:HOM0000017", "mgi")
     >>> assert mouse_mapt_mgi_id == hgnc_mgi_orthology_mapping[human_mapt_hgnc_id]
     """
-    if version is None:
-        version = get_version(prefix)
-    ontology = get_ontology(prefix, force=force, version=version, rewrite=force_process)
+    ontology = get_ontology(prefix, **kwargs)
     return ontology.get_relation_mapping(
         relation=relation, target_prefix=target_prefix, use_tqdm=use_tqdm
     )
@@ -174,8 +145,7 @@ def get_relation(
     target_prefix: str,
     *,
     use_tqdm: bool = False,
-    force: bool = False,
-    **kwargs,
+    **kwargs: Unpack[SlimLookupKwargs],
 ) -> str | None:
     """Get the target identifier corresponding to the given relationship from the source prefix/identifier pair.
 
@@ -195,16 +165,17 @@ def get_relation(
         relation=relation,
         target_prefix=target_prefix,
         use_tqdm=use_tqdm,
-        force=force,
         **kwargs,
     )
     return relation_mapping.get(source_identifier)
 
 
-def get_graph(prefix: str, **kwargs) -> nx.DiGraph:
+def get_graph(
+    prefix: str, use_tqdm: bool = False, wide: bool = False, **kwargs: Unpack[SlimLookupKwargs]
+) -> nx.DiGraph:
     """Get the relation graph."""
     rv = nx.MultiDiGraph()
-    df = get_relations_df(prefix=prefix, **kwargs)
+    df = get_relations_df(prefix=prefix, wide=wide, use_tqdm=use_tqdm, **kwargs)
     for source_id, relation_prefix, relation_id, target_ns, target_id in df.values:
         rv.add_edge(
             f"{prefix}:{source_id}",

--- a/src/pyobo/api/species.py
+++ b/src/pyobo/api/species.py
@@ -8,7 +8,7 @@ from typing_extensions import Unpack
 
 from .alts import get_primary_identifier
 from .utils import get_version_from_kwargs
-from ..constants import SlimLookupKwargs, check_should_force
+from ..constants import GetOntologyKwargs, check_should_force
 from ..getters import NoBuildError, get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..utils.cache import cached_mapping
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 @wrap_norm_prefix
-def get_species(prefix: str, identifier: str, **kwargs: Unpack[SlimLookupKwargs]) -> str | None:
+def get_species(prefix: str, identifier: str, **kwargs: Unpack[GetOntologyKwargs]) -> str | None:
     """Get the species."""
     if prefix == "uniprot":
         raise NotImplementedError
@@ -44,7 +44,7 @@ def get_species(prefix: str, identifier: str, **kwargs: Unpack[SlimLookupKwargs]
 
 @lru_cache
 @wrap_norm_prefix
-def get_id_species_mapping(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> Mapping[str, str]:
+def get_id_species_mapping(prefix: str, **kwargs: Unpack[GetOntologyKwargs]) -> Mapping[str, str]:
     """Get an identifier to species mapping."""
     if prefix == "ncbigene":
         from ..sources.ncbigene import get_ncbigene_id_to_species_mapping

--- a/src/pyobo/api/species.py
+++ b/src/pyobo/api/species.py
@@ -7,8 +7,8 @@ from functools import lru_cache
 from typing_extensions import Unpack
 
 from .alts import get_primary_identifier
-from .utils import force_cache, kwargs_version
-from ..constants import SlimLookupKwargs
+from .utils import get_version_from_kwargs
+from ..constants import SlimLookupKwargs, check_should_force
 from ..getters import NoBuildError, get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..utils.cache import cached_mapping
@@ -54,10 +54,10 @@ def get_id_species_mapping(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> M
         logger.info("[%s] done loading species mappings", prefix)
         return rv
 
-    version = kwargs_version(prefix, kwargs)
+    version = get_version_from_kwargs(prefix, kwargs)
     path = prefix_cache_join(prefix, name="species.tsv", version=version)
 
-    @cached_mapping(path=path, header=[f"{prefix}_id", "species"], force=force_cache(kwargs))
+    @cached_mapping(path=path, header=[f"{prefix}_id", "species"], force=check_should_force(kwargs))
     def _get_id_species_mapping() -> Mapping[str, str]:
         logger.info("[%s] no cached species found. getting from OBO loader", prefix)
         ontology = get_ontology(prefix, **kwargs)

--- a/src/pyobo/api/species.py
+++ b/src/pyobo/api/species.py
@@ -4,8 +4,11 @@ import logging
 from collections.abc import Mapping
 from functools import lru_cache
 
+from typing_extensions import Unpack
+
 from .alts import get_primary_identifier
-from .utils import get_version
+from .utils import force_cache, kwargs_version
+from ..constants import SlimLookupKwargs
 from ..getters import NoBuildError, get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..utils.cache import cached_mapping
@@ -20,13 +23,13 @@ logger = logging.getLogger(__name__)
 
 
 @wrap_norm_prefix
-def get_species(prefix: str, identifier: str, *, version: str | None = None) -> str | None:
+def get_species(prefix: str, identifier: str, **kwargs: Unpack[SlimLookupKwargs]) -> str | None:
     """Get the species."""
     if prefix == "uniprot":
         raise NotImplementedError
 
     try:
-        id_species = get_id_species_mapping(prefix, version=version)
+        id_species = get_id_species_mapping(prefix, **kwargs)
     except NoBuildError:
         logger.warning("unable to look up species for prefix %s", prefix)
         return None
@@ -35,19 +38,13 @@ def get_species(prefix: str, identifier: str, *, version: str | None = None) -> 
         logger.warning("no results produced for prefix %s", prefix)
         return None
 
-    primary_id = get_primary_identifier(prefix, identifier, version=version)
+    primary_id = get_primary_identifier(prefix, identifier, **kwargs)
     return id_species.get(primary_id)
 
 
 @lru_cache
 @wrap_norm_prefix
-def get_id_species_mapping(
-    prefix: str,
-    force: bool = False,
-    strict: bool = True,
-    version: str | None = None,
-    force_process: bool = False,
-) -> Mapping[str, str]:
+def get_id_species_mapping(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> Mapping[str, str]:
     """Get an identifier to species mapping."""
     if prefix == "ncbigene":
         from ..sources.ncbigene import get_ncbigene_id_to_species_mapping
@@ -57,16 +54,13 @@ def get_id_species_mapping(
         logger.info("[%s] done loading species mappings", prefix)
         return rv
 
-    if version is None:
-        version = get_version(prefix)
+    version = kwargs_version(prefix, kwargs)
     path = prefix_cache_join(prefix, name="species.tsv", version=version)
 
-    @cached_mapping(path=path, header=[f"{prefix}_id", "species"], force=force or force_process)
+    @cached_mapping(path=path, header=[f"{prefix}_id", "species"], force=force_cache(kwargs))
     def _get_id_species_mapping() -> Mapping[str, str]:
         logger.info("[%s] no cached species found. getting from OBO loader", prefix)
-        ontology = get_ontology(
-            prefix, force=force, strict=strict, version=version, rewrite=force_process
-        )
+        ontology = get_ontology(prefix, **kwargs)
         logger.info("[%s] loading species mappings", prefix)
         return ontology.get_id_species_mapping()
 

--- a/src/pyobo/api/typedefs.py
+++ b/src/pyobo/api/typedefs.py
@@ -7,7 +7,7 @@ import pandas as pd
 from typing_extensions import Unpack
 
 from .utils import get_version_from_kwargs
-from ..constants import SlimLookupKwargs, check_should_force
+from ..constants import GetOntologyKwargs, check_should_force
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..utils.cache import cached_df
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 @lru_cache
 @wrap_norm_prefix
-def get_typedef_df(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> pd.DataFrame:
+def get_typedef_df(prefix: str, **kwargs: Unpack[GetOntologyKwargs]) -> pd.DataFrame:
     """Get an identifier to name mapping for the typedefs in an OBO file."""
     version = get_version_from_kwargs(prefix, kwargs)
     path = prefix_cache_join(prefix, name="typedefs.tsv", version=version)

--- a/src/pyobo/api/typedefs.py
+++ b/src/pyobo/api/typedefs.py
@@ -4,8 +4,10 @@ import logging
 from functools import lru_cache
 
 import pandas as pd
+from typing_extensions import Unpack
 
-from .utils import get_version
+from .utils import force_cache, kwargs_version
+from ..constants import SlimLookupKwargs
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..utils.cache import cached_df
@@ -20,22 +22,15 @@ logger = logging.getLogger(__name__)
 
 @lru_cache
 @wrap_norm_prefix
-def get_typedef_df(
-    prefix: str,
-    *,
-    force: bool = False,
-    version: str | None = None,
-    force_process: bool = False,
-) -> pd.DataFrame:
+def get_typedef_df(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> pd.DataFrame:
     """Get an identifier to name mapping for the typedefs in an OBO file."""
-    if version is None:
-        version = get_version(prefix)
+    version = kwargs_version(prefix, kwargs)
     path = prefix_cache_join(prefix, name="typedefs.tsv", version=version)
 
-    @cached_df(path=path, dtype=str, force=force or force_process)
+    @cached_df(path=path, dtype=str, force=force_cache(kwargs))
     def _df_getter() -> pd.DataFrame:
         logger.debug("[%s] no cached typedefs found. getting from OBO loader", prefix)
-        ontology = get_ontology(prefix, force=force, version=version, rewrite=force_process)
+        ontology = get_ontology(prefix, **kwargs)
         logger.debug("[%s] loading typedef mappings", prefix)
         return ontology.get_typedef_df()
 

--- a/src/pyobo/api/typedefs.py
+++ b/src/pyobo/api/typedefs.py
@@ -6,8 +6,8 @@ from functools import lru_cache
 import pandas as pd
 from typing_extensions import Unpack
 
-from .utils import force_cache, kwargs_version
-from ..constants import SlimLookupKwargs
+from .utils import get_version_from_kwargs
+from ..constants import SlimLookupKwargs, check_should_force
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..utils.cache import cached_df
@@ -24,10 +24,10 @@ logger = logging.getLogger(__name__)
 @wrap_norm_prefix
 def get_typedef_df(prefix: str, **kwargs: Unpack[SlimLookupKwargs]) -> pd.DataFrame:
     """Get an identifier to name mapping for the typedefs in an OBO file."""
-    version = kwargs_version(prefix, kwargs)
+    version = get_version_from_kwargs(prefix, kwargs)
     path = prefix_cache_join(prefix, name="typedefs.tsv", version=version)
 
-    @cached_df(path=path, dtype=str, force=force_cache(kwargs))
+    @cached_df(path=path, dtype=str, force=check_should_force(kwargs))
     def _df_getter() -> pd.DataFrame:
         logger.debug("[%s] no cached typedefs found. getting from OBO loader", prefix)
         ontology = get_ontology(prefix, **kwargs)

--- a/src/pyobo/api/utils.py
+++ b/src/pyobo/api/utils.py
@@ -8,6 +8,7 @@ from typing import Literal, overload
 
 import bioversions
 
+from ..constants import LookupKwargs, SlimLookupKwargs
 from ..utils.path import prefix_directory_join
 
 __all__ = [
@@ -67,6 +68,18 @@ def get_version(prefix: str, *, strict: bool = False) -> str | None:
         raise ValueError
 
     return None
+
+
+def kwargs_version(prefix: str, kwargs: SlimLookupKwargs):
+    version = kwargs.get("version")
+    if version is None:
+        return get_version(prefix)
+    else:
+        return version
+
+
+def force_cache(d: SlimLookupKwargs | LookupKwargs) -> bool:
+    return d.get("force", False) or d.get("force_process", False)
 
 
 def safe_get_version(prefix: str) -> str:

--- a/src/pyobo/api/utils.py
+++ b/src/pyobo/api/utils.py
@@ -8,7 +8,7 @@ from typing import Literal, overload
 
 import bioversions
 
-from ..constants import SlimLookupKwargs
+from ..constants import GetOntologyKwargs
 from ..utils.path import prefix_directory_join
 
 __all__ = [
@@ -70,7 +70,7 @@ def get_version(prefix: str, *, strict: bool = False) -> str | None:
     return None
 
 
-def get_version_from_kwargs(prefix: str, kwargs: SlimLookupKwargs) -> str | None:
+def get_version_from_kwargs(prefix: str, kwargs: GetOntologyKwargs) -> str | None:
     """Get the version for the resource based on generic keyword arguments."""
     if version := kwargs.get("version"):
         return version

--- a/src/pyobo/api/utils.py
+++ b/src/pyobo/api/utils.py
@@ -72,15 +72,15 @@ def get_version(prefix: str, *, strict: bool = False) -> str | None:
 
 def get_version_from_kwargs(prefix: str, kwargs: SlimLookupKwargs) -> str | None:
     """Get the version for the resource based on generic keyword arguments."""
-    version = kwargs.get("version")
-    if not version:
-        return get_version(prefix, strict=False)
-    else:
+    if version := kwargs.get("version"):
         return version
+    # it's okay if none gets returned after getting this far, we at least tried
+    return get_version(prefix, strict=False)
 
 
 def safe_get_version(prefix: str) -> str:
     """Get the version."""
+    # FIXME replace with get_version(prefix, strict=True)
     v = get_version(prefix)
     if v is None:
         raise ValueError

--- a/src/pyobo/api/utils.py
+++ b/src/pyobo/api/utils.py
@@ -8,7 +8,7 @@ from typing import Literal, overload
 
 import bioversions
 
-from ..constants import LookupKwargs, SlimLookupKwargs
+from ..constants import SlimLookupKwargs
 from ..utils.path import prefix_directory_join
 
 __all__ = [
@@ -70,16 +70,13 @@ def get_version(prefix: str, *, strict: bool = False) -> str | None:
     return None
 
 
-def kwargs_version(prefix: str, kwargs: SlimLookupKwargs):
+def get_version_from_kwargs(prefix: str, kwargs: SlimLookupKwargs) -> str | None:
+    """Get the version for the resource based on generic keyword arguments."""
     version = kwargs.get("version")
-    if version is None:
-        return get_version(prefix)
+    if not version:
+        return get_version(prefix, strict=False)
     else:
         return version
-
-
-def force_cache(d: SlimLookupKwargs | LookupKwargs) -> bool:
-    return d.get("force", False) or d.get("force_process", False)
 
 
 def safe_get_version(prefix: str) -> str:

--- a/src/pyobo/api/xrefs.py
+++ b/src/pyobo/api/xrefs.py
@@ -10,7 +10,7 @@ from tqdm.contrib.logging import logging_redirect_tqdm
 from typing_extensions import Unpack
 
 from .utils import get_version_from_kwargs
-from ..constants import TARGET_ID, TARGET_PREFIX, SlimLookupKwargs, check_should_force
+from ..constants import TARGET_ID, TARGET_PREFIX, GetOntologyKwargs, check_should_force
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..struct import Obo, Reference
@@ -35,7 +35,7 @@ def get_xref(
     new_prefix: str,
     *,
     flip: bool = False,
-    **kwargs: Unpack[SlimLookupKwargs],
+    **kwargs: Unpack[GetOntologyKwargs],
 ) -> str | None:
     """Get the xref with the new prefix if a direct path exists."""
     filtered_xrefs = get_filtered_xrefs(prefix, new_prefix, flip=flip, **kwargs)
@@ -50,7 +50,7 @@ def get_filtered_xrefs(
     *,
     flip: bool = False,
     use_tqdm: bool = False,
-    **kwargs: Unpack[SlimLookupKwargs],
+    **kwargs: Unpack[GetOntologyKwargs],
 ) -> Mapping[str, str]:
     """Get xrefs to a given target."""
     version = get_version_from_kwargs(prefix, kwargs)
@@ -82,7 +82,7 @@ get_xrefs = get_filtered_xrefs
 
 @wrap_norm_prefix
 def get_xrefs_df(
-    prefix: str, *, use_tqdm: bool = False, **kwargs: Unpack[SlimLookupKwargs]
+    prefix: str, *, use_tqdm: bool = False, **kwargs: Unpack[GetOntologyKwargs]
 ) -> pd.DataFrame:
     """Get all xrefs."""
     version = get_version_from_kwargs(prefix, kwargs)
@@ -103,7 +103,7 @@ def get_sssom_df(
     predicate_id: str = "oboinowl:hasDbXref",
     justification: str = "sempav:UnspecifiedMatching",
     names: bool = True,
-    **kwargs: Unpack[SlimLookupKwargs],
+    **kwargs: Unpack[GetOntologyKwargs],
 ) -> pd.DataFrame:
     r"""Get xrefs from a source as an SSSOM dataframe.
 

--- a/src/pyobo/cli/database.py
+++ b/src/pyobo/cli/database.py
@@ -171,13 +171,20 @@ def species(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs]) -> 
         update_zenodo(SPECIES_RECORD, paths)
 
 
+def _extend_skip_set(kwargs: DatabaseKwargs, skip_set: set[str]) -> None:
+    ss = kwargs.get("skip_set")
+    if ss is None:
+        kwargs["skip_set"] = skip_set
+    else:
+        ss.update(skip_set)
+
+
 @database_annotate
 def definitions(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs]) -> None:
     """Make the prefix-identifier-definition dump."""
     with logging_redirect_tqdm():
-        it = _iter_definitions(
-            **kwargs, skip_set={"kegg.pathway", "kegg.genes", "kegg.genome", "umls"}
-        )
+        _extend_skip_set(kwargs, {"kegg.pathway", "kegg.genes", "kegg.genome", "umls"})
+        it = _iter_definitions(**kwargs)
         paths = db_output_helper(
             it,
             "definitions",
@@ -193,9 +200,8 @@ def definitions(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs])
 def typedefs(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs]) -> None:
     """Make the typedef prefix-identifier-name dump."""
     with logging_redirect_tqdm():
-        it = _iter_typedefs(
-            **kwargs, skip_set={"ncbigene", "kegg.pathway", "kegg.genes", "kegg.genome"}
-        )
+        _extend_skip_set(kwargs, {"ncbigene", "kegg.pathway", "kegg.genes", "kegg.genome"})
+        it = _iter_typedefs(**kwargs)
         paths = db_output_helper(
             it,
             "typedefs",
@@ -212,7 +218,8 @@ def typedefs(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs]) ->
 def alts(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs]) -> None:
     """Make the prefix-alt-id dump."""
     with logging_redirect_tqdm():
-        it = _iter_alts(**kwargs, skip_set={"kegg.pathway", "kegg.genes", "kegg.genome", "umls"})
+        _extend_skip_set(kwargs, {"kegg.pathway", "kegg.genes", "kegg.genome", "umls"})
+        it = _iter_alts(**kwargs)
         paths = db_output_helper(
             it,
             "alts",
@@ -228,7 +235,8 @@ def alts(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs]) -> Non
 def synonyms(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs]) -> None:
     """Make the prefix-identifier-synonym dump."""
     with logging_redirect_tqdm():
-        it = _iter_synonyms(**kwargs, skip_set={"kegg.pathway", "kegg.genes", "kegg.genome"})
+        _extend_skip_set(kwargs, {"kegg.pathway", "kegg.genes", "kegg.genome"})
+        it = _iter_synonyms(**kwargs)
         paths = db_output_helper(
             it,
             "synonyms",

--- a/src/pyobo/cli/database.py
+++ b/src/pyobo/cli/database.py
@@ -1,6 +1,7 @@
 """CLI for PyOBO Database Generation."""
 
 import logging
+from pathlib import Path
 
 import click
 from more_click import verbose_option
@@ -124,7 +125,7 @@ def build(ctx: click.Context, **kwargs: Unpack[DatabaseKwargs]) -> None:
 
 
 @database_annotate
-def metadata(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
+def metadata(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs]) -> None:
     """Make the prefix-metadata dump."""
     it = _iter_metadata(**kwargs)
     db_output_helper(
@@ -132,13 +133,14 @@ def metadata(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
         "metadata",
         ("prefix", "version", "date", "deprecated"),
         use_gzip=False,
+        directory=directory,
     )
     if zenodo:
         click.secho("No Zenodo record for metadata", fg="red")
 
 
 @database_annotate
-def names(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
+def names(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs]) -> None:
     """Make the prefix-identifier-name dump."""
     it = _iter_names(**kwargs)
     with logging_redirect_tqdm():
@@ -146,6 +148,7 @@ def names(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
             it,
             "names",
             ("prefix", "identifier", "name"),
+            directory=directory,
         )
     if zenodo:
         # see https://zenodo.org/record/4020486
@@ -153,7 +156,7 @@ def names(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
 
 
 @database_annotate
-def species(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
+def species(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs]) -> None:
     """Make the prefix-identifier-species dump."""
     with logging_redirect_tqdm():
         it = _iter_species(**kwargs)
@@ -161,6 +164,7 @@ def species(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
             it,
             "species",
             ("prefix", "identifier", "species"),
+            directory=directory,
         )
     if zenodo:
         # see https://zenodo.org/record/5334738
@@ -168,7 +172,7 @@ def species(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
 
 
 @database_annotate
-def definitions(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
+def definitions(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs]) -> None:
     """Make the prefix-identifier-definition dump."""
     with logging_redirect_tqdm():
         it = _iter_definitions(
@@ -178,6 +182,7 @@ def definitions(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
             it,
             "definitions",
             ("prefix", "identifier", "definition"),
+            directory=directory,
         )
     if zenodo:
         # see https://zenodo.org/record/4637061
@@ -185,7 +190,7 @@ def definitions(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
 
 
 @database_annotate
-def typedefs(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
+def typedefs(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs]) -> None:
     """Make the typedef prefix-identifier-name dump."""
     with logging_redirect_tqdm():
         it = _iter_typedefs(
@@ -196,6 +201,7 @@ def typedefs(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
             "typedefs",
             ("prefix", "typedef_prefix", "identifier", "name"),
             use_gzip=False,
+            directory=directory,
         )
     if zenodo:
         # see https://zenodo.org/record/4644013
@@ -203,7 +209,7 @@ def typedefs(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
 
 
 @database_annotate
-def alts(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
+def alts(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs]) -> None:
     """Make the prefix-alt-id dump."""
     with logging_redirect_tqdm():
         it = _iter_alts(**kwargs, skip_set={"kegg.pathway", "kegg.genes", "kegg.genome", "umls"})
@@ -211,6 +217,7 @@ def alts(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
             it,
             "alts",
             ("prefix", "identifier", "alt"),
+            directory=directory,
         )
     if zenodo:
         # see https://zenodo.org/record/4021476
@@ -218,7 +225,7 @@ def alts(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
 
 
 @database_annotate
-def synonyms(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
+def synonyms(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs]) -> None:
     """Make the prefix-identifier-synonym dump."""
     with logging_redirect_tqdm():
         it = _iter_synonyms(**kwargs, skip_set={"kegg.pathway", "kegg.genes", "kegg.genome"})
@@ -226,6 +233,7 @@ def synonyms(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
             it,
             "synonyms",
             ("prefix", "identifier", "synonym"),
+            directory=directory,
         )
     if zenodo:
         # see https://zenodo.org/record/4021482
@@ -233,7 +241,7 @@ def synonyms(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
 
 
 @database_annotate
-def relations(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
+def relations(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs]) -> None:
     """Make the relation dump."""
     with logging_redirect_tqdm():
         it = _iter_relations(**kwargs)
@@ -249,6 +257,7 @@ def relations(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
                 "target_identifier",
             ),
             summary_detailed=(0, 2, 3),  # second column corresponds to relation type
+            directory=directory,
         )
     if zenodo:
         # see https://zenodo.org/record/4625167
@@ -256,7 +265,7 @@ def relations(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
 
 
 @database_annotate
-def properties(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
+def properties(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs]) -> None:
     """Make the properties dump."""
     with logging_redirect_tqdm():
         it = _iter_properties(**kwargs)
@@ -265,6 +274,7 @@ def properties(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
             "properties",
             ("prefix", "identifier", "property", "value"),
             summary_detailed=(0, 2),  # second column corresponds to property type
+            directory=directory,
         )
     if zenodo:
         # see https://zenodo.org/record/4625172
@@ -272,7 +282,7 @@ def properties(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
 
 
 @database_annotate
-def xrefs(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
+def xrefs(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs]) -> None:
     """Make the prefix-identifier-xref dump."""
     with logging_redirect_tqdm():
         it = _iter_xrefs(**kwargs)
@@ -281,6 +291,7 @@ def xrefs(zenodo: bool, **kwargs: Unpack[DatabaseKwargs]) -> None:
             "xrefs",
             ("prefix", "identifier", "xref_prefix", "xref_identifier", "provenance"),
             summary_detailed=(0, 2),  # second column corresponds to xref prefix
+            directory=directory,
         )
     if zenodo:
         # see https://zenodo.org/record/4021477

--- a/src/pyobo/cli/database.py
+++ b/src/pyobo/cli/database.py
@@ -9,6 +9,18 @@ from tqdm.contrib.logging import logging_redirect_tqdm
 from typing_extensions import Unpack
 from zenodo_client import update_zenodo
 
+from .database_utils import (
+    _iter_alts,
+    _iter_definitions,
+    _iter_metadata,
+    _iter_names,
+    _iter_properties,
+    _iter_relations,
+    _iter_species,
+    _iter_synonyms,
+    _iter_typedefs,
+    _iter_xrefs,
+)
 from .utils import (
     Clickable,
     directory_option,
@@ -30,18 +42,6 @@ from ..constants import (
     DatabaseKwargs,
 )
 from ..getters import db_output_helper
-from ..xrefdb.xrefs_pipeline import (
-    _iter_alts,
-    _iter_definitions,
-    _iter_metadata,
-    _iter_names,
-    _iter_properties,
-    _iter_relations,
-    _iter_species,
-    _iter_synonyms,
-    _iter_typedefs,
-    _iter_xrefs,
-)
 
 __all__ = [
     "main",

--- a/src/pyobo/cli/lookup.py
+++ b/src/pyobo/cli/lookup.py
@@ -7,7 +7,9 @@ from collections.abc import Mapping
 import bioregistry
 import click
 from more_click import verbose_option
-from typing_extensions import TypedDict, Unpack
+from typing_extensions import Unpack
+
+from pyobo.constants import LookupKwargs
 
 from .utils import (
     Clickable,
@@ -66,16 +68,6 @@ def lookup_annotate(f: Clickable) -> Clickable:
 
 
 identifier_option = click.option("-i", "--identifier")
-
-
-class LookupKwargs(TypedDict):
-    """Keyword arguments for database CLI functions."""
-
-    prefix: str
-    strict: bool
-    force: bool
-    force_process: bool
-    version: str | None
 
 
 @lookup_annotate

--- a/src/pyobo/constants.py
+++ b/src/pyobo/constants.py
@@ -105,21 +105,34 @@ PROVENANCE_PREFIXES = {
 class DatabaseKwargs(TypedDict):
     """Keyword arguments for database CLI functions."""
 
-    directory: str
     strict: bool
     force: bool
     force_process: bool
     skip_pyobo: bool
     skip_below: str | None
+    skip_set: set[str] | None
+    use_tqdm: bool
 
 
-class SlimLookupKwargs(TypedDict):
+class SlimmerLookupKwargs(TypedDict):
     """Keyword arguments for database CLI functions."""
 
     strict: bool
     force: bool
     force_process: bool
+
+
+class SlimLookupKwargs(SlimmerLookupKwargs):
+    """Keyword arguments for database CLI functions."""
+
     version: str | None
+
+
+class IterHelperHelperDict(SlimmerLookupKwargs):
+    use_tqdm: bool
+    skip_below: str | None
+    skip_pyobo: bool
+    skip_set: set[str] | None
 
 
 class LookupKwargs(SlimLookupKwargs):

--- a/src/pyobo/constants.py
+++ b/src/pyobo/constants.py
@@ -114,33 +114,57 @@ class DatabaseKwargs(TypedDict):
     use_tqdm: bool
 
 
-class SlimmerLookupKwargs(TypedDict):
-    """Keyword arguments for database CLI functions."""
+class SlimGetOntologyKwargs(TypedDict):
+    """Keyword arguments for database CLI functions.
+
+    These arguments are global during iteration over _all_
+    ontologies, whereas the additional ``version`` is added in the
+    subclass below for specific instances when only a single
+    ontology is requested.
+    """
 
     strict: bool
     force: bool
     force_process: bool
 
 
-def check_should_force(data: SlimmerLookupKwargs) -> bool:
-    """Determine whether caching should be forced based on generic keyword arguments."""
-    return data.get("force", False) or data.get("force_process", False)
+class GetOntologyKwargs(SlimGetOntologyKwargs):
+    """Represents the optional keyword arguments passed to :func:`pyobo.get_ontology`.
 
-
-class SlimLookupKwargs(SlimmerLookupKwargs):
-    """Keyword arguments for database CLI functions."""
+    This dictionary doesn't contain ``prefix`` since this is always explicitly handled.
+    """
 
     version: str | None
 
 
-class IterHelperHelperDict(SlimmerLookupKwargs):
+def check_should_force(data: GetOntologyKwargs) -> bool:
+    """Determine whether caching should be forced based on generic keyword arguments."""
+    # note that this could be applied to the superclass of GetOntologyKwargs
+    # but this function should only be used in the scope where GetOntologyKwargs
+    # is appropriate.
+    return data.get("force", False) or data.get("force_process", False)
+
+
+class LookupKwargs(GetOntologyKwargs):
+    """Represents all arguments passed to :func:`pyobo.get_ontology`.
+
+    This dictionary does contain the ``prefix`` since it's used in the scope
+    of CLI functions.
+    """
+
+    prefix: str
+
+
+class IterHelperHelperDict(SlimGetOntologyKwargs):
+    """Represents arguments needed when iterating over all ontologies.
+
+    The explicitly defind arguments in this typed dict are used for
+    the loop function :func:`iter_helper_helper` and the rest that
+    are inherited get passed to :func:`pyobo.get_ontology` in each
+    iteration.
+    """
+
     use_tqdm: bool
     skip_below: str | None
     skip_pyobo: bool
     skip_set: set[str] | None
-
-
-class LookupKwargs(SlimLookupKwargs):
-    """Keyword arguments for database CLI functions."""
-
-    prefix: str

--- a/src/pyobo/constants.py
+++ b/src/pyobo/constants.py
@@ -6,6 +6,7 @@ import logging
 import re
 
 import pystow
+from typing_extensions import TypedDict
 
 __all__ = [
     "DATABASE_DIRECTORY",
@@ -99,3 +100,29 @@ PROVENANCE_PREFIXES = {
     "isbn",
     "issn",
 }
+
+
+class DatabaseKwargs(TypedDict):
+    """Keyword arguments for database CLI functions."""
+
+    directory: str
+    strict: bool
+    force: bool
+    force_process: bool
+    skip_pyobo: bool
+    skip_below: str | None
+
+
+class SlimLookupKwargs(TypedDict):
+    """Keyword arguments for database CLI functions."""
+
+    strict: bool
+    force: bool
+    force_process: bool
+    version: str | None
+
+
+class LookupKwargs(SlimLookupKwargs):
+    """Keyword arguments for database CLI functions."""
+
+    prefix: str

--- a/src/pyobo/constants.py
+++ b/src/pyobo/constants.py
@@ -122,6 +122,11 @@ class SlimmerLookupKwargs(TypedDict):
     force_process: bool
 
 
+def check_should_force(data: SlimmerLookupKwargs) -> bool:
+    """Determine whether caching should be forced based on generic keyword arguments."""
+    return data.get("force", False) or data.get("force_process", False)
+
+
 class SlimLookupKwargs(SlimmerLookupKwargs):
     """Keyword arguments for database CLI functions."""
 

--- a/src/pyobo/getters.py
+++ b/src/pyobo/getters.py
@@ -22,7 +22,12 @@ from bioontologies import robot
 from tqdm.auto import tqdm
 from typing_extensions import Unpack
 
-from .constants import DATABASE_DIRECTORY, SlimLookupKwargs
+from .constants import (
+    DATABASE_DIRECTORY,
+    IterHelperHelperDict,
+    SlimLookupKwargs,
+    SlimmerLookupKwargs,
+)
 from .identifier_utils import MissingPrefixError, wrap_norm_prefix
 from .plugins import has_nomenclature_plugin, run_nomenclature_plugin
 from .struct import Obo
@@ -247,7 +252,7 @@ X = TypeVar("X")
 
 
 def iter_helper(
-    f: Callable[[str], Mapping[str, X]],
+    f: Callable[[str, Unpack[SlimLookupKwargs]], Mapping[str, X]],
     leave: bool = False,
     **kwargs: Unpack[IterHelperHelperDict],
 ) -> Iterable[tuple[str, str, X]]:
@@ -299,20 +304,13 @@ def _prefixes(
         yield prefix
 
 
-class IterHelperHelperDict(SlimLookupKwargs):
-    use_tqdm: bool
-    skip_below: str | None
-    skip_pyobo: bool
-    skip_set: set[str]
-
-
 def iter_helper_helper(
-    f: Callable[[str], X],
+    f: Callable[[str, Unpack[SlimLookupKwargs]], X],
     use_tqdm: bool = True,
     skip_below: str | None = None,
     skip_pyobo: bool = False,
     skip_set: set[str] | None = None,
-    **kwargs: Unpack[SlimLookupKwargs],
+    **kwargs: Unpack[SlimmerLookupKwargs],
 ) -> Iterable[tuple[str, X]]:
     """Yield all mappings extracted from each database given.
 

--- a/src/pyobo/getters.py
+++ b/src/pyobo/getters.py
@@ -24,9 +24,9 @@ from typing_extensions import Unpack
 
 from .constants import (
     DATABASE_DIRECTORY,
+    GetOntologyKwargs,
     IterHelperHelperDict,
-    SlimLookupKwargs,
-    SlimmerLookupKwargs,
+    SlimGetOntologyKwargs,
 )
 from .identifier_utils import MissingPrefixError, wrap_norm_prefix
 from .plugins import has_nomenclature_plugin, run_nomenclature_plugin
@@ -252,7 +252,7 @@ X = TypeVar("X")
 
 
 def iter_helper(
-    f: Callable[[str, Unpack[SlimLookupKwargs]], Mapping[str, X]],
+    f: Callable[[str, Unpack[GetOntologyKwargs]], Mapping[str, X]],
     leave: bool = False,
     **kwargs: Unpack[IterHelperHelperDict],
 ) -> Iterable[tuple[str, str, X]]:
@@ -305,12 +305,12 @@ def _prefixes(
 
 
 def iter_helper_helper(
-    f: Callable[[str, Unpack[SlimLookupKwargs]], X],
+    f: Callable[[str, Unpack[GetOntologyKwargs]], X],
     use_tqdm: bool = True,
     skip_below: str | None = None,
     skip_pyobo: bool = False,
     skip_set: set[str] | None = None,
-    **kwargs: Unpack[SlimmerLookupKwargs],
+    **kwargs: Unpack[SlimGetOntologyKwargs],
 ) -> Iterable[tuple[str, X]]:
     """Yield all mappings extracted from each database given.
 

--- a/src/pyobo/getters.py
+++ b/src/pyobo/getters.py
@@ -20,8 +20,9 @@ import click
 import pystow.utils
 from bioontologies import robot
 from tqdm.auto import tqdm
+from typing_extensions import Unpack
 
-from .constants import DATABASE_DIRECTORY
+from .constants import DATABASE_DIRECTORY, SlimLookupKwargs
 from .identifier_utils import MissingPrefixError, wrap_norm_prefix
 from .plugins import has_nomenclature_plugin, run_nomenclature_plugin
 from .struct import Obo
@@ -55,7 +56,7 @@ def get_ontology(
     prefix: str,
     *,
     force: bool = False,
-    rewrite: bool = False,
+    force_process: bool = False,
     strict: bool = True,
     version: str | None = None,
     robot_check: bool = True,
@@ -65,7 +66,7 @@ def get_ontology(
     :param prefix: The prefix of the ontology to look up
     :param version: The pre-looked-up version of the ontology
     :param force: Download the data again
-    :param rewrite: Should the OBO cache be rewritten? Automatically set to true if ``force`` is true
+    :param force_process: Should the OBO cache be rewritten? Automatically set to true if ``force`` is true
     :param strict: Should CURIEs be treated strictly? If true, raises exceptions on invalid/malformed
     :param robot_check:
         If set to false, will send the ``--check=false`` command to ROBOT to disregard
@@ -84,7 +85,7 @@ def get_ontology(
     >>> obo = from_obo_path(path)
     """
     if force:
-        rewrite = True
+        force_process = True
     if prefix == "uberon":
         logger.info("UBERON has so much garbage in it that defaulting to non-strict parsing")
         strict = False
@@ -102,7 +103,7 @@ def get_ontology(
     if has_nomenclature_plugin(prefix):
         obo = run_nomenclature_plugin(prefix, version=version)
         logger.debug("[%s] caching nomenclature plugin", prefix)
-        obo.write_default(force=rewrite)
+        obo.write_default(force=force_process)
         return obo
 
     logger.debug("[%s] no obonet cache found at %s", prefix, obonet_json_gz_path)
@@ -133,7 +134,7 @@ def get_ontology(
                 "[%s] had version %s, overriding with %s", obo.ontology, obo.data_version, version
             )
             obo.data_version = version
-    obo.write_default(force=rewrite)
+    obo.write_default(force=force_process)
     return obo
 
 
@@ -248,11 +249,10 @@ X = TypeVar("X")
 def iter_helper(
     f: Callable[[str], Mapping[str, X]],
     leave: bool = False,
-    strict: bool = True,
-    **kwargs,
+    **kwargs: Unpack[IterHelperHelperDict],
 ) -> Iterable[tuple[str, str, X]]:
     """Yield all mappings extracted from each database given."""
-    for prefix, mapping in iter_helper_helper(f, strict=strict, **kwargs):
+    for prefix, mapping in iter_helper_helper(f, **kwargs):
         it = tqdm(
             mapping.items(),
             desc=f"iterating {prefix}",
@@ -299,14 +299,20 @@ def _prefixes(
         yield prefix
 
 
+class IterHelperHelperDict(SlimLookupKwargs):
+    use_tqdm: bool
+    skip_below: str | None
+    skip_pyobo: bool
+    skip_set: set[str]
+
+
 def iter_helper_helper(
     f: Callable[[str], X],
     use_tqdm: bool = True,
     skip_below: str | None = None,
     skip_pyobo: bool = False,
     skip_set: set[str] | None = None,
-    strict: bool = True,
-    **kwargs,
+    **kwargs: Unpack[SlimLookupKwargs],
 ) -> Iterable[tuple[str, X]]:
     """Yield all mappings extracted from each database given.
 
@@ -324,6 +330,7 @@ def iter_helper_helper(
     :raises urllib.error.URLError: If another problem was encountered during download
     :raises ValueError: If the data was not in the format that was expected (e.g., OWL)
     """
+    strict = kwargs.get("strict", True)
     prefixes = list(
         _prefixes(
             skip_set=skip_set,
@@ -401,7 +408,7 @@ def _prep_dir(directory: None | str | pathlib.Path) -> pathlib.Path:
 
 
 def db_output_helper(
-    f: Callable[..., Iterable[tuple[str, ...]]],
+    it: Iterable[tuple[str, ...]],
     db_name: str,
     columns: Sequence[str],
     *,
@@ -409,7 +416,6 @@ def db_output_helper(
     strict: bool = True,
     use_gzip: bool = True,
     summary_detailed: Sequence[int] | None = None,
-    **kwargs,
 ) -> list[pathlib.Path]:
     """Help output database builds.
 
@@ -418,7 +424,6 @@ def db_output_helper(
     :param columns: The names of the columns
     :param directory: The directory to output everything, or defaults to :data:`pyobo.constants.DATABASE_DIRECTORY`.
     :param strict: Passed to ``f`` by keyword
-    :param kwargs: Passed to ``f`` by splat
     :returns: A sequence of paths that got created.
     """
     directory = _prep_dir(directory)
@@ -436,7 +441,6 @@ def db_output_helper(
 
     logger.info("writing %s to %s", db_name, db_path)
     logger.info("writing %s sample to %s", db_name, db_sample_path)
-    it = f(strict=strict, **kwargs)
     with gzip.open(db_path, mode="wt") if use_gzip else open(db_path, "w") as gzipped_file:
         writer = get_writer(gzipped_file)
 

--- a/src/pyobo/gilda_utils.py
+++ b/src/pyobo/gilda_utils.py
@@ -23,11 +23,10 @@ from pyobo import (
     get_ids,
     get_obsolete,
 )
+from pyobo.api.utils import kwargs_version
+from pyobo.constants import SlimLookupKwargs
 from pyobo.getters import NoBuildError
 from pyobo.utils.io import multidict
-
-from ..api.utils import kwargs_version
-from ..constants import SlimLookupKwargs
 
 __all__ = [
     "get_gilda_terms",
@@ -100,9 +99,9 @@ def get_grounder(
     unnamed: Iterable[str] | None = None,
     grounder_cls: type[Grounder] | None = None,
     versions: None | str | Iterable[str | None] | dict[str, str] = None,
-    strict: bool = True,
     skip_obsolete: bool = False,
     progress: bool = True,
+    **kwargs: Unpack[SlimLookupKwargs],
 ) -> Grounder:
     """Get a Gilda grounder for the given prefix(es)."""
     unnamed = set() if unnamed is None else set(unnamed)
@@ -122,7 +121,7 @@ def get_grounder(
         raise ValueError
 
     terms: list[gilda.term.Term] = []
-    for prefix, version in zip(
+    for prefix, kwargs["version"] in zip(
         tqdm(prefixes, leave=False, disable=not progress), versions, strict=False
     ):
         try:
@@ -130,10 +129,9 @@ def get_grounder(
                 get_gilda_terms(
                     prefix,
                     identifiers_are_names=prefix in unnamed,
-                    version=version,
-                    strict=strict,
                     skip_obsolete=skip_obsolete,
                     progress=progress,
+                    **kwargs,
                 )
             )
         except (NoBuildError, CalledProcessError):
@@ -259,7 +257,9 @@ def get_gilda_terms(
 
 
 def get_gilda_term_subset(
-    source: str, ancestors: str | list[str], **kwargs
+    source: str,
+    ancestors: str | list[str],
+    **kwargs: Unpack[SlimLookupKwargs],
 ) -> Iterable[gilda.term.Term]:
     """Get a subset of terms."""
     subset = {

--- a/src/pyobo/gilda_utils.py
+++ b/src/pyobo/gilda_utils.py
@@ -23,7 +23,7 @@ from pyobo import (
     get_ids,
     get_obsolete,
 )
-from pyobo.api.utils import kwargs_version
+from pyobo.api.utils import get_version_from_kwargs
 from pyobo.constants import SlimLookupKwargs
 from pyobo.getters import NoBuildError
 from pyobo.utils.io import multidict
@@ -180,7 +180,7 @@ def get_gilda_terms(
     **kwargs: Unpack[SlimLookupKwargs],
 ) -> Iterable[gilda.term.Term]:
     """Get gilda terms for the given namespace."""
-    kwargs["version"] = kwargs_version(prefix, kwargs)  # type:ignore
+    kwargs["version"] = get_version_from_kwargs(prefix, kwargs)  # type:ignore
     id_to_name = get_id_name_mapping(prefix, **kwargs)
     id_to_species = get_id_species_mapping(prefix, **kwargs)
     obsoletes = get_obsolete(prefix, **kwargs) if skip_obsolete else set()

--- a/src/pyobo/gilda_utils.py
+++ b/src/pyobo/gilda_utils.py
@@ -13,6 +13,7 @@ from gilda.grounder import Grounder
 from gilda.process import normalize
 from gilda.term import filter_out_duplicates
 from tqdm.auto import tqdm
+from typing_extensions import Unpack
 
 from pyobo import (
     get_descendants,
@@ -24,6 +25,9 @@ from pyobo import (
 )
 from pyobo.getters import NoBuildError
 from pyobo.utils.io import multidict
+
+from ..api.utils import kwargs_version
+from ..constants import SlimLookupKwargs
 
 __all__ = [
     "get_gilda_terms",
@@ -173,15 +177,15 @@ def get_gilda_terms(
     prefix: str,
     *,
     identifiers_are_names: bool = False,
-    version: str | None = None,
-    strict: bool = True,
-    skip_obsolete: bool = False,
     progress: bool = True,
+    skip_obsolete: bool = False,
+    **kwargs: Unpack[SlimLookupKwargs],
 ) -> Iterable[gilda.term.Term]:
     """Get gilda terms for the given namespace."""
-    id_to_name = get_id_name_mapping(prefix, version=version, strict=strict)
-    id_to_species = get_id_species_mapping(prefix, version=version, strict=strict)
-    obsoletes = get_obsolete(prefix, version=version, strict=strict) if skip_obsolete else set()
+    kwargs["version"] = kwargs_version(prefix, kwargs)  # type:ignore
+    id_to_name = get_id_name_mapping(prefix, **kwargs)
+    id_to_species = get_id_species_mapping(prefix, **kwargs)
+    obsoletes = get_obsolete(prefix, **kwargs) if skip_obsolete else set()
 
     it = tqdm(
         id_to_name.items(),
@@ -204,7 +208,7 @@ def get_gilda_terms(
         if term is not None:
             yield term
 
-    id_to_synonyms = get_id_synonyms_mapping(prefix, version=version)
+    id_to_synonyms = get_id_synonyms_mapping(prefix, **kwargs)
     if id_to_synonyms:
         it = tqdm(
             id_to_synonyms.items(),

--- a/src/pyobo/gilda_utils.py
+++ b/src/pyobo/gilda_utils.py
@@ -24,7 +24,7 @@ from pyobo import (
     get_obsolete,
 )
 from pyobo.api.utils import get_version_from_kwargs
-from pyobo.constants import SlimLookupKwargs
+from pyobo.constants import GetOntologyKwargs
 from pyobo.getters import NoBuildError
 from pyobo.utils.io import multidict
 
@@ -101,7 +101,7 @@ def get_grounder(
     versions: None | str | Iterable[str | None] | dict[str, str] = None,
     skip_obsolete: bool = False,
     progress: bool = True,
-    **kwargs: Unpack[SlimLookupKwargs],
+    **kwargs: Unpack[GetOntologyKwargs],
 ) -> Grounder:
     """Get a Gilda grounder for the given prefix(es)."""
     unnamed = set() if unnamed is None else set(unnamed)
@@ -177,7 +177,7 @@ def get_gilda_terms(
     identifiers_are_names: bool = False,
     progress: bool = True,
     skip_obsolete: bool = False,
-    **kwargs: Unpack[SlimLookupKwargs],
+    **kwargs: Unpack[GetOntologyKwargs],
 ) -> Iterable[gilda.term.Term]:
     """Get gilda terms for the given namespace."""
     kwargs["version"] = get_version_from_kwargs(prefix, kwargs)  # type:ignore
@@ -259,7 +259,7 @@ def get_gilda_terms(
 def get_gilda_term_subset(
     source: str,
     ancestors: str | list[str],
-    **kwargs: Unpack[SlimLookupKwargs],
+    **kwargs: Unpack[GetOntologyKwargs],
 ) -> Iterable[gilda.term.Term]:
     """Get a subset of terms."""
     subset = {

--- a/src/pyobo/xrefdb/xrefs_pipeline.py
+++ b/src/pyobo/xrefdb/xrefs_pipeline.py
@@ -102,25 +102,33 @@ def _iter_names(leave: bool = False, **kwargs) -> Iterable[tuple[str, str, str]]
             yield pubchem.PREFIX, identifier, name
 
 
-def _iter_species(leave: bool = False, **kwargs) -> Iterable[tuple[str, str, str]]:
+def _iter_species(
+    leave: bool = False, **kwargs: Unpack[IterHelperHelperDict]
+) -> Iterable[tuple[str, str, str]]:
     """Iterate over all prefix-identifier-species triples we can get."""
     yield from iter_helper(get_id_species_mapping, leave=leave, **kwargs)
     # TODO ncbigene
 
 
-def _iter_definitions(leave: bool = False, **kwargs) -> Iterable[tuple[str, str, str]]:
+def _iter_definitions(
+    leave: bool = False, **kwargs: Unpack[IterHelperHelperDict]
+) -> Iterable[tuple[str, str, str]]:
     """Iterate over all prefix-identifier-descriptions triples we can get."""
     yield from iter_helper(get_id_definition_mapping, leave=leave, **kwargs)
     yield from _iter_ncbigene(1, 8)
 
 
-def _iter_alts(leave: bool = False, **kwargs) -> Iterable[tuple[str, str, str]]:
+def _iter_alts(
+    leave: bool = False, **kwargs: Unpack[IterHelperHelperDict]
+) -> Iterable[tuple[str, str, str]]:
     for prefix, identifier, alts in iter_helper(get_id_to_alts, leave=leave, **kwargs):
         for alt in alts:
             yield prefix, identifier, alt
 
 
-def _iter_synonyms(leave: bool = False, **kwargs) -> Iterable[tuple[str, str, str]]:
+def _iter_synonyms(
+    leave: bool = False, **kwargs: Unpack[IterHelperHelperDict]
+) -> Iterable[tuple[str, str, str]]:
     """Iterate over all prefix-identifier-synonym triples we can get.
 
     :param leave: should the tqdm be left behind?

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from pyobo import Canonicalizer
 from pyobo.constants import XREF_COLUMNS
-from pyobo.xrefdb.xrefs_pipeline import get_graph_from_xref_df
+from pyobo.xrefdb.canonicalizer import get_graph_from_xref_df
 
 
 class TestCanonicalizer(unittest.TestCase):


### PR DESCRIPTION
All of the functions in the API (e.g. for getting names, alternative IDs, descriptions) have the same API where you can pass `force`, `force_process`, `version`, etc.

This PR enforces that these really are standardized by using variadic keyword arguments to pass them around in combination with some clever type annotations. These annotations use a combination of `Unpack` and typed dicts to enforce the functions work the same, without duplicating. It also makes it possible to add additional arguments in bulk later.

This abstraction has the minor drawback that it's a bit less transparent, but this significantly reduces the code complexity.

- [x] initial implementation
- [x] check docs are still applicable
- [x] add docs to new typed dicts and rename them