### PR TITLE
Update typedef handling

### DIFF
--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -473,9 +473,8 @@ class Term(Referenced):
     ) -> Iterable[str]:
         for typedef, references in sorted(self.relationships.items()):
             _typedef_warn(ontology, typedef.reference, typedefs)
-            typedef_preferred_curie = typedef.preferred_curie
             for reference in sorted(references):
-                s = f"relationship: {typedef_preferred_curie} {reference.preferred_curie}"
+                s = f"relationship: {typedef.preferred_curie} {reference.preferred_curie}"
                 if typedef.name or reference.name:
                     s += " !"
                 if typedef.name:

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -137,7 +137,7 @@ class SynonymTypeDef(Referenced):
 
 
 DEFAULT_SYNONYM_TYPE = SynonymTypeDef(
-    reference=Reference(prefix="oboInOwl", identifier="SynonymType", name="synonym type"),
+    reference=Reference(prefix="oboInOwl", identifier="SynonymType", name="Synonym"),
 )
 abbreviation = SynonymTypeDef(
     reference=Reference(prefix="OMO", identifier="0003000", name="abbreviation")

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -935,7 +935,6 @@ class Obo:
                 it=fn(),  # type:ignore
             )
 
-
         typedefs = self._index_typedefs()
         for relation in (is_a, has_part, part_of, from_species, orthologous):
             if relation is not is_a and relation.pair not in typedefs:

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -76,7 +76,9 @@ class TestStruct(unittest.TestCase):
     def test_term(self):
         """Test emitting properties."""
         term = Term(
-            reference=Reference(prefix="GO", identifier="0050069", name="lysine dehydrogenase activity"),
+            reference=Reference(
+                prefix="GO", identifier="0050069", name="lysine dehydrogenase activity"
+            ),
         )
         self.assert_lines(
             """\
@@ -84,14 +86,16 @@ class TestStruct(unittest.TestCase):
             id: GO:0050069
             name: lysine dehydrogenase activity
             """,
-            term.iterate_obo_lines(ontology="GO", typedefs={})
+            term.iterate_obo_lines(ontology="GO", typedefs={}),
         )
 
         term = Term(
-            reference=Reference(prefix="GO", identifier="0050069", name="lysine dehydrogenase activity"),
+            reference=Reference(
+                prefix="GO", identifier="0050069", name="lysine dehydrogenase activity"
+            ),
             properties={
                 "key": ["value"],
-            }
+            },
         )
         self.assert_lines(
             """\
@@ -100,17 +104,17 @@ class TestStruct(unittest.TestCase):
             name: lysine dehydrogenase activity
             property_value: key "value" xsd:string
             """,
-            term.iterate_obo_lines(ontology="GO", typedefs={})
+            term.iterate_obo_lines(ontology="GO", typedefs={}),
         )
 
-        typedef = TypeDef(
-            reference=Reference.from_curie("RO:1234567")
-        )
+        typedef = TypeDef(reference=Reference.from_curie("RO:1234567"))
         term = Term(
-            reference=Reference(prefix="GO", identifier="0050069", name="lysine dehydrogenase activity"),
+            reference=Reference(
+                prefix="GO", identifier="0050069", name="lysine dehydrogenase activity"
+            ),
             relationships={
                 typedef: [Reference.from_curie("EC:1.1.1.1")],
-            }
+            },
         )
         self.assert_lines(
             """\
@@ -119,5 +123,5 @@ class TestStruct(unittest.TestCase):
             name: lysine dehydrogenase activity
             relationship: RO:1234567 eccode:1.1.1.1
             """,
-            term.iterate_obo_lines(ontology="GO", typedefs={typedef.pair: typedef})
+            term.iterate_obo_lines(ontology="GO", typedefs={typedef.pair: typedef}),
         )


### PR DESCRIPTION
1. Reformat the way properties are emitted from a Term object to reduce code
2. Add a reusable way of warning for undefined typedefs