### PR TITLE
Update CURIE parsing utilities

### DIFF
--- a/src/pyobo/cli/lookup.py
+++ b/src/pyobo/cli/lookup.py
@@ -9,8 +9,6 @@ import click
 from more_click import verbose_option
 from typing_extensions import Unpack
 
-from pyobo.constants import LookupKwargs
-
 from .utils import (
     Clickable,
     echo_df,
@@ -40,7 +38,8 @@ from ..api import (
     get_typedef_df,
     get_xrefs_df,
 )
-from ..identifier_utils import normalize_curie
+from ..constants import LookupKwargs
+from ..struct import Reference
 
 __all__ = [
     "lookup",
@@ -196,8 +195,9 @@ def relations(
         else:
             echo_df(relations_df)
     else:
-        curie = normalize_curie(relation)
-        if curie[1] is None:
+        relation_reference = Reference.from_curie(relation, strict=False)
+        if relation_reference is None:
+            click.secho(f"not a valid curie: {relation}", fg="red")
             raise sys.exit(1)
 
         if target is not None:
@@ -205,7 +205,7 @@ def relations(
             if norm_target is None:
                 raise ValueError
             relations_df = get_filtered_relations_df(
-                relation=curie,
+                relation=relation_reference,
                 target=norm_target,
                 **kwargs,
             )

--- a/src/pyobo/identifier_utils.py
+++ b/src/pyobo/identifier_utils.py
@@ -67,7 +67,11 @@ BAD_CURIES = set()
 
 
 def normalize_curie(
-    curie: str, *, strict: bool = True, ontology: str | None = None
+    curie: str,
+    *,
+    strict: bool = True,
+    ontology: str | None = None,
+    reference_node: curies.Reference | None = None,
 ) -> tuple[str, str] | tuple[None, None]:
     """Parse a string that looks like a CURIE.
 
@@ -105,9 +109,13 @@ def normalize_curie(
         identifier = identifier[len(head_ns) + 1 :]
 
     norm_node_prefix = _normalize_prefix(head_ns, curie=curie, strict=strict)
-    if not norm_node_prefix:
+    if norm_node_prefix:
+        return norm_node_prefix, identifier
+    elif strict:
+        raise MissingPrefixError(curie=curie, ontology=ontology)
+    else:
         return None, None
-    return norm_node_prefix, identifier
+
 
 
 def wrap_norm_prefix(f):

--- a/src/pyobo/identifier_utils.py
+++ b/src/pyobo/identifier_utils.py
@@ -28,39 +28,26 @@ logger = logging.getLogger(__name__)
 class MissingPrefixError(ValueError):
     """Raised on a missing prefix."""
 
-    reference: Reference | None
-
     def __init__(
-        self, prefix: str, curie: str, xref: str | None = None, ontology: str | None = None
+        self,
+        *,
+        curie: str,
+        ontology: str | None = None,
+        reference: Reference | None = None,
     ):
         """Initialize the error."""
-        self.prefix = prefix
         self.curie = curie
-        self.xref = xref
         self.ontology = ontology
-        self.reference = None
+        self.reference = reference
 
     def __str__(self) -> str:
         s = ""
         if self.ontology:
             s += f"[{self.ontology}] "
-        s += f"unhandled prefix {self.prefix} found in curie {self.curie}"
-        if self.xref:
-            s += f"/xref {self.xref}"
+        s += f"curie contains unhandled prefix: `{self.curie}`"
         if self.reference is not None:
             s += f" from {self.reference.curie}"
         return s
-
-
-def _normalize_prefix(prefix: str, *, curie=None, xref=None, strict: bool = True) -> str | None:
-    """Normalize a namespace and return, if possible."""
-    norm_prefix = bioregistry.normalize_prefix(prefix)
-    if norm_prefix is not None:
-        return norm_prefix
-    elif strict:
-        raise MissingPrefixError(prefix=prefix, curie=curie, xref=xref)
-    else:
-        return None
 
 
 BAD_CURIES = set()
@@ -71,7 +58,7 @@ def normalize_curie(
     *,
     strict: bool = True,
     ontology: str | None = None,
-    reference_node: curies.Reference | None = None,
+    reference_node: Reference | None = None,
 ) -> tuple[str, str] | tuple[None, None]:
     """Parse a string that looks like a CURIE.
 
@@ -97,7 +84,7 @@ def normalize_curie(
     curie = remap_prefix(curie, ontology_prefix=ontology)
 
     try:
-        head_ns, identifier = curie.split(":", 1)
+        prefix, identifier = curie.split(":", 1)
     except ValueError:  # skip nodes that don't look like normal CURIEs
         if curie not in BAD_CURIES:
             BAD_CURIES.add(curie)
@@ -105,17 +92,16 @@ def normalize_curie(
         return None, None
 
     # remove redundant prefix
-    if identifier.casefold().startswith(f"{head_ns.casefold()}:"):
-        identifier = identifier[len(head_ns) + 1 :]
+    if identifier.casefold().startswith(f"{prefix.casefold()}:"):
+        identifier = identifier[len(prefix) + 1 :]
 
-    norm_node_prefix = _normalize_prefix(head_ns, curie=curie, strict=strict)
+    norm_node_prefix = bioregistry.normalize_prefix(prefix)
     if norm_node_prefix:
         return norm_node_prefix, identifier
     elif strict:
-        raise MissingPrefixError(curie=curie, ontology=ontology)
+        raise MissingPrefixError(curie=curie, ontology=ontology, reference=reference_node)
     else:
         return None, None
-
 
 
 def wrap_norm_prefix(f):

--- a/src/pyobo/reader.py
+++ b/src/pyobo/reader.py
@@ -154,32 +154,18 @@ def from_obonet(graph: nx.MultiDiGraph, *, strict: bool = True) -> Obo:
                 xrefs.append(node_xref)
         n_xrefs += len(xrefs)
 
-        definition, definition_references = get_definition(
-            data,
-            node=reference,
-        )
+        definition, definition_references = get_definition(data, node=reference)
         if definition_references:
             provenance.extend(definition_references)
 
         alt_ids = list(iterate_node_alt_ids(data, strict=strict))
         n_alt_ids += len(alt_ids)
 
-        parents = list(
-            iterate_node_parents(
-                data,
-                node=reference,
-                strict=strict,
-            )
-        )
+        parents = list(iterate_node_parents(data, node=reference, strict=strict))
         n_parents += len(parents)
 
         synonyms = list(
-            iterate_node_synonyms(
-                data,
-                synonym_typedefs,
-                node=reference,
-                strict=strict,
-            )
+            iterate_node_synonyms(data, synonym_typedefs, node=reference, strict=strict)
         )
         n_synonyms += len(synonyms)
 

--- a/src/pyobo/reader.py
+++ b/src/pyobo/reader.py
@@ -16,7 +16,7 @@ from more_itertools import pairwise
 from tqdm.auto import tqdm
 
 from .constants import DATE_FORMAT, PROVENANCE_PREFIXES
-from .identifier_utils import MissingPrefixError, normalize_curie
+from .identifier_utils import normalize_curie
 from .registries import curie_has_blacklisted_prefix, curie_is_blacklisted, remap_prefix
 from .struct import (
     Obo,
@@ -144,11 +144,7 @@ def from_obonet(graph: nx.MultiDiGraph, *, strict: bool = True) -> Obo:
         identifier = bioregistry.standardize_identifier(prefix, identifier)
         reference = references[ReferenceTuple(ontology, identifier)]
 
-        try:
-            node_xrefs = list(iterate_node_xrefs(prefix=prefix, data=data, strict=strict))
-        except MissingPrefixError as e:
-            e.reference = reference
-            raise e
+        node_xrefs = list(iterate_node_xrefs(prefix=prefix, data=data, strict=strict))
         xrefs, provenance = [], []
         for node_xref in node_xrefs:
             if node_xref.prefix in PROVENANCE_PREFIXES:
@@ -163,25 +159,17 @@ def from_obonet(graph: nx.MultiDiGraph, *, strict: bool = True) -> Obo:
         if definition_references:
             provenance.extend(definition_references)
 
-        try:
-            alt_ids = list(iterate_node_alt_ids(data, strict=strict))
-        except MissingPrefixError as e:
-            e.reference = reference
-            raise e
+        alt_ids = list(iterate_node_alt_ids(data, strict=strict))
         n_alt_ids += len(alt_ids)
 
-        try:
-            parents = list(
-                iterate_node_parents(
-                    data,
-                    prefix=prefix,
-                    identifier=identifier,
-                    strict=strict,
-                )
+        parents = list(
+            iterate_node_parents(
+                data,
+                prefix=prefix,
+                identifier=identifier,
+                strict=strict,
             )
-        except MissingPrefixError as e:
-            e.reference = reference
-            raise e
+        )
         n_parents += len(parents)
 
         synonyms = list(
@@ -205,18 +193,14 @@ def from_obonet(graph: nx.MultiDiGraph, *, strict: bool = True) -> Obo:
             alt_ids=alt_ids,
         )
 
-        try:
-            relations_references = list(
-                iterate_node_relationships(
-                    data,
-                    prefix=ontology,
-                    identifier=identifier,
-                    strict=strict,
-                )
+        relations_references = list(
+            iterate_node_relationships(
+                data,
+                prefix=ontology,
+                identifier=identifier,
+                strict=strict,
             )
-        except MissingPrefixError as e:
-            e.reference = reference
-            raise e
+        )
         for relation, reference in relations_references:
             if relation.pair in typedefs:
                 typedef = typedefs[relation.pair]

--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -80,6 +80,7 @@ class Reference(curies.Reference):
         strict: bool = True,
         auto: bool = False,
         ontology_prefix: str | None = None,
+        reference_node: Reference | None = None,
     ) -> Reference | None:
         """Get a reference from a CURIE.
 
@@ -88,7 +89,9 @@ class Reference(curies.Reference):
         :param strict: If true, raises an error if the CURIE can not be parsed.
         :param auto: Automatically look up name
         """
-        prefix, identifier = normalize_curie(curie, strict=strict, ontology=ontology_prefix)
+        prefix, identifier = normalize_curie(
+            curie, strict=strict, ontology=ontology_prefix, reference_node=reference_node
+        )
         return cls._materialize(prefix=prefix, identifier=identifier, name=name, auto=auto)
 
     @classmethod

--- a/src/pyobo/struct/typedef.py
+++ b/src/pyobo/struct/typedef.py
@@ -130,9 +130,13 @@ class TypeDef(Referenced):
         return cls(reference=Reference(prefix=prefix, identifier=identifier, name=name))
 
     @classmethod
-    def from_curie(cls, curie: str, name: str | None = None) -> TypeDef:
+    def from_curie(
+        cls, curie: str, *, name: str | None = None, ontology_prefix: str | None = None
+    ) -> TypeDef:
         """Create a TypeDef directly from a CURIE and optional name."""
-        reference = Reference.from_curie(curie, name=name, strict=True)
+        reference = Reference.from_curie(
+            curie, name=name, strict=True, ontology_prefix=ontology_prefix
+        )
         if reference is None:
             raise RuntimeError
         return cls(reference=reference)

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -35,8 +35,7 @@ class TestParseObonet(unittest.TestCase):
     def test_get_graph_typedefs(self):
         """Test getting type definitions from an :mod:`obonet` graph."""
         pairs = {
-            typedef.pair
-            for typedef in iterate_graph_typedefs(self.graph, ontology_prefix="chebi")
+            typedef.pair for typedef in iterate_graph_typedefs(self.graph, ontology_prefix="chebi")
         }
         self.assertIn(ReferenceTuple("obo", "chebi#has_part"), pairs)
 
@@ -175,7 +174,9 @@ class TestParseObonet(unittest.TestCase):
         }
         data = self.graph.nodes["CHEBI:51990"]
         synonyms = list(
-            iterate_node_synonyms(data, synoynym_typedefs, node=Reference(prefix="chebi", identifier="XXX"))
+            iterate_node_synonyms(
+                data, synoynym_typedefs, node=Reference(prefix="chebi", identifier="XXX")
+            )
         )
         self.assertEqual(1, len(synonyms))
         synonym = synonyms[0]
@@ -226,7 +227,10 @@ class TestParseObonet(unittest.TestCase):
         """Test getting relations from a node in a :mod:`obonet` graph."""
         data = self.graph.nodes["CHEBI:17051"]
         relations = list(
-            iterate_node_relationships(data, node=Reference(prefix="chebi", identifier="XXX"), ontology_prefix="chebi"))
+            iterate_node_relationships(
+                data, node=Reference(prefix="chebi", identifier="XXX"), ontology_prefix="chebi"
+            )
+        )
         self.assertEqual(1, len(relations))
         typedef, target = relations[0]
 
@@ -278,9 +282,8 @@ class TestGet(unittest.TestCase):
 
     def test_iter_filtered_relations(self):
         """Test getting filtered relations w/ upgrade."""
-        all_relations = '\n'.join(
-            ' '.join((s.curie, p.curie, o.curie))
-            for s, p, o in self.ontology.iterate_relations()
+        all_relations = "\n".join(
+            " ".join((s.curie, p.curie, o.curie)) for s, p, o in self.ontology.iterate_relations()
         )
         curie = "obo:chebi#is_conjugate_base_of"
         for inp in [

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -282,9 +282,6 @@ class TestGet(unittest.TestCase):
 
     def test_iter_filtered_relations(self):
         """Test getting filtered relations w/ upgrade."""
-        all_relations = "\n".join(
-            " ".join((s.curie, p.curie, o.curie)) for s, p, o in self.ontology.iterate_relations()
-        )
         curie = "obo:chebi#is_conjugate_base_of"
         for inp in [
             curie,
@@ -297,7 +294,7 @@ class TestGet(unittest.TestCase):
                     (term.reference, target)
                     for term, target in self.ontology.iterate_filtered_relations(inp)
                 )
-                self.assertNotEqual(0, len(rr), msg=f"all relations:\n{all_relations}")
+                self.assertNotEqual(0, len(rr))
                 term = Reference.from_curie("chebi:17051")
                 self.assertIn(term, rr)
                 self.assertIn(Reference.from_curie("chebi:29228"), rr[term])

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -18,7 +18,7 @@ from pyobo.reader import (
     iterate_node_synonyms,
     iterate_node_xrefs,
 )
-from pyobo.struct.struct import acronym
+from pyobo.struct.struct import acronym, default_reference
 from pyobo.utils.io import multidict
 from tests.constants import TEST_CHEBI_OBO_PATH, chebi_patch
 
@@ -35,10 +35,10 @@ class TestParseObonet(unittest.TestCase):
     def test_get_graph_typedefs(self):
         """Test getting type definitions from an :mod:`obonet` graph."""
         pairs = {
-            (typedef.prefix, typedef.identifier)
-            for typedef in iterate_graph_typedefs(self.graph, "chebi")
+            typedef.pair
+            for typedef in iterate_graph_typedefs(self.graph, ontology_prefix="chebi")
         }
-        self.assertIn(("chebi", "has_part"), pairs)
+        self.assertIn(ReferenceTuple("obo", "chebi#has_part"), pairs)
 
     def test_get_graph_synonym_typedefs(self):
         """Test getting synonym type definitions from an :mod:`obonet` graph."""
@@ -86,7 +86,7 @@ class TestParseObonet(unittest.TestCase):
         ]:
             with self.subTest(s=s):
                 actual_text, actual_references = _extract_definition(
-                    s, prefix="chebi", identifier="XXX"
+                    s, node=Reference(prefix="chebi", identifier="XXX")
                 )
                 self.assertEqual(expected_text, actual_text)
                 self.assertEqual(expected_references, actual_references)
@@ -96,7 +96,7 @@ class TestParseObonet(unittest.TestCase):
         expected_text = """The canonical 3' splice site has the sequence "AG"."""
         s = """"The canonical 3' splice site has the sequence \\"AG\\"." [PMID:1234]"""
         actual_text, actual_references = _extract_definition(
-            s, strict=True, prefix="chebi", identifier="XXX"
+            s, strict=True, node=Reference(prefix="chebi", identifier="XXX")
         )
         self.assertEqual(expected_text, actual_text)
         self.assertEqual([Reference(prefix="pubmed", identifier="1234")], actual_references)
@@ -160,7 +160,7 @@ class TestParseObonet(unittest.TestCase):
         ]:
             with self.subTest(s=text):
                 actual_synonym = _extract_synonym(
-                    text, synoynym_typedefs, prefix="chebi", identifier="XXX"
+                    text, synoynym_typedefs, node=Reference(prefix="chebi", identifier="XXX")
                 )
                 self.assertIsInstance(actual_synonym, Synonym)
                 self.assertEqual(expected_synonym, actual_synonym)
@@ -175,7 +175,7 @@ class TestParseObonet(unittest.TestCase):
         }
         data = self.graph.nodes["CHEBI:51990"]
         synonyms = list(
-            iterate_node_synonyms(data, synoynym_typedefs, prefix="chebi", identifier="XXX")
+            iterate_node_synonyms(data, synoynym_typedefs, node=Reference(prefix="chebi", identifier="XXX"))
         )
         self.assertEqual(1, len(synonyms))
         synonym = synonyms[0]
@@ -198,7 +198,7 @@ class TestParseObonet(unittest.TestCase):
     def test_get_node_parents(self):
         """Test getting parents from a node in a :mod:`obonet` graph."""
         data = self.graph.nodes["CHEBI:51990"]
-        parents = list(iterate_node_parents(data, prefix="chebi", identifier="XXX"))
+        parents = list(iterate_node_parents(data, node=Reference(prefix="chebi", identifier="XXX")))
         self.assertEqual(2, len(parents))
         self.assertEqual({"24060", "51992"}, {parent.identifier for parent in parents})
         self.assertEqual({"chebi"}, {parent.prefix for parent in parents})
@@ -225,7 +225,8 @@ class TestParseObonet(unittest.TestCase):
     def test_get_node_relations(self):
         """Test getting relations from a node in a :mod:`obonet` graph."""
         data = self.graph.nodes["CHEBI:17051"]
-        relations = list(iterate_node_relationships(data, prefix="chebi", identifier="XXX"))
+        relations = list(
+            iterate_node_relationships(data, node=Reference(prefix="chebi", identifier="XXX"), ontology_prefix="chebi"))
         self.assertEqual(1, len(relations))
         typedef, target = relations[0]
 
@@ -236,8 +237,8 @@ class TestParseObonet(unittest.TestCase):
 
         self.assertIsNotNone(typedef)
         self.assertIsInstance(typedef, Reference)
-        self.assertEqual("chebi", typedef.prefix)
-        self.assertEqual("is_conjugate_base_of", typedef.identifier)
+        self.assertEqual("obo", typedef.prefix)
+        self.assertEqual("chebi#is_conjugate_base_of", typedef.identifier)
 
 
 class TestGet(unittest.TestCase):
@@ -269,9 +270,19 @@ class TestGet(unittest.TestCase):
         self.assertIn("16042", id_alts_mapping, msg="halide anion alt_id fields not parsed")
         self.assertEqual({"5605", "14384"}, set(id_alts_mapping["16042"]))
 
+    def test_typedefs(self):
+        """Test typedefs."""
+        xx = default_reference("chebi", "is_conjugate_base_of")
+        td = {t.pair for t in self.ontology.typedefs}
+        self.assertIn(xx.pair, td)
+
     def test_iter_filtered_relations(self):
         """Test getting filtered relations w/ upgrade."""
-        curie = "chebi:is_conjugate_base_of"
+        all_relations = '\n'.join(
+            ' '.join((s.curie, p.curie, o.curie))
+            for s, p, o in self.ontology.iterate_relations()
+        )
+        curie = "obo:chebi#is_conjugate_base_of"
         for inp in [
             curie,
             ReferenceTuple.from_curie(curie),
@@ -283,6 +294,7 @@ class TestGet(unittest.TestCase):
                     (term.reference, target)
                     for term, target in self.ontology.iterate_filtered_relations(inp)
                 )
+                self.assertNotEqual(0, len(rr), msg=f"all relations:\n{all_relations}")
                 term = Reference.from_curie("chebi:17051")
                 self.assertIn(term, rr)
                 self.assertIn(Reference.from_curie("chebi:29228"), rr[term])


### PR DESCRIPTION
1. Standardize usage in `lookup.py` to go through `pyobo.Reference.from_curie`
2. Expose extra option through `TypeDef.from_curie` for specifying ontology prefix
3. Refactor construction of missing prefix errors by passing the reference node through
4. Change default typedef handling to be more consistent with OWLAPI