### PR TITLE
Rename variables

### DIFF
--- a/src/pyobo/identifier_utils.py
+++ b/src/pyobo/identifier_utils.py
@@ -32,21 +32,21 @@ class MissingPrefixError(ValueError):
         self,
         *,
         curie: str,
-        ontology: str | None = None,
-        reference: Reference | None = None,
+        ontology_prefix: str | None = None,
+        node: Reference | None = None,
     ):
         """Initialize the error."""
         self.curie = curie
-        self.ontology = ontology
-        self.reference = reference
+        self.ontology_prefix = ontology_prefix
+        self.node = node
 
     def __str__(self) -> str:
         s = ""
-        if self.ontology:
-            s += f"[{self.ontology}] "
-        s += f"curie contains unhandled prefix: `{self.curie}`"
-        if self.reference is not None:
-            s += f" from {self.reference.curie}"
+        if self.ontology_prefix:
+            s += f"[{self.ontology_prefix}] "
+        s += f"CURIE contains unhandled prefix: `{self.curie}`"
+        if self.node is not None:
+            s += f" from {self.node.curie}"
         return s
 
 
@@ -57,14 +57,14 @@ def normalize_curie(
     curie: str,
     *,
     strict: bool = True,
-    ontology: str | None = None,
-    reference_node: Reference | None = None,
+    ontology_prefix: str | None = None,
+    node: Reference | None = None,
 ) -> tuple[str, str] | tuple[None, None]:
     """Parse a string that looks like a CURIE.
 
     :param curie: A compact uniform resource identifier (CURIE)
     :param strict: Should an exception be thrown if the CURIE can not be parsed w.r.t. the Bioregistry?
-    :param ontology: The ontology in which the CURIE appears
+    :param ontology_prefix: The ontology in which the CURIE appears
     :return: A parse tuple or a tuple of None, None if not able to parse and not strict
 
     - Normalizes the namespace
@@ -81,7 +81,7 @@ def normalize_curie(
     curie = remap_full(curie)
 
     # Remap node's prefix (if necessary)
-    curie = remap_prefix(curie, ontology_prefix=ontology)
+    curie = remap_prefix(curie, ontology_prefix=ontology_prefix)
 
     try:
         prefix, identifier = curie.split(":", 1)
@@ -99,7 +99,7 @@ def normalize_curie(
     if norm_node_prefix:
         return norm_node_prefix, identifier
     elif strict:
-        raise MissingPrefixError(curie=curie, ontology=ontology, reference=reference_node)
+        raise MissingPrefixError(curie=curie, ontology_prefix=ontology_prefix, node=node)
     else:
         return None, None
 

--- a/src/pyobo/reader.py
+++ b/src/pyobo/reader.py
@@ -105,11 +105,15 @@ def from_obonet(graph: nx.MultiDiGraph, *, strict: bool = True) -> Obo:
             data_version = date.strftime("%Y-%m-%d")
         else:
             logger.warning(
-                "[%s] UNRECOGNIZED VERSION FORMAT AND MISSING DATE: %s", ontology_prefix, data_version
+                "[%s] UNRECOGNIZED VERSION FORMAT AND MISSING DATE: %s",
+                ontology_prefix,
+                data_version,
             )
 
     if data_version and "/" in data_version:
-        raise ValueError(f"[{ontology_prefix}] will not accept slash in data version: {data_version}")
+        raise ValueError(
+            f"[{ontology_prefix}] will not accept slash in data version: {data_version}"
+        )
 
     #: Parsed CURIEs to references (even external ones)
     reference_it = (
@@ -127,12 +131,15 @@ def from_obonet(graph: nx.MultiDiGraph, *, strict: bool = True) -> Obo:
 
     #: CURIEs to typedefs
     typedefs: Mapping[ReferenceTuple, TypeDef] = {
-        typedef.pair: typedef for typedef in iterate_graph_typedefs(graph, ontology_prefix=ontology_prefix)
+        typedef.pair: typedef
+        for typedef in iterate_graph_typedefs(graph, ontology_prefix=ontology_prefix)
     }
 
     synonym_typedefs: Mapping[str, SynonymTypeDef] = {
         synonym_typedef.curie: synonym_typedef
-        for synonym_typedef in iterate_graph_synonym_typedefs(graph, ontology_prefix=ontology_prefix)
+        for synonym_typedef in iterate_graph_synonym_typedefs(
+            graph, ontology_prefix=ontology_prefix
+        )
     }
 
     missing_typedefs: set[ReferenceTuple] = set()
@@ -258,7 +265,9 @@ def _get_date(graph, ontology_prefix: str) -> datetime | None:
         logger.info("[%s] does not report a date", ontology_prefix)
         return None
     except ValueError:
-        logger.info("[%s] reports a date that can't be parsed: %s", ontology_prefix, graph.graph["date"])
+        logger.info(
+            "[%s] reports a date that can't be parsed: %s", ontology_prefix, graph.graph["date"]
+        )
         return None
     else:
         return rv

--- a/src/pyobo/reader.py
+++ b/src/pyobo/reader.py
@@ -72,14 +72,14 @@ def from_obo_path(
 
 def from_obonet(graph: nx.MultiDiGraph, *, strict: bool = True) -> Obo:
     """Get all of the terms from a OBO graph."""
-    _ontology = graph.graph["ontology"]
-    ontology = bioregistry.normalize_prefix(_ontology)  # probably always okay
-    if ontology is None:
-        raise ValueError(f"unknown prefix: {_ontology}")
-    logger.info("[%s] extracting OBO using obonet", ontology)
+    ontology_prefix_raw = graph.graph["ontology"]
+    ontology_prefix = bioregistry.normalize_prefix(ontology_prefix_raw)  # probably always okay
+    if ontology_prefix is None:
+        raise ValueError(f"unknown prefix: {ontology_prefix_raw}")
+    logger.info("[%s] extracting OBO using obonet", ontology_prefix)
 
-    date = _get_date(graph=graph, ontology=ontology)
-    name = _get_name(graph=graph, ontology=ontology)
+    date = _get_date(graph=graph, ontology_prefix=ontology_prefix)
+    name = _get_name(graph=graph, ontology_prefix=ontology_prefix)
 
     data_version = graph.graph.get("data-version")
     if not data_version:
@@ -87,29 +87,29 @@ def from_obonet(graph: nx.MultiDiGraph, *, strict: bool = True) -> Obo:
             data_version = date.strftime("%Y-%m-%d")
             logger.info(
                 "[%s] does not report a version. falling back to date: %s",
-                ontology,
+                ontology_prefix,
                 data_version,
             )
         else:
-            logger.warning("[%s] does not report a version nor a date", ontology)
+            logger.warning("[%s] does not report a version nor a date", ontology_prefix)
     else:
-        data_version = cleanup_version(data_version=data_version, prefix=ontology)
+        data_version = cleanup_version(data_version=data_version, prefix=ontology_prefix)
         if data_version is not None:
-            logger.info("[%s] using version %s", ontology, data_version)
+            logger.info("[%s] using version %s", ontology_prefix, data_version)
         elif date is not None:
             logger.info(
                 "[%s] unrecognized version format, falling back to date: %s",
-                ontology,
+                ontology_prefix,
                 data_version,
             )
             data_version = date.strftime("%Y-%m-%d")
         else:
             logger.warning(
-                "[%s] UNRECOGNIZED VERSION FORMAT AND MISSING DATE: %s", ontology, data_version
+                "[%s] UNRECOGNIZED VERSION FORMAT AND MISSING DATE: %s", ontology_prefix, data_version
             )
 
     if data_version and "/" in data_version:
-        raise ValueError(f"[{ontology}] will not accept slash in data version: {data_version}")
+        raise ValueError(f"[{ontology_prefix}] will not accept slash in data version: {data_version}")
 
     #: Parsed CURIEs to references (even external ones)
     reference_it = (
@@ -127,23 +127,23 @@ def from_obonet(graph: nx.MultiDiGraph, *, strict: bool = True) -> Obo:
 
     #: CURIEs to typedefs
     typedefs: Mapping[ReferenceTuple, TypeDef] = {
-        typedef.pair: typedef for typedef in iterate_graph_typedefs(graph, ontology_prefix=ontology)
+        typedef.pair: typedef for typedef in iterate_graph_typedefs(graph, ontology_prefix=ontology_prefix)
     }
 
     synonym_typedefs: Mapping[str, SynonymTypeDef] = {
         synonym_typedef.curie: synonym_typedef
-        for synonym_typedef in iterate_graph_synonym_typedefs(graph, ontology=ontology)
+        for synonym_typedef in iterate_graph_synonym_typedefs(graph, ontology_prefix=ontology_prefix)
     }
 
     missing_typedefs: set[ReferenceTuple] = set()
     terms = []
     n_alt_ids, n_parents, n_synonyms, n_relations, n_properties, n_xrefs = 0, 0, 0, 0, 0, 0
     for prefix, identifier, data in _iter_obo_graph(graph=graph, strict=strict):
-        if prefix != ontology or not data:
+        if prefix != ontology_prefix or not data:
             continue
 
         identifier = bioregistry.standardize_identifier(prefix, identifier)
-        reference = references[ReferenceTuple(ontology, identifier)]
+        reference = references[ReferenceTuple(ontology_prefix, identifier)]
 
         node_xrefs = list(iterate_node_xrefs(prefix=prefix, data=data, strict=strict))
         xrefs, provenance = [], []
@@ -184,7 +184,7 @@ def from_obonet(graph: nx.MultiDiGraph, *, strict: bool = True) -> Obo:
                 data,
                 node=reference,
                 strict=strict,
-                ontology_prefix=ontology,
+                ontology_prefix=ontology_prefix,
             )
         )
         for relation, reference in relations_references:
@@ -195,8 +195,8 @@ def from_obonet(graph: nx.MultiDiGraph, *, strict: bool = True) -> Obo:
             else:
                 if relation.pair not in missing_typedefs:
                     missing_typedefs.add(relation.pair)
-                    logger.warning("[%s] has no typedef for %s", ontology, relation)
-                    logger.debug("[%s] available typedefs: %s", ontology, set(typedefs))
+                    logger.warning("[%s] has no typedef for %s", ontology_prefix, relation)
+                    logger.debug("[%s] available typedefs: %s", ontology_prefix, set(typedefs))
                 continue
             n_relations += 1
             term.append_relationship(typedef, reference)
@@ -206,13 +206,13 @@ def from_obonet(graph: nx.MultiDiGraph, *, strict: bool = True) -> Obo:
         terms.append(term)
 
     logger.info(
-        f"[{ontology}] got {len(references):,} references, {len(typedefs):,} typedefs, {len(terms):,} terms,"
+        f"[{ontology_prefix}] got {len(references):,} references, {len(typedefs):,} typedefs, {len(terms):,} terms,"
         f" {n_alt_ids:,} alt ids, {n_parents:,} parents, {n_synonyms:,} synonyms, {n_xrefs:,} xrefs,"
         f" {n_relations:,} relations, and {n_properties:,} properties",
     )
 
     return make_ad_hoc_ontology(
-        _ontology=ontology,
+        _ontology=ontology_prefix,
         _name=name,
         _auto_generated_by=graph.graph.get("auto-generated-by"),
         _format_version=graph.graph.get("format-version"),
@@ -231,7 +231,7 @@ def _clean_graph_ontology(graph, prefix: str) -> None:
         graph.graph["ontology"] = prefix
     elif not graph.graph["ontology"].isalpha():
         logger.warning(
-            "[%s] ontology=%s has a strange format. replacing with prefix",
+            "[%s] ontology prefix `%s` has a strange format. replacing with prefix",
             prefix,
             graph.graph["ontology"],
         )
@@ -251,30 +251,30 @@ def _iter_obo_graph(
         yield prefix, identifier, data
 
 
-def _get_date(graph, ontology: str) -> datetime | None:
+def _get_date(graph, ontology_prefix: str) -> datetime | None:
     try:
         rv = datetime.strptime(graph.graph["date"], DATE_FORMAT)
     except KeyError:
-        logger.info("[%s] does not report a date", ontology)
+        logger.info("[%s] does not report a date", ontology_prefix)
         return None
     except ValueError:
-        logger.info("[%s] reports a date that can't be parsed: %s", ontology, graph.graph["date"])
+        logger.info("[%s] reports a date that can't be parsed: %s", ontology_prefix, graph.graph["date"])
         return None
     else:
         return rv
 
 
-def _get_name(graph, ontology: str) -> str:
+def _get_name(graph, ontology_prefix: str) -> str:
     try:
         rv = graph.graph["name"]
     except KeyError:
-        logger.info("[%s] does not report a name", ontology)
-        rv = ontology
+        logger.info("[%s] does not report a name", ontology_prefix)
+        rv = ontology_prefix
     return rv
 
 
 def iterate_graph_synonym_typedefs(
-    graph: nx.MultiDiGraph, *, ontology: str, strict: bool = False
+    graph: nx.MultiDiGraph, *, ontology_prefix: str, strict: bool = False
 ) -> Iterable[SynonymTypeDef]:
     """Get synonym type definitions from an :mod:`obonet` graph."""
     for s in graph.graph.get("synonymtypedef", []):
@@ -283,7 +283,7 @@ def iterate_graph_synonym_typedefs(
         if sid.startswith("http://") or sid.startswith("https://"):
             reference = Reference.from_iri(sid, name=name)
         elif ":" not in sid:  # assume it's ad-hoc
-            reference = Reference(prefix=ontology, identifier=sid, name=name)
+            reference = Reference(prefix=ontology_prefix, identifier=sid, name=name)
         else:  # assume it's a curie
             reference = Reference.from_curie(sid, name=name, strict=strict)
 
@@ -356,7 +356,7 @@ def _extract_definition(
         logger.warning("[%s] problem with definition: %s", node.curie, s)
         provenance = []
     else:
-        provenance = _parse_trailing_ref_list(rest, strict=strict, reference=node)
+        provenance = _parse_trailing_ref_list(rest, strict=strict, node=node)
     return definition, provenance
 
 
@@ -425,7 +425,7 @@ def _extract_synonym(
         logger.warning("[%s] problem with synonym: %s", node.curie, s)
         return None
 
-    provenance = _parse_trailing_ref_list(rest, strict=strict, reference=node)
+    provenance = _parse_trailing_ref_list(rest, strict=strict, node=node)
     return Synonym(
         name=name,
         specificity=specificity or "EXACT",
@@ -434,10 +434,10 @@ def _extract_synonym(
     )
 
 
-def _parse_trailing_ref_list(rest, *, strict: bool = True, reference: Reference):
+def _parse_trailing_ref_list(rest, *, strict: bool = True, node: Reference):
     rest = rest.lstrip("[").rstrip("]")
     return [
-        Reference.from_curie(curie.strip(), strict=strict, reference_node=reference)
+        Reference.from_curie(curie.strip(), strict=strict, node=node)
         for curie in rest.split(",")
         if curie.strip()
     ]

--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -80,7 +80,7 @@ class Reference(curies.Reference):
         strict: bool = True,
         auto: bool = False,
         ontology_prefix: str | None = None,
-        reference_node: Reference | None = None,
+        node: Reference | None = None,
     ) -> Reference | None:
         """Get a reference from a CURIE.
 
@@ -90,7 +90,7 @@ class Reference(curies.Reference):
         :param auto: Automatically look up name
         """
         prefix, identifier = normalize_curie(
-            curie, strict=strict, ontology=ontology_prefix, reference_node=reference_node
+            curie, strict=strict, ontology_prefix=ontology_prefix, node=node
         )
         return cls._materialize(prefix=prefix, identifier=identifier, name=name, auto=auto)
 

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -438,7 +438,7 @@ class Term(Referenced):
     def iterate_obo_lines(
         self,
         *,
-        ontology: str,
+        ontology_prefix: str,
         typedefs: dict[ReferenceTuple, TypeDef],
         emit_object_properties: bool = True,
         emit_annotation_properties: bool = True,
@@ -467,7 +467,7 @@ class Term(Referenced):
             yield f"{parent_tag}: {parent}"  # __str__ bakes in the ! name
 
         if emit_object_properties:
-            yield from self._emit_relations(ontology, typedefs)
+            yield from self._emit_relations(ontology_prefix, typedefs)
 
         if emit_annotation_properties:
             for line in self._emit_properties(typedefs):
@@ -477,10 +477,10 @@ class Term(Referenced):
             yield synonym.to_obo()
 
     def _emit_relations(
-        self, ontology: str, typedefs: dict[ReferenceTuple, TypeDef]
+        self, ontology_prefix: str, typedefs: dict[ReferenceTuple, TypeDef]
     ) -> Iterable[str]:
         for typedef, references in sorted(self.relationships.items()):
-            _typedef_warn(ontology, typedef.reference, typedefs)
+            _typedef_warn(ontology_prefix, typedef.reference, typedefs)
             for reference in sorted(references):
                 s = f"relationship: {typedef.preferred_curie} {reference.preferred_curie}"
                 if typedef.name or reference.name:

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -773,7 +773,7 @@ class Obo:
         typedefs = self._index_typedefs()
         for term in self:
             yield from term.iterate_obo_lines(
-                ontology=self.ontology,
+                ontology_prefix=self.ontology,
                 typedefs=typedefs,
                 emit_object_properties=emit_object_properties,
                 emit_annotation_properties=emit_annotation_properties,

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -42,7 +42,7 @@ class TestParseObonet(unittest.TestCase):
     def test_get_graph_synonym_typedefs(self):
         """Test getting synonym type definitions from an :mod:`obonet` graph."""
         synonym_typedefs = sorted(
-            iterate_graph_synonym_typedefs(self.graph, ontology=self.ontology),
+            iterate_graph_synonym_typedefs(self.graph, ontology_prefix=self.ontology),
             key=attrgetter("curie"),
         )
         self.assertEqual(

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -86,7 +86,7 @@ class TestStruct(unittest.TestCase):
             id: GO:0050069
             name: lysine dehydrogenase activity
             """,
-            term.iterate_obo_lines(ontology="GO", typedefs={}),
+            term.iterate_obo_lines(ontology_prefix="GO", typedefs={}),
         )
 
         term = Term(
@@ -104,7 +104,7 @@ class TestStruct(unittest.TestCase):
             name: lysine dehydrogenase activity
             property_value: key "value" xsd:string
             """,
-            term.iterate_obo_lines(ontology="GO", typedefs={}),
+            term.iterate_obo_lines(ontology_prefix="GO", typedefs={}),
         )
 
         typedef = TypeDef(reference=Reference.from_curie("RO:1234567"))
@@ -123,5 +123,5 @@ class TestStruct(unittest.TestCase):
             name: lysine dehydrogenase activity
             relationship: RO:1234567 eccode:1.1.1.1
             """,
-            term.iterate_obo_lines(ontology="GO", typedefs={typedef.pair: typedef}),
+            term.iterate_obo_lines(ontology_prefix="GO", typedefs={typedef.pair: typedef}),
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,7 +25,7 @@ class TestStringUtils(unittest.TestCase):
 
         # Test resource-specific remapping
         self.assertEqual((None, None), normalize_curie("Thesaurus:C1234", strict=False))
-        self.assertEqual(("ncit", "C1234"), normalize_curie("Thesaurus:C1234", ontology="enm"))
+        self.assertEqual(("ncit", "C1234"), normalize_curie("Thesaurus:C1234", ontology_prefix="enm"))
 
     def test_parse_eccode_transfer(self):
         """Test parse_eccode_transfer."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,7 +25,9 @@ class TestStringUtils(unittest.TestCase):
 
         # Test resource-specific remapping
         self.assertEqual((None, None), normalize_curie("Thesaurus:C1234", strict=False))
-        self.assertEqual(("ncit", "C1234"), normalize_curie("Thesaurus:C1234", ontology_prefix="enm"))
+        self.assertEqual(
+            ("ncit", "C1234"), normalize_curie("Thesaurus:C1234", ontology_prefix="enm")
+        )
 
     def test_parse_eccode_transfer(self):
         """Test parse_eccode_transfer."""


### PR DESCRIPTION
This standardizes the way "ontology" -> "ontology_prefix" and "reference_node" -> "node" are used to be more consistent and descriptive