### PR TITLE
Breaking: update handling of properties

### DIFF
--- a/src/pyobo/obographs.py
+++ b/src/pyobo/obographs.py
@@ -133,7 +133,7 @@ def _iter_edges(term: Term) -> Iterable[Edge]:
         for target in targets:
             yield Edge.from_parsed(
                 _rewire(term.reference),
-                _rewire(typedef.reference),
+                _rewire(typedef),
                 _rewire(target),
             )
 

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -179,12 +179,16 @@ def _ensure_ref(
 
 
 class ObjectProperty(NamedTuple):
+    """A tuple representing a propert with an object."""
+
     predicate: Reference
     object: Reference
     datatype: None
 
 
 class LiteralProperty(NamedTuple):
+    """A tuple representing a property with a literal value."""
+
     predicate: Reference
     value: str
     datatype: Reference

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -189,8 +189,12 @@ class TestParseObonet(unittest.TestCase):
     def test_get_node_properties(self):
         """Test getting properties from a node in a :mod:`obonet` graph."""
         data = self.graph.nodes["CHEBI:51990"]
-        properties = list(iterate_node_properties(data))
-        t_prop = "http://purl.obolibrary.org/obo/chebi/monoisotopicmass"
+        properties = list(
+            iterate_node_properties(
+                data, node=Reference(prefix="chebi", identifier="51990"), ontology_prefix="chebi"
+            )
+        )
+        t_prop = default_reference("chebi", "monoisotopicmass")
         self.assertIn(t_prop, {prop for prop, value, _ in properties})
         self.assertEqual(1, sum(prop == t_prop for prop, value, _ in properties))
         value = next(value for prop, value, _ in properties if prop == t_prop)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -227,6 +227,15 @@ class TestReader(unittest.TestCase):
         self.assertEqual(1, len(list(term.annotations_literal)))
         self.assertEqual("high", term.get_property(default_reference("chebi", "level")))
 
+        df = ontology.get_properties_df()
+        self.assertEqual(4, len(df.columns))
+        self.assertEqual(1, len(df))
+        row = dict(df.iloc[0])
+        self.assertEqual(
+            {"chebi_id": "1234", "property": "level", "value": "high", "datatype": "xsd:string"},
+            row,
+        )
+
     def test_property_literal_typed(self) -> None:
         """Test parsing a property with a literal object."""
         ontology = _read("""\
@@ -239,6 +248,15 @@ class TestReader(unittest.TestCase):
         term = self.get_only_term(ontology)
         self.assertEqual(1, len(list(term.annotations_literal)))
         self.assertEqual("121.323", term.get_property(default_reference("chebi", "mass")))
+
+        df = ontology.get_properties_df()
+        self.assertEqual(4, len(df.columns))
+        self.assertEqual(1, len(df))
+        row = dict(df.iloc[0])
+        self.assertEqual("1234", row["chebi_id"])
+        self.assertEqual("mass", row["property"])
+        self.assertEqual("121.323", row["value"])
+        self.assertEqual("xsd:decimal", row["datatype"])
 
     def test_property_literal_url_questionable(self) -> None:
         """Test parsing a property with a literal object."""
@@ -253,6 +271,15 @@ class TestReader(unittest.TestCase):
         self.assertEqual(1, len(list(term.annotations_literal)))
         self.assertEqual("121.323", term.get_property(default_reference("chebi", "mass")))
 
+        df = ontology.get_properties_df()
+        self.assertEqual(4, len(df.columns))
+        self.assertEqual(1, len(df))
+        row = dict(df.iloc[0])
+        self.assertEqual("1234", row["chebi_id"])
+        self.assertEqual("mass", row["property"])
+        self.assertEqual("121.323", row["value"])
+        self.assertEqual("xsd:decimal", row["datatype"])
+
     def test_property_literal_url_default(self) -> None:
         """Test parsing a property with a literal object."""
         ontology = _read("""\
@@ -265,6 +292,15 @@ class TestReader(unittest.TestCase):
         term = self.get_only_term(ontology)
         self.assertEqual(1, len(list(term.annotations_literal)))
         self.assertEqual("121.323", term.get_property(default_reference("chebi", "mass")))
+
+        df = ontology.get_properties_df()
+        self.assertEqual(4, len(df.columns))
+        self.assertEqual(1, len(df))
+        row = dict(df.iloc[0])
+        self.assertEqual("1234", row["chebi_id"])
+        self.assertEqual("mass", row["property"])
+        self.assertEqual("121.323", row["value"])
+        self.assertEqual("xsd:decimal", row["datatype"])
 
     def test_property_literal_obo_purl(self) -> None:
         """Test using a full OBO PURL as the property."""
@@ -279,6 +315,15 @@ class TestReader(unittest.TestCase):
         self.assertEqual(0, len(list(term.annotations_literal)))
         self.assertEqual(1, len(list(term.annotations_object)))
         self.assertEqual("CHEBI:5678", term.get_property(is_conjugate_base_of))
+
+        df = ontology.get_properties_df()
+        self.assertEqual(4, len(df.columns))
+        self.assertEqual(1, len(df))
+        row = dict(df.iloc[0])
+        self.assertEqual(
+            {"chebi_id": "1234", "property": "RO:0018033", "value": "CHEBI:5678", "datatype": ""},
+            row,
+        )
 
     def test_property_literal_url(self) -> None:
         """Test using a full OBO PURL as the property."""

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -223,7 +223,7 @@ class TestTerm(unittest.TestCase):
         )
 
         term = Term(LYSINE_DEHYDROGENASE_ACT)
-        term.append_property(
+        term.annotate_object(
             exact_match,
             Reference(prefix="eccode", identifier="1.4.1.15", name="lysine dehydrogenase"),
         )

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 
 from pyobo import Obo, Reference
 from pyobo.constants import NCBITAXON_PREFIX
-from pyobo.struct.struct import BioregistryError, SynonymTypeDef, Term, TypeDef
+from pyobo.struct.struct import BioregistryError, SynonymTypeDef, Term, TypeDef, default_reference
 from pyobo.struct.typedef import exact_match, see_also
 
 LYSINE_DEHYDROGENASE_ACT = Reference(
@@ -107,7 +107,7 @@ class TestTerm(unittest.TestCase):
             [Term]
             id: GO:0050069
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
         )
 
     def test_term_with_name(self) -> None:
@@ -119,7 +119,7 @@ class TestTerm(unittest.TestCase):
             id: GO:0050069
             name: lysine dehydrogenase activity
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
         )
 
     def test_property_literal(self) -> None:
@@ -133,7 +133,7 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             property_value: RO:1234567 "value" xsd:string
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
         )
 
     def test_property_object(self) -> None:
@@ -147,7 +147,7 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             property_value: RO:1234567 hgnc:123
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
         )
 
     def test_relation(self) -> None:
@@ -161,7 +161,7 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             relationship: RO:1234567 eccode:1.4.1.15
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
 
     def test_xref(self) -> None:
@@ -175,7 +175,7 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             xref: eccode:1.4.1.15
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
 
     def test_parent(self) -> None:
@@ -189,7 +189,7 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             is_a: GO:1234568
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
 
     def test_append_exact_match(self) -> None:
@@ -205,7 +205,7 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             property_value: skos:exactMatch eccode:1.4.1.15 ! exact match lysine dehydrogenase
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
 
         term = Term(LYSINE_DEHYDROGENASE_ACT)
@@ -219,7 +219,7 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             property_value: skos:exactMatch eccode:1.4.1.15 ! exact match lysine dehydrogenase
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
 
         term = Term(LYSINE_DEHYDROGENASE_ACT)
@@ -234,7 +234,7 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             property_value: skos:exactMatch eccode:1.4.1.15 ! exact match lysine dehydrogenase
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
 
     def test_set_species(self) -> None:
@@ -248,7 +248,7 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             relationship: RO:0002162 NCBITaxon:9606 ! in taxon Homo sapiens
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
 
         species = term.get_species()
@@ -267,7 +267,7 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             property_value: rdfs:comment "I like this record" xsd:string
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
 
     def test_replaced_by(self) -> None:
@@ -281,7 +281,22 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             property_value: IAO:0100001 GO:1234569 ! term replaced by dummy
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+        )
+
+    def test_property_default_reference(self) -> None:
+        """Test adding a replaced by."""
+        r = default_reference("go", "hey")
+        term = Term(LYSINE_DEHYDROGENASE_ACT)
+        term.annotate_object(r, Reference(prefix="GO", identifier="1234569", name="dummy"))
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            property_value: hey GO:1234569
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
 
     def test_alt(self) -> None:
@@ -295,7 +310,7 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             alt_id: GO:1234569 ! dummy
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
 
         term = Term(LYSINE_DEHYDROGENASE_ACT)
@@ -307,7 +322,7 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             alt_id: GO:1234569
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
 
     def test_append_synonym(self) -> None:
@@ -323,7 +338,7 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             synonym: "L-lysine:NAD+ oxidoreductase" EXACT []
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
 
         term = Term(LYSINE_DEHYDROGENASE_ACT)
@@ -338,7 +353,7 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             synonym: "L-lysine:NAD+ oxidoreductase" RELATED []
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
 
         term = Term(LYSINE_DEHYDROGENASE_ACT)
@@ -352,7 +367,7 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             synonym: "L-lysine:NAD+ oxidoreductase" RELATED [orcid:0000-0003-4423-4370]
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
 
         term = Term(LYSINE_DEHYDROGENASE_ACT)
@@ -369,7 +384,7 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             synonym: "L-lysine:NAD+ oxidoreductase" EXACT OMO:1234567 [orcid:0000-0003-4423-4370]
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
 
     def test_definition(self):
@@ -382,7 +397,7 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             def: "Something" []
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
         )
 
         term = Term(LYSINE_DEHYDROGENASE_ACT, definition="Something")
@@ -394,7 +409,7 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             def: "Something" [orcid:0000-0003-4423-4370]
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
         )
 
     def test_provenance_no_definition(self) -> None:
@@ -407,7 +422,7 @@ class TestTerm(unittest.TestCase):
             id: GO:0050069
             name: lysine dehydrogenase activity
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
         )
 
     def test_obsolete(self) -> None:
@@ -420,7 +435,7 @@ class TestTerm(unittest.TestCase):
             is_obsolete: true
             name: lysine dehydrogenase activity
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
         )
 
         term = Term(LYSINE_DEHYDROGENASE_ACT, is_obsolete=False)
@@ -430,7 +445,7 @@ class TestTerm(unittest.TestCase):
             id: GO:0050069
             name: lysine dehydrogenase activity
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
         )
 
     def test_see_also_single(self) -> None:
@@ -444,7 +459,7 @@ class TestTerm(unittest.TestCase):
             name: lysine dehydrogenase activity
             property_value: rdfs:seeAlso "https://example.org/test" xsd:anyURI
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
         )
 
         self.assertEqual(
@@ -474,7 +489,7 @@ class TestTerm(unittest.TestCase):
             property_value: rdfs:seeAlso hgnc:1234 ! see also dummy 1
             property_value: rdfs:seeAlso hgnc:1235 ! see also dummy 2
             """,
-            term.iterate_obo_lines(ontology_prefix="GO", typedefs={}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
         )
 
         self.assertEqual(


### PR DESCRIPTION
This PR introduces some breaking changes:

1. it fixes many bugs in the handling of properties, so the results will change drastically in some cases
2. splits storage into two new dictionaries - `annotations_literal` and `annotations_object`
3. removes the `Term.append_property` function and replaces it with two new ones for the two different dictionaries
4. Changes the datatypes in several of the iterators
5. Adds datatype handling for annotation properties