### PR TITLE
Make data model more explicit

### DIFF
--- a/src/pyobo/__init__.py
+++ b/src/pyobo/__init__.py
@@ -53,7 +53,7 @@ from .plugins import (
     run_nomenclature_plugin,
 )
 from .reader import from_obo_path, from_obonet
-from .struct import Obo, Reference, Synonym, SynonymTypeDef, Term, TypeDef
+from .struct import Obo, Reference, Synonym, SynonymTypeDef, Term, TypeDef, default_reference
 from .utils.path import ensure_path
 from .version import get_version
 from .xrefdb.canonicalizer import (
@@ -76,6 +76,7 @@ __all__ = [
     "SynonymTypeDef",
     "Term",
     "TypeDef",
+    "default_reference",
     "ensure_path",
     "from_obo_path",
     "from_obonet",

--- a/src/pyobo/sources/cvx.py
+++ b/src/pyobo/sources/cvx.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 
 import pandas as pd
 
-from pyobo import Obo, Reference, Term
+from pyobo import Obo, Reference, Term, TypeDef
 
 __all__ = [
     "CVXGetter",
@@ -13,6 +13,8 @@ __all__ = [
 
 cvx_url = "https://www2a.cdc.gov/vaccines/iis/iisstandards/downloads/cvx.txt"
 PREFIX = "cvx"
+STATUS = TypeDef.default(PREFIX, "status", name="has status")
+NONVACCINE = TypeDef.default(PREFIX, "nonvaccine")
 
 
 class CVXGetter(Obo):
@@ -20,6 +22,7 @@ class CVXGetter(Obo):
 
     ontology = PREFIX
     dynamic_version = True
+    typedefs = [STATUS, NONVACCINE]
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""
@@ -80,9 +83,9 @@ def iter_terms() -> Iterable[Term]:
             if replacement_identifier:
                 term.append_replaced_by(Reference(prefix=PREFIX, identifier=replacement_identifier))
         if pd.notna(status):
-            term.annotate_literal("status", status)
+            term.annotate_literal(STATUS, status)
         if pd.notna(nonvaccine):
-            term.annotate_literal("nonvaccine", nonvaccine)
+            term.annotate_boolean(NONVACCINE, nonvaccine)
         terms[cvx] = term
 
     for child, parents in dd.items():

--- a/src/pyobo/sources/expasy.py
+++ b/src/pyobo/sources/expasy.py
@@ -158,7 +158,9 @@ def get_terms(version: str, force: bool = False) -> Iterable[Term]:
                 ),
             )
         for go_id, go_name in ec2go.get(ec_code, []):
-            term.annotate_object(enables, Reference(prefix="GO", identifier=go_id, name=go_name))
+            term.append_relationship(
+                enables, Reference(prefix="GO", identifier=go_id, name=go_name)
+            )
 
     return terms.values()
 

--- a/src/pyobo/sources/gtdb.py
+++ b/src/pyobo/sources/gtdb.py
@@ -96,7 +96,7 @@ def _process_row(tax_string, ncbitaxon_id) -> Iterable[Term]:
         if ncbitaxon_id and level == "s":
             # if the level is "s", it's a species. There might be multiple
             # mappings to NCBITaxon, so we only use "see also" as the predicate
-            term.append_see_also(Reference(prefix="ncbitaxon", identifier=ncbitaxon_id))
+            term.append_xref(Reference(prefix="ncbitaxon", identifier=ncbitaxon_id))
 
         yield term
         parent_reference = term.reference

--- a/src/pyobo/sources/interpro.py
+++ b/src/pyobo/sources/interpro.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable, Mapping
 
 from .utils import get_go_mapping
 from ..struct import Obo, Reference, Term
-from ..struct.typedef import enables, has_member
+from ..struct.typedef import enables, has_category, has_member
 from ..utils.io import multisetdict
 from ..utils.path import ensure_df, ensure_path
 
@@ -30,7 +30,7 @@ class InterProGetter(Obo):
     """An ontology representation of InterPro."""
 
     ontology = bioversions_key = PREFIX
-    typedefs = [enables, has_member]
+    typedefs = [enables, has_member, has_category]
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over InterPro terms."""
@@ -74,7 +74,7 @@ def iter_terms(*, version: str, proteins: bool = False, force: bool = False) -> 
             term.append_relationship(
                 enables, Reference(prefix="go", identifier=go_id, name=go_name)
             )
-        term.annotate_literal("type", entry_type)
+        term.annotate_literal(has_category, entry_type)
         for uniprot_id in interpro_to_proteins.get(identifier, []):
             term.append_relationship(has_member, Reference(prefix="uniprot", identifier=uniprot_id))
         yield term

--- a/src/pyobo/sources/mgi.py
+++ b/src/pyobo/sources/mgi.py
@@ -35,8 +35,7 @@ ENSEMBL_XREFS_URL = "http://www.informatics.jax.org/downloads/reports/MRK_ENSEMB
 class MGIGetter(Obo):
     """An ontology representation of MGI's mouse gene nomenclature."""
 
-    ontology = PREFIX
-    dynamic_version = True
+    ontology = bioversions_key = PREFIX
     typedefs = [from_species, has_gene_product, transcribes_to, exact_match]
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:

--- a/src/pyobo/sources/msigdb.py
+++ b/src/pyobo/sources/msigdb.py
@@ -126,7 +126,7 @@ def iter_terms(version: str, force: bool = False) -> Iterable[Term]:
 
         for ncbigene_id in attrib["MEMBERS_EZID"].strip().split(","):
             if ncbigene_id:
-                term.append_relationship(
+                term.annotate_object(
                     has_participant, Reference(prefix="ncbigene", identifier=ncbigene_id)
                 )
         yield term

--- a/src/pyobo/sources/rgd.py
+++ b/src/pyobo/sources/rgd.py
@@ -108,7 +108,7 @@ def get_terms(force: bool = False, version: str | None = None) -> Iterable[Term]
         on_bad_lines="skip",
     )
     for _, row in tqdm(
-        df.iterrows(), total=len(df.index), desc=f"Mapping {PREFIX}", unit_scale=True
+        df.head(500).iterrows(), total=len(df.index), desc=f"Mapping {PREFIX}", unit_scale=True
     ):
         if pd.notna(row["NAME"]):
             definition = row["NAME"]
@@ -136,7 +136,7 @@ def get_terms(force: bool = False, version: str | None = None) -> Iterable[Term]
                     if xref_id == "nan":
                         continue
                     if prefix == "uniprot":
-                        term.append_relationship(
+                        term.annotate_object(
                             has_gene_product, Reference(prefix=prefix, identifier=xref_id)
                         )
                     elif prefix == "ensembl":
@@ -144,11 +144,11 @@ def get_terms(force: bool = False, version: str | None = None) -> Iterable[Term]
                             # second one is reverse strand
                             term.append_xref(Reference(prefix=prefix, identifier=xref_id))
                         elif xref_id.startswith("ENSMUST"):
-                            term.append_relationship(
+                            term.annotate_object(
                                 transcribes_to, Reference(prefix=prefix, identifier=xref_id)
                             )
                         elif xref_id.startswith("ENSMUSP"):
-                            term.append_relationship(
+                            term.annotate_object(
                                 has_gene_product, Reference(prefix=prefix, identifier=xref_id)
                             )
                         else:

--- a/src/pyobo/sources/rhea.py
+++ b/src/pyobo/sources/rhea.py
@@ -165,8 +165,8 @@ def iter_terms(version: str, force: bool = False) -> Iterable[Term]:
             right_rhea_id = master_to_left[master_rhea_id]
         else:
             raise ValueError(f"Invalid side: {side_uri}")
-        terms[master_rhea_id].append_relationship(has_participant, chebi_reference)
-        terms[master_to_bi[master_rhea_id]].append_relationship(has_participant, chebi_reference)
+        terms[master_rhea_id].annotations_object(has_participant, chebi_reference)
+        terms[master_to_bi[master_rhea_id]].annotate_object(has_participant, chebi_reference)
         terms[left_rhea_id].append_relationship(has_input, chebi_reference)
         terms[right_rhea_id].append_relationship(has_output, chebi_reference)
 

--- a/src/pyobo/sources/rhea.py
+++ b/src/pyobo/sources/rhea.py
@@ -165,7 +165,7 @@ def iter_terms(version: str, force: bool = False) -> Iterable[Term]:
             right_rhea_id = master_to_left[master_rhea_id]
         else:
             raise ValueError(f"Invalid side: {side_uri}")
-        terms[master_rhea_id].annotations_object(has_participant, chebi_reference)
+        terms[master_rhea_id].annotate_object(has_participant, chebi_reference)
         terms[master_to_bi[master_rhea_id]].annotate_object(has_participant, chebi_reference)
         terms[left_rhea_id].append_relationship(has_input, chebi_reference)
         terms[right_rhea_id].append_relationship(has_output, chebi_reference)

--- a/src/pyobo/sources/slm.py
+++ b/src/pyobo/sources/slm.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 import pandas as pd
 from tqdm.auto import tqdm
 
-from pyobo import Obo, Reference, Term
+from pyobo import Obo, Reference, Term, TypeDef
 from pyobo.struct.struct import abbreviation as abbreviation_typedef
 from pyobo.struct.typedef import exact_match, has_inchi, has_smiles
 from pyobo.utils.path import ensure_df
@@ -36,13 +36,14 @@ COLUMNS = [
     "HMDB",
     "PMID",
 ]
+LEVEL = TypeDef.default(PREFIX, "level")
 
 
 class SLMGetter(Obo):
     """An ontology representation of SwissLipid's lipid nomenclature."""
 
     ontology = bioversions_key = PREFIX
-    typedefs = [exact_match]
+    typedefs = [exact_match, LEVEL, has_inchi, has_smiles]
     synonym_typedefs = [abbreviation_typedef]
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
@@ -90,7 +91,7 @@ def iter_terms(version: str, force: bool = False):
             raise ValueError(identifier)
         term = Term.from_triple(PREFIX, identifier, name)
         if pd.notna(level):
-            term.annotate_literal("level", level)
+            term.annotate_literal(LEVEL, level)
         if pd.notna(abbreviation):
             term.append_synonym(abbreviation, type=abbreviation_typedef)
         if pd.notna(synonyms):

--- a/src/pyobo/sources/uniprot/uniprot.py
+++ b/src/pyobo/sources/uniprot/uniprot.py
@@ -10,7 +10,7 @@ from pyobo import Obo, Reference
 from pyobo.api.utils import get_version
 from pyobo.constants import RAW_MODULE
 from pyobo.identifier_utils import standardize_ec
-from pyobo.struct import Term, derives_from, enables, from_species, participates_in
+from pyobo.struct import Term, TypeDef, derives_from, enables, from_species, participates_in
 from pyobo.struct.typedef import gene_product_of, located_in, molecularly_interacts_with
 from pyobo.utils.io import open_reader
 
@@ -42,6 +42,7 @@ PARAMS = {
     "query": QUERY,
     "fields": FIELDS,
 }
+IS_REVIEWED = TypeDef.default(PREFIX, "reviewed")
 
 
 class UniProtGetter(Obo):
@@ -56,6 +57,7 @@ class UniProtGetter(Obo):
         molecularly_interacts_with,
         derives_from,
         located_in,
+        IS_REVIEWED,
     ]
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
@@ -102,7 +104,7 @@ def iter_terms(version: str | None = None) -> Iterable[Term]:
                         gene_product_of, Reference(prefix="ncbigene", identifier=gene_id.strip())
                     )
 
-            term.annotate_boolean("reviewed", True)
+            term.annotate_boolean(IS_REVIEWED, True)
 
             for go_process_ref in _parse_go(go_processes):
                 term.annotate_object(participates_in, go_process_ref)

--- a/src/pyobo/struct/__init__.py
+++ b/src/pyobo/struct/__init__.py
@@ -1,6 +1,6 @@
 """Data structures for OBO."""
 
-from .reference import Reference, Referenced
+from .reference import Reference, Referenced, default_reference
 from .struct import (
     Obo,
     Synonym,
@@ -8,7 +8,6 @@ from .struct import (
     SynonymSpecificity,
     SynonymTypeDef,
     Term,
-    default_reference,
     int_identifier_sort_key,
     make_ad_hoc_ontology,
 )

--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -212,7 +212,7 @@ def default_reference(prefix: str, part: str, name: str | None = None) -> Refere
     return Reference(prefix="obo", identifier=f"{prefix}#{part}", name=name)
 
 
-def reference_escape(predicate: Reference, *, ontology_prefix: str) -> str:
+def reference_escape(predicate: Reference | Referenced, *, ontology_prefix: str) -> str:
     """Write a reference with default namespace removed."""
     if predicate.prefix == "obo" and predicate.identifier.startswith(f"{ontology_prefix}#"):
         return predicate.identifier.removeprefix(f"{ontology_prefix}#")

--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -17,6 +17,7 @@ from ..identifier_utils import normalize_curie
 __all__ = [
     "Reference",
     "Referenced",
+    "default_reference",
 ]
 
 
@@ -193,3 +194,27 @@ class Referenced:
     def bioregistry_link(self) -> str:
         """Get the bioregistry link."""
         return self.reference.bioregistry_link
+
+
+def default_reference(prefix: str, part: str, name: str | None = None) -> Reference:
+    """Create a CURIE for an "unqualified" reference.
+
+    :param prefix: The prefix of the ontology in which the "unqualified" reference is made
+    :param part: The "unqualified" reference. For example, if you just write
+        "located_in" somewhere there is supposed to be a CURIE
+    :returns: A CURIE for the "unqualified" reference based on the OBO semantic space
+
+    >>> default_reference("chebi", "conjugate_base_of")
+    Reference(prefix="obo", identifier="chebi#conjugate_base_of")
+    """
+    if not part.strip():
+        raise ValueError("default identifier is empty")
+    return Reference(prefix="obo", identifier=f"{prefix}#{part}", name=name)
+
+
+def reference_escape(predicate: Reference, *, ontology_prefix: str) -> str:
+    """Write a reference with default namespace removed."""
+    if predicate.prefix == "obo" and predicate.identifier.startswith(f"{ontology_prefix}#"):
+        return predicate.identifier.removeprefix(f"{ontology_prefix}#")
+    else:
+        return predicate.preferred_curie

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -130,7 +130,8 @@ class SynonymTypeDef(Referenced):
     def to_obo(self, ontology_prefix: str) -> str:
         """Serialize to OBO."""
         rv = f"synonymtypedef: {reference_escape(self.reference, ontology_prefix=ontology_prefix)}"
-        rv = f'{rv} "{self.name or ''}"'
+        name = self.name or ""
+        rv = f'{rv} "{name}"'
         if self.specificity:
             rv = f"{rv} {self.specificity}"
         return rv
@@ -1147,7 +1148,9 @@ class Obo:
                 "xref": [xref.curie for xref in term.xrefs],
                 "is_a": parents,
                 "relationship": relations,
-                "synonym": [synonym._fp() for synonym in term.synonyms],
+                "synonym": [
+                    synonym._fp(ontology_prefix=self.ontology) for synonym in term.synonyms
+                ],
                 "property_value": list(term._emit_properties(self.ontology, typedefs)),
             }
             nodes[term.curie] = {k: v for k, v in d.items() if v}

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -25,7 +25,7 @@ from more_click import force_option, verbose_option
 from tqdm.auto import tqdm
 from typing_extensions import Self
 
-from .reference import Reference, Referenced
+from .reference import Reference, Referenced, default_reference, reference_escape
 from .typedef import (
     TypeDef,
     comment,
@@ -63,7 +63,6 @@ __all__ = [
     "Term",
     "abbreviation",
     "acronym",
-    "default_reference",
     "int_identifier_sort_key",
     "make_ad_hoc_ontology",
 ]
@@ -102,14 +101,14 @@ class Synonym:
     def _sort_key(self) -> tuple[str, str, SynonymTypeDef]:
         return self.name, self.specificity, self.type
 
-    def to_obo(self) -> str:
+    def to_obo(self, ontology_prefix: str) -> str:
         """Write this synonym as an OBO line to appear in a [Term] stanza."""
-        return f"synonym: {self._fp()}"
+        return f"synonym: {self._fp(ontology_prefix)}"
 
-    def _fp(self) -> str:
+    def _fp(self, ontology_prefix: str) -> str:
         x = f'"{self._escape(self.name)}" {self.specificity}'
         if self.type and self.type.pair != DEFAULT_SYNONYM_TYPE.pair:
-            x = f"{x} {self.type.preferred_curie}"
+            x = f"{x} {reference_escape(self.type, ontology_prefix=ontology_prefix)}"
         return f"{x} [{comma_separate(self.provenance)}]"
 
     @staticmethod
@@ -128,11 +127,10 @@ class SynonymTypeDef(Referenced):
         # have to re-define hash because of the @dataclass
         return hash((self.__class__, self.prefix, self.identifier))
 
-    def to_obo(self) -> str:
+    def to_obo(self, ontology_prefix: str) -> str:
         """Serialize to OBO."""
-        rv = f"synonymtypedef: {self.preferred_curie}"
-        if self.name:
-            rv = f'{rv} "{self.name}"'
+        rv = f"synonymtypedef: {reference_escape(self.reference, ontology_prefix=ontology_prefix)}"
+        rv = f'{rv} "{self.name or ''}"'
         if self.specificity:
             rv = f"{rv} {self.specificity}"
         return rv
@@ -497,15 +495,18 @@ class Term(Referenced):
             )
             yield f"namespace: {namespace_normalized}"
 
+        xrefs = list(self.xrefs)
+
         if self.definition:
             yield f"def: {self._definition_fp()}"
         elif self.provenance:
-            logger.warning("%s has provenance but no definition, can't write", self.curie)
+            # if no definition, just stick on xrefs
+            xrefs.extend(self.provenance)
 
         for alt in sorted(self.alt_ids):
             yield f"alt_id: {alt}"  # __str__ bakes in the ! name
 
-        for xref in sorted(self.xrefs):
+        for xref in sorted(xrefs):
             yield f"xref: {xref}"  # __str__ bakes in the ! name
 
         parent_tag = "is_a" if self.type == "Term" else "instance_of"
@@ -520,7 +521,7 @@ class Term(Referenced):
                 yield f"property_value: {line}"
 
         for synonym in sorted(self.synonyms):
-            yield synonym.to_obo()
+            yield synonym.to_obo(ontology_prefix=ontology_prefix)
 
     def _emit_relations(
         self, ontology_prefix: str, typedefs: Mapping[ReferenceTuple, TypeDef]
@@ -565,11 +566,9 @@ class Term(Referenced):
                 # TODO clean/escape value?
                 yield f'{predicate_curie} "{value}" {datatype.preferred_curie}'
 
-    def _reference(self, predicate: Reference, ontology_prefix: str) -> str:
-        if predicate.prefix == "obo" and predicate.identifier.startswith(f"{ontology_prefix}#"):
-            return predicate.identifier.removeprefix(f"{ontology_prefix}#")
-        else:
-            return predicate.preferred_curie
+    @staticmethod
+    def _reference(predicate: Reference, ontology_prefix: str) -> str:
+        return reference_escape(predicate, ontology_prefix=ontology_prefix)
 
     @staticmethod
     def _escape(s) -> str:
@@ -808,18 +807,21 @@ class Obo:
             yield f"date: {self.date_formatted}"
 
         for prefix, url in sorted((self.idspaces or {}).items()):
-            yield f"idspace: {prefix} {url}"
+            yv = f"idspace: {prefix} {url}"
+            if _yv_name := bioregistry.get_name(prefix):
+                yv += f' "{_yv_name}"'
+            yield yv
 
         for synonym_typedef in sorted(self.synonym_typedefs or []):
             if synonym_typedef.curie == DEFAULT_SYNONYM_TYPE.curie:
                 continue
-            yield synonym_typedef.to_obo()
+            yield synonym_typedef.to_obo(ontology_prefix=self.ontology)
 
         yield f"ontology: {self.ontology}"
 
         if self.name is None:
             raise ValueError("ontology is missing name")
-        yield f'property_value: http://purl.org/dc/elements/1.1/title "{self.name}" xsd:string'
+        yield f'property_value: http://purl.org/dc/terms/title "{self.name}" xsd:string'
         license_spdx_id = bioregistry.get_license(self.ontology)
         if license_spdx_id:
             # TODO add SPDX to idspaces and use as a CURIE?
@@ -827,13 +829,13 @@ class Obo:
         description = bioregistry.get_description(self.ontology)
         if description:
             description = obo_escape_slim(description.strip())
-            yield f'property_value: http://purl.org/dc/elements/1.1/description "{description}" xsd:string'
+            yield f'property_value: http://purl.org/dc/terms/description "{description}" xsd:string'
 
         for root_term in self.root_terms or []:
             yield f"property_value: {has_ontology_root_term.preferred_curie} {root_term.preferred_curie}"
 
         for typedef in sorted(self.typedefs or []):
-            yield from typedef.iterate_obo_lines()
+            yield from typedef.iterate_obo_lines(ontology_prefix=self.ontology)
 
         typedefs = self._index_typedefs()
         for term in self:
@@ -1675,19 +1677,3 @@ def _convert_synonym_typedefs(synonym_typedefs: Iterable[SynonymTypeDef] | None)
 
 def _convert_synonym_typedef(synonym_typedef: SynonymTypeDef) -> str:
     return f'{synonym_typedef.preferred_curie} "{synonym_typedef.name}"'
-
-
-def default_reference(prefix: str, part: str, name: str | None = None) -> Reference:
-    """Create a CURIE for an "unqualified" reference.
-
-    :param prefix: The prefix of the ontology in which the "unqualified" reference is made
-    :param part: The "unqualified" reference. For example, if you just write
-        "located_in" somewhere there is supposed to be a CURIE
-    :returns: A CURIE for the "unqualified" reference based on the OBO semantic space
-
-    >>> default_reference("chebi", "conjugate_base_of")
-    Reference(prefix="obo", identifier="chebi#conjugate_base_of")
-    """
-    if not part.strip():
-        raise ValueError("default identifier is empty")
-    return Reference(prefix="obo", identifier=f"{prefix}#{part}", name=name)

--- a/src/pyobo/struct/typedef.py
+++ b/src/pyobo/struct/typedef.py
@@ -6,8 +6,9 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 
 from curies import ReferenceTuple
+from typing_extensions import Self
 
-from .reference import Reference, Referenced
+from .reference import Reference, Referenced, default_reference, reference_escape
 from ..resources.ro import load_ro
 
 __all__ = [
@@ -85,10 +86,10 @@ class TypeDef(Referenced):
         # have to re-define hash because of the @dataclass
         return hash((self.__class__, self.prefix, self.identifier))
 
-    def iterate_obo_lines(self) -> Iterable[str]:
+    def iterate_obo_lines(self, ontology_prefix: str) -> Iterable[str]:
         """Iterate over the lines to write in an OBO file."""
         yield "\n[Typedef]"
-        yield f"id: {self.reference.preferred_curie}"
+        yield f"id: {reference_escape(self.reference, ontology_prefix=ontology_prefix)}"
         if self.name:
             yield f"name: {self.reference.name}"
         if self.definition:
@@ -141,6 +142,11 @@ class TypeDef(Referenced):
         if reference is None:
             raise RuntimeError
         return cls(reference=reference)
+
+    @classmethod
+    def default(cls, prefix: str, identifier: str, *, name: str | None = None) -> Self:
+        """Construct a default type definition from within the OBO namespace."""
+        return cls(reference=default_reference(prefix, identifier, name=name))
 
 
 RO_PREFIX = "RO"

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -6,7 +6,7 @@ from operator import attrgetter
 import obonet
 from curies import ReferenceTuple
 
-from pyobo import Reference, Synonym, SynonymTypeDef, TypeDef, get_ontology
+from pyobo import Reference, Synonym, SynonymTypeDef, TypeDef, default_reference, get_ontology
 from pyobo.reader import (
     _extract_definition,
     _extract_synonym,
@@ -18,7 +18,7 @@ from pyobo.reader import (
     iterate_node_synonyms,
     iterate_node_xrefs,
 )
-from pyobo.struct.struct import acronym, default_reference
+from pyobo.struct.struct import acronym
 from pyobo.utils.io import multidict
 from tests.constants import TEST_CHEBI_OBO_PATH, chebi_patch
 

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -66,16 +66,16 @@ class TestStruct(unittest.TestCase):
         r2 = Reference(prefix="omo", identifier="0003012")
 
         s1 = SynonymTypeDef(reference=r1)
-        self.assertEqual('synonymtypedef: OMO:0003012 "acronym"', s1.to_obo())
+        self.assertEqual('synonymtypedef: OMO:0003012 "acronym"', s1.to_obo(ontology_prefix="chebi"))
 
         s2 = SynonymTypeDef(reference=r2)
-        self.assertEqual("synonymtypedef: OMO:0003012", s2.to_obo())
+        self.assertEqual("synonymtypedef: OMO:0003012 \"\"", s2.to_obo(ontology_prefix="chebi"))
 
         s3 = SynonymTypeDef(reference=r1, specificity="EXACT")
-        self.assertEqual('synonymtypedef: OMO:0003012 "acronym" EXACT', s3.to_obo())
+        self.assertEqual('synonymtypedef: OMO:0003012 "acronym" EXACT', s3.to_obo(ontology_prefix="chebi"))
 
         s4 = SynonymTypeDef(reference=r2, specificity="EXACT")
-        self.assertEqual("synonymtypedef: OMO:0003012 EXACT", s4.to_obo())
+        self.assertEqual("synonymtypedef: OMO:0003012 \"\" EXACT", s4.to_obo(ontology_prefix="chebi"))
 
 
 class TestTerm(unittest.TestCase):
@@ -421,6 +421,7 @@ class TestTerm(unittest.TestCase):
             [Term]
             id: GO:0050069
             name: lysine dehydrogenase activity
+            xref: orcid:0000-0003-4423-4370
             """,
             term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
         )

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -66,16 +66,20 @@ class TestStruct(unittest.TestCase):
         r2 = Reference(prefix="omo", identifier="0003012")
 
         s1 = SynonymTypeDef(reference=r1)
-        self.assertEqual('synonymtypedef: OMO:0003012 "acronym"', s1.to_obo(ontology_prefix="chebi"))
+        self.assertEqual(
+            'synonymtypedef: OMO:0003012 "acronym"', s1.to_obo(ontology_prefix="chebi")
+        )
 
         s2 = SynonymTypeDef(reference=r2)
-        self.assertEqual("synonymtypedef: OMO:0003012 \"\"", s2.to_obo(ontology_prefix="chebi"))
+        self.assertEqual('synonymtypedef: OMO:0003012 ""', s2.to_obo(ontology_prefix="chebi"))
 
         s3 = SynonymTypeDef(reference=r1, specificity="EXACT")
-        self.assertEqual('synonymtypedef: OMO:0003012 "acronym" EXACT', s3.to_obo(ontology_prefix="chebi"))
+        self.assertEqual(
+            'synonymtypedef: OMO:0003012 "acronym" EXACT', s3.to_obo(ontology_prefix="chebi")
+        )
 
         s4 = SynonymTypeDef(reference=r2, specificity="EXACT")
-        self.assertEqual("synonymtypedef: OMO:0003012 \"\" EXACT", s4.to_obo(ontology_prefix="chebi"))
+        self.assertEqual('synonymtypedef: OMO:0003012 "" EXACT', s4.to_obo(ontology_prefix="chebi"))
 
 
 class TestTerm(unittest.TestCase):

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -4,9 +4,9 @@ import unittest
 from collections.abc import Iterable
 from textwrap import dedent
 
-from pyobo import Obo, Reference
+from pyobo import Obo, Reference, default_reference
 from pyobo.constants import NCBITAXON_PREFIX
-from pyobo.struct.struct import BioregistryError, SynonymTypeDef, Term, TypeDef, default_reference
+from pyobo.struct.struct import BioregistryError, SynonymTypeDef, Term, TypeDef
 from pyobo.struct.typedef import exact_match, see_also
 
 LYSINE_DEHYDROGENASE_ACT = Reference(


### PR DESCRIPTION
1. Move the default_reference function so it can be more widely reused
2. Add a companion function for escaping a default reference (i.e., show `has_part` instead of obo:chebi#has_part` on OBO export in chebi)
3. Make property typedefs explicit in several sources
4. Require synonym typedefs to have names. Default to empty string if note
5. Update several sources to better use annotation properties