### PR TITLE
Streamline URI and CURIE parsing in the reader

### DIFF
--- a/src/pyobo/api/alts.py
+++ b/src/pyobo/api/alts.py
@@ -63,7 +63,7 @@ def get_primary_curie(
     **kwargs: Unpack[GetOntologyKwargs],
 ) -> str | None:
     """Get the primary curie for an entity."""
-    reference = Reference.from_curie(curie, strict=kwargs.get("strict", True))
+    reference = Reference.from_curie_or_uri(curie, strict=kwargs.get("strict", True))
     if reference is None:
         return None
     primary_identifier = get_primary_identifier(reference, **kwargs)

--- a/src/pyobo/cli/lookup.py
+++ b/src/pyobo/cli/lookup.py
@@ -213,7 +213,7 @@ def relations(
         else:
             echo_df(relations_df)
     else:
-        relation_reference = Reference.from_curie(relation, strict=False)
+        relation_reference = Reference.from_curie_or_uri(relation, strict=False)
         if relation_reference is None:
             click.secho(f"not a valid curie: {relation}", fg="red")
             raise sys.exit(1)

--- a/src/pyobo/sources/complexportal.py
+++ b/src/pyobo/sources/complexportal.py
@@ -125,7 +125,7 @@ def _parse_xrefs(s) -> list[tuple[Reference, str]]:
             xref_curie = _clean_intenz(xref_curie)
 
         try:
-            reference = Reference.from_curie(xref_curie)
+            reference = Reference.from_curie_or_uri(xref_curie)
         except ValueError:
             logger.warning("can not parse CURIE: %s", xref_curie)
             continue

--- a/src/pyobo/sources/conso.py
+++ b/src/pyobo/sources/conso.py
@@ -42,7 +42,7 @@ def iter_terms() -> Iterable[Term]:
 
     synonyms_df = ensure_df(PREFIX, url=SYNONYMS_URL)
     synonyms_df["reference"] = synonyms_df["reference"].map(
-        lambda s: [Reference.from_curie(s)] if pd.notna(s) and s != "?" else [],
+        lambda s: [Reference.from_curie_or_uri(s)] if pd.notna(s) and s != "?" else [],
     )
     synonyms_df["specificity"] = synonyms_df["specificity"].map(
         lambda s: "EXACT" if pd.isna(s) or s == "?" else s
@@ -71,7 +71,7 @@ def iter_terms() -> Iterable[Term]:
             curie = curie.strip()
             if not curie:
                 continue
-            reference = Reference.from_curie(curie)
+            reference = Reference.from_curie_or_uri(curie)
             if reference is not None:
                 provenance.append(reference)
         identifier = row["Identifier"]

--- a/src/pyobo/sources/famplex.py
+++ b/src/pyobo/sources/famplex.py
@@ -107,7 +107,7 @@ def get_terms(version: str, force: bool = False) -> Iterable[Term]:
         reference = Reference(prefix=PREFIX, identifier=entity, name=entity)
         definition, provenance = id_to_definition.get(entity, (None, None))
         provenance_reference = (
-            Reference.from_curie(provenance) if isinstance(provenance, str) else None
+            Reference.from_curie_or_uri(provenance) if isinstance(provenance, str) else None
         )
         term = Term(
             reference=reference,

--- a/src/pyobo/sources/flybase.py
+++ b/src/pyobo/sources/flybase.py
@@ -154,7 +154,7 @@ def get_terms(version: str, force: bool = False) -> Iterable[Term]:
         for hgnc_curie in human_orthologs.get(identifier, []):
             if not hgnc_curie or pd.isna(hgnc_curie):
                 continue
-            hgnc_ortholog = Reference.from_curie(hgnc_curie)
+            hgnc_ortholog = Reference.from_curie_or_uri(hgnc_curie)
             if hgnc_ortholog is None:
                 tqdm.write(f"[{PREFIX}] {identifier} had invalid ortholog: {hgnc_curie}")
             else:

--- a/src/pyobo/sources/uniprot/uniprot.py
+++ b/src/pyobo/sources/uniprot/uniprot.py
@@ -126,7 +126,7 @@ def iter_terms(version: str | None = None) -> Iterable[Term]:
                         # FIXME this needs a different relation than enables
                         #  see https://github.com/biopragmatics/pyobo/pull/168#issuecomment-1918680152
                         enables,
-                        cast(Reference, Reference.from_curie(rhea_curie, strict=True)),
+                        cast(Reference, Reference.from_curie_or_uri(rhea_curie, strict=True)),
                     )
 
             if bindings:
@@ -136,7 +136,7 @@ def iter_terms(version: str | None = None) -> Iterable[Term]:
                     if part.startswith("/ligand_id"):
                         curie = part.removeprefix('/ligand_id="').rstrip('"')
                         binding_references.add(
-                            cast(Reference, Reference.from_curie(curie, strict=True))
+                            cast(Reference, Reference.from_curie_or_uri(curie, strict=True))
                         )
                 for binding_reference in sorted(binding_references):
                     term.annotate_object(molecularly_interacts_with, binding_reference)

--- a/src/pyobo/sources/uniprot/uniprot_ptm.py
+++ b/src/pyobo/sources/uniprot/uniprot_ptm.py
@@ -96,7 +96,7 @@ def _parse(i, lines: Iterable[tuple[str, str]]) -> Term | None:
             if line.startswith(y):
                 line = x + line[len(y) :]
 
-        ref = Reference.from_curie(line.replace("; ", ":"))
+        ref = Reference.from_curie_or_uri(line.replace("; ", ":"))
         if ref:
             term.append_xref(ref)
         else:

--- a/src/pyobo/sources/zfin.py
+++ b/src/pyobo/sources/zfin.py
@@ -150,7 +150,7 @@ def get_terms(force: bool = False, version: str | None = None) -> Iterable[Term]
         for hgnc_id in human_orthologs.get(identifier, []):
             term.append_relationship(orthologous, Reference(prefix="hgnc", identifier=hgnc_id))
         for mgi_curie in mouse_orthologs.get(identifier, []):
-            mouse_ortholog = Reference.from_curie(mgi_curie)
+            mouse_ortholog = Reference.from_curie_or_uri(mgi_curie)
             if mouse_ortholog:
                 term.append_relationship(orthologous, mouse_ortholog)
         for flybase_id in fly_orthologs.get(identifier, []):

--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -73,7 +73,7 @@ class Reference(curies.Reference):
         return f"https://bioregistry.io/{self.curie}"
 
     @classmethod
-    def from_curie(  # type:ignore[override]
+    def from_curie_or_uri(
         cls,
         curie: str,
         name: str | None = None,

--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -95,6 +95,9 @@ class Reference(curies.Reference):
         )
         if prefix is None or identifier is None:
             return None
+
+        identifier = bioregistry.standardize_identifier(prefix, identifier)
+
         if name is None and auto:
             from ..api import get_name
 

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -295,14 +295,6 @@ class Term(Referenced):
             definition=get_definition(prefix, identifier),
         )
 
-    @classmethod
-    def from_curie(cls, curie: str, name: str | None = None) -> Term:
-        """Create a term directly from a CURIE and optional name."""
-        reference = Reference.from_curie(curie, name=name, strict=True)
-        if reference is None:
-            raise RuntimeError
-        return cls(reference=reference)
-
     def append_provenance(self, reference: ReferenceHint) -> None:
         """Add a provenance reference."""
         self.provenance.append(_ensure_ref(reference))

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -190,7 +190,7 @@ def _ensure_ref(
         if not ontology_prefix:
             raise ValueError(f"can't parse reference: {reference}")
         return default_reference(ontology_prefix, reference)
-    _rv = Reference.from_curie(reference, strict=True, ontology_prefix=ontology_prefix)
+    _rv = Reference.from_curie_or_uri(reference, strict=True, ontology_prefix=ontology_prefix)
     if _rv is None:
         raise ValueError(f"[{ontology_prefix}] unable to parse {reference}")
     return _rv

--- a/src/pyobo/struct/typedef.py
+++ b/src/pyobo/struct/typedef.py
@@ -137,18 +137,6 @@ class TypeDef(Referenced):
         return cls(reference=Reference(prefix=prefix, identifier=identifier, name=name))
 
     @classmethod
-    def from_curie(
-        cls, curie: str, *, name: str | None = None, ontology_prefix: str | None = None
-    ) -> TypeDef:
-        """Create a TypeDef directly from a CURIE and optional name."""
-        reference = Reference.from_curie(
-            curie, name=name, strict=True, ontology_prefix=ontology_prefix
-        )
-        if reference is None:
-            raise RuntimeError
-        return cls(reference=reference)
-
-    @classmethod
     def default(cls, prefix: str, identifier: str, *, name: str | None = None) -> Self:
         """Construct a default type definition from within the OBO namespace."""
         return cls(reference=default_reference(prefix, identifier, name=name))
@@ -329,7 +317,9 @@ has_ontology_root_term = TypeDef.from_triple(
 definition_source = TypeDef.from_triple(
     prefix=IAO_PREFIX, identifier="0000119", name="definition source"
 )
-has_dbxref = TypeDef.from_curie("oboInOwl:hasDbXref", name="has database cross-reference")
+has_dbxref = TypeDef.from_triple(
+    prefix="oboInOwl", identifier="hasDbXref", name="has database cross-reference"
+)
 
 editor_note = TypeDef.from_triple(prefix=IAO_PREFIX, identifier="0000116", name="editor note")
 

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -85,7 +85,7 @@ class TestParseObonet(unittest.TestCase):
         ]:
             with self.subTest(s=s):
                 actual_text, actual_references = _extract_definition(
-                    s, node=Reference(prefix="chebi", identifier="XXX")
+                    s, node=Reference(prefix="chebi", identifier="XXX"), ontology_prefix="chebi"
                 )
                 self.assertEqual(expected_text, actual_text)
                 self.assertEqual(expected_references, actual_references)
@@ -95,7 +95,10 @@ class TestParseObonet(unittest.TestCase):
         expected_text = """The canonical 3' splice site has the sequence "AG"."""
         s = """"The canonical 3' splice site has the sequence \\"AG\\"." [PMID:1234]"""
         actual_text, actual_references = _extract_definition(
-            s, strict=True, node=Reference(prefix="chebi", identifier="XXX")
+            s,
+            strict=True,
+            node=Reference(prefix="chebi", identifier="XXX"),
+            ontology_prefix="chebi",
         )
         self.assertEqual(expected_text, actual_text)
         self.assertEqual([Reference(prefix="pubmed", identifier="1234")], actual_references)
@@ -159,7 +162,10 @@ class TestParseObonet(unittest.TestCase):
         ]:
             with self.subTest(s=text):
                 actual_synonym = _extract_synonym(
-                    text, synoynym_typedefs, node=Reference(prefix="chebi", identifier="XXX")
+                    text,
+                    synoynym_typedefs,
+                    node=Reference(prefix="chebi", identifier="XXX"),
+                    ontology_prefix="chebi",
                 )
                 self.assertIsInstance(actual_synonym, Synonym)
                 self.assertEqual(expected_synonym, actual_synonym)
@@ -175,7 +181,10 @@ class TestParseObonet(unittest.TestCase):
         data = self.graph.nodes["CHEBI:51990"]
         synonyms = list(
             iterate_node_synonyms(
-                data, synoynym_typedefs, node=Reference(prefix="chebi", identifier="XXX")
+                data,
+                synoynym_typedefs,
+                node=Reference(prefix="chebi", identifier="XXX"),
+                ontology_prefix="chebi",
             )
         )
         self.assertEqual(1, len(synonyms))
@@ -215,7 +224,13 @@ class TestParseObonet(unittest.TestCase):
     def test_get_node_xrefs(self):
         """Test getting parents from a node in a :mod:`obonet` graph."""
         data = self.graph.nodes["CHEBI:51990"]
-        xrefs = list(iterate_node_xrefs(prefix="chebi", data=data))
+        xrefs = list(
+            iterate_node_xrefs(
+                data=data,
+                ontology_prefix="chebi",
+                node=Reference(prefix="chebi", identifier="51990"),
+            )
+        )
         self.assertEqual(7, len(xrefs))
         # NOTE the prefixes are remapped by Bioregistry
         self.assertEqual({"pubmed", "cas", "reaxys"}, {xref.prefix for xref in xrefs})

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -290,7 +290,9 @@ class TestGet(unittest.TestCase):
 
     def test_iter_filtered_relations(self):
         """Test getting filtered relations w/ upgrade."""
+        term_reference = Reference(prefix="chebi", identifier="17051")
         reference = default_reference("chebi", "is_conjugate_base_of")
+        object_reference = Reference(prefix="chebi", identifier="29228")
         for inp in [
             reference.curie,
             reference,
@@ -303,6 +305,5 @@ class TestGet(unittest.TestCase):
                     for term, target in self.ontology.iterate_filtered_relations(inp)
                 )
                 self.assertNotEqual(0, len(rr))
-                term = Reference.from_curie("chebi:17051")
-                self.assertIn(term, rr)
-                self.assertIn(Reference.from_curie("chebi:29228"), rr[term])
+                self.assertIn(term_reference, rr)
+                self.assertIn(object_reference, rr[term_reference])

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -290,12 +290,12 @@ class TestGet(unittest.TestCase):
 
     def test_iter_filtered_relations(self):
         """Test getting filtered relations w/ upgrade."""
-        curie = "obo:chebi#is_conjugate_base_of"
+        reference = default_reference("chebi", "is_conjugate_base_of")
         for inp in [
-            curie,
-            ReferenceTuple.from_curie(curie),
-            Reference.from_curie(curie),
-            TypeDef.from_curie(curie),
+            reference.curie,
+            reference,
+            reference.pair,
+            TypeDef(reference=reference),
         ]:
             with self.subTest(inp=inp):
                 rr = multidict(

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -390,7 +390,7 @@ class TestReader(unittest.TestCase):
             id: CHEBI:1234
             property_value: https://w3id.org/biolink/vocab/something CHEBI:5678
         """)
-        td = TypeDef.from_curie("biolink:something")
+        td = TypeDef.from_triple(prefix="biolink", identifier="something")
         term = self.get_only_term(ontology)
         self.assertEqual(0, len(list(term.annotations_literal)))
         self.assertEqual(1, len(list(term.annotations_object)))

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -12,7 +12,7 @@ from pyobo.struct.typedef import exact_match, see_also
 LYSINE_DEHYDROGENASE_ACT = Reference(
     prefix="GO", identifier="0050069", name="lysine dehydrogenase activity"
 )
-RO_DUMMY = TypeDef(reference=Reference.from_curie("RO:1234567"))
+RO_DUMMY = TypeDef(reference=Reference(prefix="RO", identifier="1234567"))
 CHARLIE = Reference(prefix="orcid", identifier="0000-0003-4423-4370")
 
 


### PR DESCRIPTION
1. Rename Reference.from_curie to Reference.from_curie_to_uri. This has the benefit that it can be typed differently, and also reflects its different functionality from the base class.
2. Updated node iteration to directly construct references. This reduces some superfluous code in indexing them in a mapping
3. Pass `ontology_prefix` through to functions where it was missed