### PR TITLE
Improve typedef parsing

### DIFF
--- a/src/pyobo/getters.py
+++ b/src/pyobo/getters.py
@@ -70,6 +70,7 @@ def get_ontology(
     strict: bool = True,
     version: str | None = None,
     robot_check: bool = True,
+    upgrade: bool = False,
 ) -> Obo:
     """Get the OBO for a given graph.
 
@@ -81,6 +82,9 @@ def get_ontology(
     :param robot_check:
         If set to false, will send the ``--check=false`` command to ROBOT to disregard
         malformed ontology components. Necessary to load some ontologies like VO.
+    :param upgrade:
+        If set to true, will automatically upgrade relationships, such as
+        ``obo:chebi#part_of`` to ``BFO:0000051``
     :returns: An OBO object
 
     :raises OnlyOWLError: If the OBO foundry only has an OWL document for this resource.
@@ -132,7 +136,7 @@ def get_ontology(
     else:
         raise UnhandledFormatError(f"[{prefix}] unhandled ontology file format: {path.suffix}")
 
-    obo = from_obo_path(path, prefix=prefix, strict=strict, version=version)
+    obo = from_obo_path(path, prefix=prefix, strict=strict, version=version, upgrade=upgrade)
     obo.write_default(force=force_process)
     return obo
 

--- a/src/pyobo/getters.py
+++ b/src/pyobo/getters.py
@@ -70,7 +70,7 @@ def get_ontology(
     strict: bool = True,
     version: str | None = None,
     robot_check: bool = True,
-    upgrade: bool = False,
+    upgrade: bool = True,
 ) -> Obo:
     """Get the OBO for a given graph.
 

--- a/src/pyobo/identifier_utils.py
+++ b/src/pyobo/identifier_utils.py
@@ -75,6 +75,7 @@ def normalize_curie(
     strict: bool = True,
     ontology_prefix: str | None = None,
     node: Reference | None = None,
+    upgrade: bool = True,
 ) -> ReferenceTuple | tuple[None, None]:
     """Parse a string that looks like a CURIE.
 
@@ -86,11 +87,12 @@ def normalize_curie(
     - Normalizes the namespace
     - Checks against a blacklist for the entire curie, for the namespace, and for suffixes.
     """
-    # Remap the curie with the full list
-    curie = remap_full(curie)
+    if upgrade:
+        # Remap the curie with the full list
+        curie = remap_full(curie)
 
-    # Remap node's prefix (if necessary)
-    curie = remap_prefix(curie, ontology_prefix=ontology_prefix)
+        # Remap node's prefix (if necessary)
+        curie = remap_prefix(curie, ontology_prefix=ontology_prefix)
 
     if curie_is_blacklisted(curie):
         return None, None
@@ -99,7 +101,7 @@ def normalize_curie(
     if curie_has_blacklisted_suffix(curie):
         return None, None
 
-    if reference_t := bioontologies.upgrade.upgrade(curie):
+    if upgrade and (reference_t := bioontologies.upgrade.upgrade(curie)):
         return reference_t
 
     if curie.startswith("http:") or curie.startswith("https:"):

--- a/src/pyobo/reader.py
+++ b/src/pyobo/reader.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+import bioontologies.relations
 import bioregistry
 import networkx as nx
 from curies import ReferenceTuple
@@ -390,6 +391,8 @@ def iterate_graph_typedefs(
             reference = Reference.from_curie_or_uri(
                 curie, name=name, strict=strict, ontology_prefix=ontology_prefix
             )
+        elif reference := _ground_relation(curie):
+            pass
         else:
             reference = default_reference(ontology_prefix, curie, name=name)
         if reference is None:
@@ -700,6 +703,8 @@ def iterate_node_relationships(
             relation = Reference.from_curie_or_uri(
                 relation_curie, strict=strict, ontology_prefix=ontology_prefix, node=node
             )
+        elif relation := _ground_relation(relation_curie):
+            pass
         else:
             relation = default_reference(ontology_prefix, relation_curie)
             logger.debug(
@@ -750,3 +755,10 @@ def iterate_node_xrefs(
         )
         if yv is not None:
             yield yv
+
+
+def _ground_relation(relation_str: str) -> Reference | None:
+    prefix, identifier = bioontologies.relations.ground_relation(relation_str)
+    if prefix and identifier:
+        return Reference(prefix=prefix, identifier=identifier)
+    return None

--- a/src/pyobo/reader.py
+++ b/src/pyobo/reader.py
@@ -52,7 +52,7 @@ def from_obo_path(
     *,
     strict: bool = True,
     version: str | None,
-    upgrade: bool = False,
+    upgrade: bool = True,
 ) -> Obo:
     """Get the OBO graph from a path."""
     path = Path(path).expanduser().resolve()
@@ -105,7 +105,7 @@ def from_obonet(
     *,
     strict: bool = True,
     version: str | None = None,
-    upgrade: bool = False,
+    upgrade: bool = True,
 ) -> Obo:
     """Get all of the terms from a OBO graph."""
     ontology_prefix_raw = graph.graph["ontology"]

--- a/src/pyobo/reader.py
+++ b/src/pyobo/reader.py
@@ -33,6 +33,7 @@ from .struct import (
     default_reference,
     make_ad_hoc_ontology,
 )
+from .struct.reference import _parse_identifier
 from .struct.struct import DEFAULT_SYNONYM_TYPE, LiteralProperty, ObjectProperty
 from .struct.typedef import default_typedefs
 from .utils.misc import STATIC_VERSION_REWRITES, cleanup_version
@@ -386,7 +387,7 @@ def iterate_graph_typedefs(
         if name is None:
             logger.debug("[%s] typedef %s is missing a name", ontology_prefix, typedef_id)
 
-        reference = Reference.from_curie_uri_or_default(
+        reference = _parse_identifier(
             typedef_id, strict=strict, ontology_prefix=ontology_prefix, name=name
         )
         if reference is None:
@@ -653,9 +654,7 @@ def _get_prop(
         if property_id.startswith(sw):
             identifier = property_id.removeprefix(sw)
             return default_reference(ontology_prefix, identifier)
-    return Reference.from_curie_uri_or_default(
-        property_id, strict=strict, node=node, ontology_prefix=ontology_prefix
-    )
+    return _parse_identifier(property_id, strict=strict, node=node, ontology_prefix=ontology_prefix)
 
 
 def iterate_node_parents(
@@ -698,7 +697,7 @@ def iterate_node_relationships(
     """Extract relationships from a :mod:`obonet` node's data."""
     for s in data.get("relationship", []):
         relation_curie, target_curie = s.split(" ")
-        relation = Reference.from_curie_uri_or_default(
+        relation = _parse_identifier(
             relation_curie, strict=strict, ontology_prefix=ontology_prefix, node=node
         )
         if relation is None:

--- a/src/pyobo/reader_utils.py
+++ b/src/pyobo/reader_utils.py
@@ -43,7 +43,7 @@ def _chomp_typedef(
         return None, s
 
     try:
-        stype_curie, rest = (x.strip() for x in s.split(" ", 1))
+        synonym_typedef_id, rest = (x.strip() for x in s.split(" ", 1))
     except ValueError as e:
         if "not enough values to unpack" not in str(e):
             raise
@@ -55,14 +55,18 @@ def _chomp_typedef(
             # if there
             return None, s
 
-        stype_curie, rest = s, ""
+        synonym_typedef_id, rest = s, ""
 
     reference = _parse_identifier(
-        stype_curie, strict=strict, node=node, ontology_prefix=ontology_prefix, upgrade=upgrade
+        synonym_typedef_id,
+        strict=strict,
+        node=node,
+        ontology_prefix=ontology_prefix,
+        upgrade=upgrade,
     )
     if reference is None:
         logger.warning(
-            "[%s] unable to parse synonym type `%s` in line %s", node.curie, stype_curie, s
+            "[%s] unable to parse synonym type `%s` in line %s", node.curie, synonym_typedef_id, s
         )
         return None, rest
 

--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -103,26 +103,6 @@ class Reference(curies.Reference):
             name = get_name(prefix, identifier)
         return cls.model_validate({"prefix": prefix, "identifier": identifier, "name": name})
 
-    @classmethod
-    def from_curie_uri_or_default(
-        cls,
-        s: str,
-        *,
-        ontology_prefix: str,
-        strict: bool = True,
-        node: Reference | None = None,
-        name: str | None = None,
-    ) -> Reference | None:
-        """Parse from a CURIE, URI, or default string in the ontology prefix's IDspace."""
-        if ":" in s:
-            return cls.from_curie_or_uri(
-                s, ontology_prefix=ontology_prefix, name=name, strict=strict, node=node
-            )
-        elif reference := _ground_relation(s):
-            return reference
-        else:
-            return default_reference(ontology_prefix, s, name=name)
-
     @property
     def _escaped_identifier(self):
         return obo_escape(self.identifier)
@@ -222,3 +202,22 @@ def _ground_relation(relation_str: str) -> Reference | None:
     if prefix and identifier:
         return Reference(prefix=prefix, identifier=identifier)
     return None
+
+
+def _parse_identifier(
+    s: str,
+    *,
+    ontology_prefix: str,
+    strict: bool = True,
+    node: Reference | None = None,
+    name: str | None = None,
+) -> Reference | None:
+    """Parse from a CURIE, URI, or default string in the ontology prefix's IDspace."""
+    if ":" in s:
+        return Reference.from_curie_or_uri(
+            s, ontology_prefix=ontology_prefix, name=name, strict=strict, node=node
+        )
+    elif reference := _ground_relation(s):
+        return reference
+    else:
+        return default_reference(ontology_prefix, s, name=name)

--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -211,13 +211,14 @@ def _parse_identifier(
     strict: bool = True,
     node: Reference | None = None,
     name: str | None = None,
+    upgrade: bool,
 ) -> Reference | None:
     """Parse from a CURIE, URI, or default string in the ontology prefix's IDspace."""
     if ":" in s:
         return Reference.from_curie_or_uri(
             s, ontology_prefix=ontology_prefix, name=name, strict=strict, node=node
         )
-    elif reference := _ground_relation(s):
+    elif upgrade and (reference := _ground_relation(s)):
         return reference
     else:
         return default_reference(ontology_prefix, s, name=name)

--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import bioontologies.relations
+import bioontologies.upgrade
 import bioregistry
 import curies
 from curies import ReferenceTuple
@@ -211,14 +212,16 @@ def _parse_identifier(
     strict: bool = True,
     node: Reference | None = None,
     name: str | None = None,
-    upgrade: bool,
+    upgrade: bool = True,
 ) -> Reference | None:
     """Parse from a CURIE, URI, or default string in the ontology prefix's IDspace."""
     if ":" in s:
         return Reference.from_curie_or_uri(
             s, ontology_prefix=ontology_prefix, name=name, strict=strict, node=node
         )
-    elif upgrade and (reference := _ground_relation(s)):
-        return reference
-    else:
-        return default_reference(ontology_prefix, s, name=name)
+    if upgrade:
+        if xx := bioontologies.upgrade.upgrade(s):
+            return Reference(prefix=xx.prefix, identifier=xx.identifier, name=name)
+        if yy := _ground_relation(s):
+            return Reference(prefix=yy.prefix, identifier=yy.identifier, name=name)
+    return default_reference(ontology_prefix, s, name=name)

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -6,7 +6,7 @@ from operator import attrgetter
 import obonet
 from curies import ReferenceTuple
 
-from pyobo import Reference, Synonym, SynonymTypeDef, TypeDef, default_reference, get_ontology
+from pyobo import Reference, Synonym, SynonymTypeDef, default_reference, get_ontology
 from pyobo.reader import (
     _extract_definition,
     _extract_synonym,
@@ -19,7 +19,6 @@ from pyobo.reader import (
     iterate_node_xrefs,
 )
 from pyobo.struct.struct import acronym
-from pyobo.utils.io import multidict
 from tests.constants import TEST_CHEBI_OBO_PATH, chebi_patch
 
 
@@ -37,7 +36,7 @@ class TestParseObonet(unittest.TestCase):
         pairs = {
             typedef.pair for typedef in iterate_graph_typedefs(self.graph, ontology_prefix="chebi")
         }
-        self.assertIn(ReferenceTuple("obo", "chebi#has_part"), pairs)
+        self.assertIn(ReferenceTuple("obo", "chebi#has_major_microspecies_at_pH_7_3"), pairs)
 
     def test_get_graph_synonym_typedefs(self):
         """Test getting synonym type definitions from an :mod:`obonet` graph."""
@@ -251,7 +250,7 @@ class TestParseObonet(unittest.TestCase):
         data = self.graph.nodes["CHEBI:17051"]
         relations = list(
             iterate_node_relationships(
-                data, node=Reference(prefix="chebi", identifier="XXX"), ontology_prefix="chebi"
+                data, node=Reference(prefix="chebi", identifier="17051"), ontology_prefix="chebi"
             )
         )
         self.assertEqual(1, len(relations))
@@ -259,13 +258,11 @@ class TestParseObonet(unittest.TestCase):
 
         self.assertIsNotNone(target)
         self.assertIsInstance(target, Reference)
-        self.assertEqual("chebi", target.prefix)
-        self.assertEqual("29228", target.identifier)
+        self.assertEqual(("chebi", "29228"), target.pair)
 
         self.assertIsNotNone(typedef)
         self.assertIsInstance(typedef, Reference)
-        self.assertEqual("obo", typedef.prefix)
-        self.assertEqual("chebi#is_conjugate_base_of", typedef.identifier)
+        self.assertEqual(("ro", "0018033"), typedef.pair)
 
 
 class TestGet(unittest.TestCase):
@@ -299,26 +296,7 @@ class TestGet(unittest.TestCase):
 
     def test_typedefs(self):
         """Test typedefs."""
-        xx = default_reference("chebi", "is_conjugate_base_of")
-        td = {t.pair for t in self.ontology.typedefs}
+        xx = default_reference("chebi", "has_major_microspecies_at_pH_7_3")
+        td = self.ontology._index_typedefs()
         self.assertIn(xx.pair, td)
-
-    def test_iter_filtered_relations(self):
-        """Test getting filtered relations w/ upgrade."""
-        term_reference = Reference(prefix="chebi", identifier="17051")
-        reference = default_reference("chebi", "is_conjugate_base_of")
-        object_reference = Reference(prefix="chebi", identifier="29228")
-        for inp in [
-            reference.curie,
-            reference,
-            reference.pair,
-            TypeDef(reference=reference),
-        ]:
-            with self.subTest(inp=inp):
-                rr = multidict(
-                    (term.reference, target)
-                    for term, target in self.ontology.iterate_filtered_relations(inp)
-                )
-                self.assertNotEqual(0, len(rr))
-                self.assertIn(term_reference, rr)
-                self.assertIn(object_reference, rr[term_reference])
+        self.assertIn(ReferenceTuple("ro", "0018033"), td)

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -34,14 +34,19 @@ class TestParseObonet(unittest.TestCase):
     def test_get_graph_typedefs(self):
         """Test getting type definitions from an :mod:`obonet` graph."""
         pairs = {
-            typedef.pair for typedef in iterate_graph_typedefs(self.graph, ontology_prefix="chebi")
+            typedef.pair
+            for typedef in iterate_graph_typedefs(
+                self.graph, ontology_prefix="chebi", upgrade=False
+            )
         }
         self.assertIn(ReferenceTuple("obo", "chebi#has_major_microspecies_at_pH_7_3"), pairs)
 
     def test_get_graph_synonym_typedefs(self):
         """Test getting synonym type definitions from an :mod:`obonet` graph."""
         synonym_typedefs = sorted(
-            iterate_graph_synonym_typedefs(self.graph, ontology_prefix=self.ontology),
+            iterate_graph_synonym_typedefs(
+                self.graph, ontology_prefix=self.ontology, upgrade=False
+            ),
             key=attrgetter("curie"),
         )
         self.assertEqual(
@@ -165,6 +170,7 @@ class TestParseObonet(unittest.TestCase):
                     synoynym_typedefs,
                     node=Reference(prefix="chebi", identifier="XXX"),
                     ontology_prefix="chebi",
+                    upgrade=False,
                 )
                 self.assertIsInstance(actual_synonym, Synonym)
                 self.assertEqual(expected_synonym, actual_synonym)
@@ -184,6 +190,7 @@ class TestParseObonet(unittest.TestCase):
                 synoynym_typedefs,
                 node=Reference(prefix="chebi", identifier="XXX"),
                 ontology_prefix="chebi",
+                upgrade=False,
             )
         )
         self.assertEqual(1, len(synonyms))
@@ -199,7 +206,10 @@ class TestParseObonet(unittest.TestCase):
         data = self.graph.nodes["CHEBI:51990"]
         properties = list(
             iterate_node_properties(
-                data, node=Reference(prefix="chebi", identifier="51990"), ontology_prefix="chebi"
+                data,
+                node=Reference(prefix="chebi", identifier="51990"),
+                ontology_prefix="chebi",
+                upgrade=False,
             )
         )
         t_prop = default_reference("chebi", "monoisotopicmass")
@@ -250,7 +260,10 @@ class TestParseObonet(unittest.TestCase):
         data = self.graph.nodes["CHEBI:17051"]
         relations = list(
             iterate_node_relationships(
-                data, node=Reference(prefix="chebi", identifier="17051"), ontology_prefix="chebi"
+                data,
+                node=Reference(prefix="chebi", identifier="17051"),
+                ontology_prefix="chebi",
+                upgrade=False,
             )
         )
         self.assertEqual(1, len(relations))
@@ -262,7 +275,7 @@ class TestParseObonet(unittest.TestCase):
 
         self.assertIsNotNone(typedef)
         self.assertIsInstance(typedef, Reference)
-        self.assertEqual(("ro", "0018033"), typedef.pair)
+        self.assertEqual(("chebi", "chebi#is_conjugate_base_of"), typedef.pair)
 
 
 class TestGet(unittest.TestCase):

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -275,7 +275,7 @@ class TestParseObonet(unittest.TestCase):
 
         self.assertIsNotNone(typedef)
         self.assertIsInstance(typedef, Reference)
-        self.assertEqual(("chebi", "chebi#is_conjugate_base_of"), typedef.pair)
+        self.assertEqual(("obo", "chebi#is_conjugate_base_of"), typedef.pair)
 
 
 class TestGet(unittest.TestCase):

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -12,7 +12,14 @@ from pyobo.identifier_utils import UnparsableIRIError
 from pyobo.reader import from_obonet, get_first_nonescaped_quote
 from pyobo.struct import default_reference
 from pyobo.struct.struct import DEFAULT_SYNONYM_TYPE, abbreviation
-from pyobo.struct.typedef import TypeDef, exact_match, has_dbxref, is_conjugate_base_of, see_also
+from pyobo.struct.typedef import (
+    TypeDef,
+    derives_from,
+    exact_match,
+    has_dbxref,
+    is_conjugate_base_of,
+    see_also,
+)
 
 CHARLIE = Reference(prefix="orcid", identifier="0000-0003-4423-4370")
 
@@ -946,7 +953,7 @@ class TestReader(unittest.TestCase):
         )
 
     def test_default_relation(self):
-        """Test parsing DO's weird url prefixing."""
+        """Test parsing a default relation."""
         ontology = _read("""\
             ontology: chebi
 
@@ -956,6 +963,7 @@ class TestReader(unittest.TestCase):
         """)
         term = self.get_only_term(ontology)
         self.assertEqual(1, len(term.relationships))
+        self.assertIn(derives_from.reference, term.relationships)
 
 
 class TestVersionHandling(unittest.TestCase):

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -251,18 +251,23 @@ class TestReader(unittest.TestCase):
 
             [Term]
             id: CHEBI:1234
-            property_value: mass "121.323" xsd:decimal
+            property_value: xyz "121.323" xsd:decimal
+
+            [Typedef]
+            id: xyz
         """)
         term = self.get_only_term(ontology)
         self.assertEqual(1, len(list(term.annotations_literal)))
-        self.assertEqual("121.323", term.get_property(default_reference("chebi", "mass")))
+        ref = default_reference("chebi", "xyz")
+        self.assertIn(ref, term.annotations_literal)
+        self.assertEqual("121.323", term.get_property(ref))
 
         df = ontology.get_properties_df()
         self.assertEqual(4, len(df.columns))
         self.assertEqual(1, len(df))
         row = dict(df.iloc[0])
         self.assertEqual("1234", row["chebi_id"])
-        self.assertEqual("mass", row["property"])
+        self.assertEqual("xyz", row["property"])
         self.assertEqual("121.323", row["value"])
         self.assertEqual("xsd:decimal", row["datatype"])
 


### PR DESCRIPTION
This PR introduces a new function that consolidates parsing when an unprefixed identifier should be tried to be grounded against RO/BFO.

It also does a bit of renaming to make the diff easier to read