### PR TITLE
Improve root term handling

### DIFF
--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -1105,7 +1105,7 @@ class Obo:
             yield f'property_value: http://purl.org/dc/terms/description "{description}" xsd:string'
 
         for root_term in self.root_terms or []:
-            yield f"property_value: {has_ontology_root_term.preferred_curie} {root_term.preferred_curie}"
+            yield f"property_value: {has_ontology_root_term.preferred_curie} {reference_escape(root_term, ontology_prefix=self.ontology)}"
 
         for typedef in sorted(self.typedefs or []):
             yield from typedef.iterate_obo_lines(ontology_prefix=self.ontology)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -993,7 +993,11 @@ class TestReader(unittest.TestCase):
             [Term]
             id: GO:0050069
         """)
-        self.assertEqual([Reference(prefix="GO", identifier="0050069")], ontology.root_terms)
+        # FIXME support default reference, like property_value: IAO:0000700 adhoc
+        self.assertEqual(
+            [Reference(prefix="GO", identifier="0050069")],
+            ontology.root_terms,
+        )
 
 
 class TestVersionHandling(unittest.TestCase):

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -984,6 +984,17 @@ class TestReader(unittest.TestCase):
         self.assertIsNotNone(context.contributor)
         self.assertEqual("0000-0003-4423-4370", context.contributor.identifier)
 
+    def test_root(self) -> None:
+        """Test root terms."""
+        ontology = _read("""\
+            ontology: go
+            property_value: IAO:0000700 GO:0050069
+
+            [Term]
+            id: GO:0050069
+        """)
+        self.assertEqual([Reference(prefix="GO", identifier="0050069")], ontology.root_terms)
+
 
 class TestVersionHandling(unittest.TestCase):
     """Test version handling."""


### PR DESCRIPTION
1. Fix bug to output correctly normalized "default" references
2. Add reading for property values with custom handling for root terms
3. Still TODO - handle reading "default" references