### PR TITLE
Add turtle export

### DIFF
--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -235,3 +235,11 @@ def _parse_identifier(
 unspecified_matching = Reference(
     prefix="semapv", identifier="UnspecifiedMatching", name="unspecified matching process"
 )
+
+
+def turtle_reference_escape(reference: Reference) -> str:
+    """Escape a reference for writing in turtle."""
+    if reference.prefix == "obo":
+        return f"<http://purl.obolibrary.org/obo/{reference.identifier}>"
+    else:
+        return reference.preferred_curie

--- a/src/pyobo/struct/utils.py
+++ b/src/pyobo/struct/utils.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from typing import TypeAlias
+
 __all__ = [
     "OBO_ESCAPE",
     "OBO_ESCAPE_SLIM",
+    "TurtlePredicates",
     "obo_escape",
     "obo_escape_slim",
+    "turtle_predicates_to_lines",
 ]
 
 OBO_ESCAPE_SLIM = {c: f"\\{c}" for c in ':,"\\()[]{}'}
@@ -23,3 +28,45 @@ def obo_escape_slim(string: str) -> str:
     rv = "".join(OBO_ESCAPE_SLIM.get(character, character) for character in string)
     rv = rv.replace("\n", "\\n")
     return rv
+
+
+def turtle_quote(s: str) -> str:
+    """Escape a string and quote it for turtle."""
+    return f'"{_turtle_escape(s)}"'
+
+
+def _turtle_escape(s: str) -> str:
+    return s.replace('"', '\\"')
+
+
+TurtlePredicates: TypeAlias = list[tuple[str, str | list[str]]]
+
+
+def turtle_predicates_to_lines(identifier, turtle_predicates: TurtlePredicates) -> Iterable[str]:
+    """Yield lines from turtle predicates."""
+    if len(turtle_predicates) == 0:
+        raise ValueError
+    elif len(turtle_predicates) == 1:
+        pred, values = turtle_predicates[0]
+        if isinstance(values, list) and len(values) == 1:
+            values = values[0]
+        if isinstance(values, str):
+            pass
+        else:
+            ", ".join(values)
+        yield f"{identifier} {pred} {values} ."
+    else:
+        first, *middles, last = turtle_predicates
+        yield f"{identifier} {first[0]} {_handle_os(first[1])} ;"
+        for pred, values in middles:
+            yield f"    {pred} {_handle_os(values)} ;"
+        yield f"    {last[0]} {_handle_os(last[1])} ."
+
+
+def _handle_os(values: str | list[str]) -> str:
+    if isinstance(values, list) and len(values) == 1:
+        values = values[0]
+    if isinstance(values, str):
+        return values
+    else:
+        return ", ".join(values)

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -153,6 +153,13 @@ class TestTerm(unittest.TestCase):
             """,
             term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
         )
+        self.assert_lines(
+            """\
+            GO:0050069 a owl:Class ;
+                rdfs:label "lysine dehydrogenase activity"^^xsd:string .
+            """,
+            term.iterate_turtle_lines(),
+        )
 
     def test_property_literal(self) -> None:
         """Test emitting property literals."""
@@ -166,6 +173,14 @@ class TestTerm(unittest.TestCase):
             property_value: RO:1234567 "value" xsd:string
             """,
             term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
+        )
+        self.assert_lines(
+            """\
+            GO:0050069 a owl:Class ;
+                rdfs:label "lysine dehydrogenase activity"^^xsd:string ;
+                RO:1234567 "value"^^xsd:string .
+            """,
+            term.iterate_turtle_lines(),
         )
 
     def test_property_object(self) -> None:
@@ -195,6 +210,37 @@ class TestTerm(unittest.TestCase):
             """,
             term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
+        self.assert_lines(
+            """\
+            GO:0050069 a owl:Class ;
+                rdfs:label "lysine dehydrogenase activity"^^xsd:string ;
+                rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty RO:1234567 ; owl:someValuesFrom eccode:1.4.1.15 ] .
+            """,
+            term.iterate_turtle_lines(),
+        )
+
+    def test_relation_instance(self) -> None:
+        """Test emitting a relationship from an instance."""
+        # note that this test isn't realistic since this should be a class
+        term = Term(LYSINE_DEHYDROGENASE_ACT, type="Instance")
+        term.append_relationship(RO_DUMMY, Reference(prefix="eccode", identifier="1.4.1.15"))
+        self.assert_lines(
+            """\
+            [Instance]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            relationship: RO:1234567 eccode:1.4.1.15
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+        )
+        self.assert_lines(
+            """\
+            GO:0050069 a owl:NamedIndividual ;
+                rdfs:label "lysine dehydrogenase activity"^^xsd:string ;
+                RO:1234567 eccode:1.4.1.15 .
+            """,
+            term.iterate_turtle_lines(),
+        )
 
     def test_xref(self) -> None:
         """Test emitting a relationship."""
@@ -208,6 +254,14 @@ class TestTerm(unittest.TestCase):
             xref: eccode:1.4.1.15
             """,
             term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+        )
+        self.assert_lines(
+            """\
+            GO:0050069 a owl:Class ;
+                rdfs:label "lysine dehydrogenase activity"^^xsd:string ;
+                oboInOwl:hasDbXref eccode:1.4.1.15 .
+            """,
+            term.iterate_turtle_lines(),
         )
 
         ontology = _ontology_from_term("go", term)
@@ -234,6 +288,13 @@ class TestTerm(unittest.TestCase):
             """,
             term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
+        self.assert_lines(
+            """\
+            GO:0050069 rdfs:subClassOf GO:1234568 ;
+                rdfs:label "lysine dehydrogenase activity"^^xsd:string .
+            """,
+            term.iterate_turtle_lines(),
+        )
 
     def test_append_exact_match(self) -> None:
         """Test emitting a relationship."""
@@ -249,6 +310,14 @@ class TestTerm(unittest.TestCase):
             property_value: skos:exactMatch eccode:1.4.1.15 ! exact match lysine dehydrogenase
             """,
             term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+        )
+        self.assert_lines(
+            """\
+            GO:0050069 a owl:Class ;
+                rdfs:label "lysine dehydrogenase activity"^^xsd:string ;
+                skos:exactMatch eccode:1.4.1.15 .
+            """,
+            term.iterate_turtle_lines(),
         )
 
         ontology = _ontology_from_term("go", term)
@@ -275,6 +344,14 @@ class TestTerm(unittest.TestCase):
             """,
             term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
+        self.assert_lines(
+            """\
+            GO:0050069 a owl:Class ;
+                rdfs:label "lysine dehydrogenase activity"^^xsd:string ;
+                skos:exactMatch eccode:1.4.1.15 .
+            """,
+            term.iterate_turtle_lines(),
+        )
 
         term = Term(LYSINE_DEHYDROGENASE_ACT)
         term.annotate_object(
@@ -290,6 +367,14 @@ class TestTerm(unittest.TestCase):
             """,
             term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
+        self.assert_lines(
+            """\
+            GO:0050069 a owl:Class ;
+                rdfs:label "lysine dehydrogenase activity"^^xsd:string ;
+                skos:exactMatch eccode:1.4.1.15 .
+            """,
+            term.iterate_turtle_lines(),
+        )
 
     def test_set_species(self) -> None:
         """Test emitting a relationship."""
@@ -303,6 +388,14 @@ class TestTerm(unittest.TestCase):
             relationship: RO:0002162 NCBITaxon:9606 ! in taxon Homo sapiens
             """,
             term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+        )
+        self.assert_lines(
+            """\
+            GO:0050069 a owl:Class ;
+                rdfs:label "lysine dehydrogenase activity"^^xsd:string ;
+                rdfs:subClassOf [ rdf:type owl:Restriction ; owl:onProperty RO:0002162 ; owl:someValuesFrom NCBITaxon:9606 ] .
+            """,
+            term.iterate_turtle_lines(),
         )
 
         species = term.get_species()


### PR DESCRIPTION
This PR adds Turtle RDF export for ontologies. 

This is necessary because the OWLAPI does not allow conversion to or from OBO files containing `[Instance]` stanzas. This feature was requested in https://github.com/owlcs/owlapi/issues/208 in 2014.

This is a problem for ontologizations of databases like ORCID, ROR, NLM Catalog, and GeoNames where the records all correspond to instances. This also affects other ontologies that use instances in an ad-hoc way, such as VO.