### PR TITLE
Improve type annotations for synonym specificity

### DIFF
--- a/src/pyobo/obographs.py
+++ b/src/pyobo/obographs.py
@@ -8,8 +8,6 @@ from collections.abc import Iterable
 import bioregistry
 import curies
 from bioontologies.obograph import (
-    OBO_SYNONYM_TO_OIO,
-    OIO_TO_REFERENCE,
     Definition,
     Edge,
     Graph,
@@ -94,7 +92,7 @@ def _get_class_node(term: Term) -> Node:
     synonyms = [
         Synonym.from_parsed(
             name=synonym.name,
-            predicate=OIO_TO_REFERENCE[OBO_SYNONYM_TO_OIO[synonym.specificity or "EXACT"]],
+            predicate=synonym.predicate,
             synonym_type=_rewire(synonym.type) if synonym.type else None,
             references=[_rewire(x) for x in synonym.provenance],
         )

--- a/src/pyobo/reader_utils.py
+++ b/src/pyobo/reader_utils.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import logging
+import typing as t
 from collections import Counter
 from collections.abc import Mapping
 
 from curies import ReferenceTuple
+from curies import vocabulary as v
 
-from pyobo.struct import SynonymSpecificities, SynonymSpecificity
 from pyobo.struct.reference import _parse_identifier
 from pyobo.struct.struct import Reference, SynonymTypeDef, _synonym_typedef_warn
 
@@ -17,9 +18,9 @@ logger = logging.getLogger(__name__)
 TARGET_URI_WARNINGS: Counter[tuple[str, str]] = Counter()
 
 
-def _chomp_specificity(s: str) -> tuple[SynonymSpecificity | None, str]:
+def _chomp_specificity(s: str) -> tuple[v.SynonymScope | None, str]:
     s = s.strip()
-    for _specificity in SynonymSpecificities:
+    for _specificity in t.get_args(v.SynonymScope):
         if s.startswith(_specificity):
             return _specificity, s[len(_specificity) :].strip()
     return None, s

--- a/src/pyobo/struct/__init__.py
+++ b/src/pyobo/struct/__init__.py
@@ -4,8 +4,6 @@ from .reference import Reference, Referenced, default_reference
 from .struct import (
     Obo,
     Synonym,
-    SynonymSpecificities,
-    SynonymSpecificity,
     SynonymTypeDef,
     Term,
     int_identifier_sort_key,
@@ -38,8 +36,6 @@ __all__ = [
     "Reference",
     "Referenced",
     "Synonym",
-    "SynonymSpecificities",
-    "SynonymSpecificity",
     "SynonymTypeDef",
     "Term",
     "TypeDef",

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -7,7 +7,6 @@ import json
 import logging
 import os
 import sys
-import typing
 import warnings
 from collections import ChainMap, defaultdict
 from collections.abc import Callable, Collection, Iterable, Iterator, Mapping, Sequence
@@ -24,7 +23,6 @@ import curies
 import networkx as nx
 import pandas as pd
 from curies import ReferenceTuple
-from curies.vocabulary import SynonymScope as SynonymSpecificity
 from curies import vocabulary as v
 from more_click import force_option, verbose_option
 from pydantic import BaseModel
@@ -79,8 +77,6 @@ __all__ = [
     "Obo",
     "ReferenceHint",
     "Synonym",
-    "SynonymSpecificities",
-    "SynonymSpecificity",
     "SynonymTypeDef",
     "Term",
     "abbreviation",
@@ -91,8 +87,6 @@ __all__ = [
 
 logger = logging.getLogger(__name__)
 
-#: .. warning:: This will be removed in a future version of PyOBO
-SynonymSpecificities: Sequence[v.SynonymScope] = typing.get_args(SynonymSpecificity)
 DEFAULT_SPECIFICITY: v.SynonymScope = "EXACT"
 
 #: Columns in the SSSOM dataframe


### PR DESCRIPTION
- Update to using `curies` builtins
- Remove unnecessary exports for replaced type hints
