### PR TITLE
Add additional features to parser

### DIFF
--- a/src/pyobo/reader.py
+++ b/src/pyobo/reader.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 import logging
+import typing as t
 from collections import Counter
 from collections.abc import Iterable, Mapping
 from datetime import datetime
+from io import StringIO
 from pathlib import Path
+from textwrap import dedent
 from typing import Any
 
 import bioregistry
 import networkx as nx
 from curies import ReferenceTuple
+from curies.vocabulary import SynonymScope
 from more_itertools import pairwise
 from tqdm.auto import tqdm
 
@@ -35,6 +39,7 @@ from .struct import (
 )
 from .struct.reference import OBOLiteral, _parse_identifier
 from .struct.struct_utils import Annotation, Stanza
+from .struct.typedef import comment as has_comment
 from .struct.typedef import default_typedefs, has_ontology_root_term
 from .utils.misc import STATIC_VERSION_REWRITES, cleanup_version
 
@@ -53,6 +58,7 @@ def from_obo_path(
     strict: bool = True,
     version: str | None,
     upgrade: bool = True,
+    ignore_obsolete: bool = False,
 ) -> Obo:
     """Get the OBO graph from a path."""
     path = Path(path).expanduser().resolve()
@@ -61,7 +67,7 @@ def from_obo_path(
 
         logger.info("[%s] parsing gzipped OBO with obonet from %s", prefix or "<unknown>", path)
         with gzip.open(path, "rt") as file:
-            graph = _read_obo(file, prefix)
+            graph = _read_obo(file, prefix, ignore_obsolete=ignore_obsolete)
     elif path.suffix.endswith(".zip"):
         import io
         import zipfile
@@ -70,11 +76,11 @@ def from_obo_path(
         with zipfile.ZipFile(path) as zf:
             with zf.open(path.name.removesuffix(".zip"), "r") as file:
                 content = file.read().decode("utf-8")
-                graph = _read_obo(io.StringIO(content), prefix)
+                graph = _read_obo(io.StringIO(content), prefix, ignore_obsolete=ignore_obsolete)
     else:
         logger.info("[%s] parsing OBO with obonet from %s", prefix or "<unknown>", path)
         with open(path) as file:
-            graph = _read_obo(file, prefix)
+            graph = _read_obo(file, prefix, ignore_obsolete=ignore_obsolete)
 
     if prefix:
         # Make sure the graph is named properly
@@ -84,7 +90,7 @@ def from_obo_path(
     return from_obonet(graph, strict=strict, version=version, upgrade=upgrade)
 
 
-def _read_obo(filelike, prefix: str | None) -> nx.MultiDiGraph:
+def _read_obo(filelike, prefix: str | None, ignore_obsolete: bool) -> nx.MultiDiGraph:
     import obonet
 
     return obonet.read_obo(
@@ -95,8 +101,7 @@ def _read_obo(filelike, prefix: str | None) -> nx.MultiDiGraph:
             disable=None,
             leave=True,
         ),
-        # TODO this is the default, turn it off and see what happens
-        ignore_obsolete=True,
+        ignore_obsolete=ignore_obsolete,
     )
 
 
@@ -105,6 +110,25 @@ def _normalize_prefix_strict(prefix: str) -> str:
     if n is None:
         raise ValueError(f"unknown prefix: {prefix}")
     return n
+
+
+def from_str(
+    text: str,
+    *,
+    strict: bool = True,
+    version: str | None = None,
+    upgrade: bool = True,
+    ignore_obsolete: bool = False,
+) -> Obo:
+    """Read an ontology from a string representation."""
+    import obonet
+
+    text = dedent(text).strip()
+    io = StringIO()
+    io.write(text)
+    io.seek(0)
+    graph = obonet.read_obo(io, ignore_obsolete=ignore_obsolete)
+    return from_obonet(graph, strict=strict, version=version, upgrade=upgrade)
 
 
 def from_obonet(
@@ -121,6 +145,7 @@ def from_obonet(
 
     date = _get_date(graph=graph, ontology_prefix=ontology_prefix)
     name = _get_name(graph=graph, ontology_prefix=ontology_prefix)
+    imports = graph.graph.get("import")
 
     macro_config = MacroConfig(graph.graph, strict=strict, ontology_prefix=ontology_prefix)
 
@@ -132,27 +157,39 @@ def from_obonet(
             f"[{ontology_prefix}] slashes not allowed in data versions because of filesystem usage: {data_version}"
         )
 
+    missing_typedefs: set[ReferenceTuple] = set()
+
+    subset_typedefs = _get_subsetdefs(graph.graph, ontology_prefix=ontology_prefix)
+
     root_terms: list[Reference] = []
     property_values: list[Annotation] = []
-    for t in iterate_node_properties(
+    for ann in iterate_node_properties(
         graph.graph,
         ontology_prefix=ontology_prefix,
         upgrade=upgrade,
         node=Reference(prefix="obo", identifier=ontology_prefix),
     ):
-        if t.predicate.pair == has_ontology_root_term.pair:
-            match t.value:
+        if ann.predicate.pair == has_ontology_root_term.pair:
+            match ann.value:
                 case OBOLiteral():
                     raise RuntimeError
                 case Reference():
-                    root_terms.append(t.value)
+                    root_terms.append(ann.value)
         else:
-            property_values.append(t)
+            property_values.append(ann)
+
+    for remark in graph.graph.get("remark", []):
+        property_values.append(Annotation(has_comment.reference, OBOLiteral.string(remark)))
+
+    idspaces: dict[str, str] = {}
+    for x in graph.graph.get("idspace", []):
+        prefix, uri_prefix, *_ = (y.strip() for y in x.split(" ", 2))
+        idspaces[prefix] = uri_prefix
 
     #: CURIEs to typedefs
     typedefs: Mapping[ReferenceTuple, TypeDef] = {
         typedef.pair: typedef
-        for typedef in iterate_graph_typedefs(
+        for typedef in iterate_typedefs(
             graph,
             ontology_prefix=ontology_prefix,
             strict=strict,
@@ -171,120 +208,16 @@ def from_obonet(
         )
     }
 
-    missing_typedefs: set[ReferenceTuple] = set()
-    terms = []
-    n_alt_ids, n_parents, n_synonyms, n_relations, n_properties, n_xrefs = 0, 0, 0, 0, 0, 0
-    n_references = 0
-    for reference, data in _iter_obo_graph(
-        graph=graph, strict=strict, ontology_prefix=ontology_prefix
-    ):
-        if reference.prefix != ontology_prefix or not data:
-            continue
-        n_references += 1
-
-        provenance = []
-        definition, definition_references = get_definition(
-            data, node=reference, strict=strict, ontology_prefix=ontology_prefix
-        )
-        provenance.extend(definition_references)
-
-        alt_ids = list(
-            iterate_node_alt_ids(
-                data, node=reference, strict=strict, ontology_prefix=ontology_prefix
-            )
-        )
-        n_alt_ids += len(alt_ids)
-
-        parents = list(
-            iterate_node_parents(
-                data, node=reference, strict=strict, ontology_prefix=ontology_prefix
-            )
-        )
-        n_parents += len(parents)
-
-        synonyms = list(
-            iterate_node_synonyms(
-                data,
-                synonym_typedefs,
-                node=reference,
-                strict=strict,
-                ontology_prefix=ontology_prefix,
-                upgrade=upgrade,
-            )
-        )
-        n_synonyms += len(synonyms)
-
-        term = Term(
-            reference=reference,
-            definition=definition,
-            parents=parents,
-            synonyms=synonyms,
-            provenance=provenance,
-            alt_ids=alt_ids,
-            builtin=_get_boolean(data, "builtin"),
-            is_anonymous=_get_boolean(data, "is_anonymous"),
-            is_obsolete=_get_boolean(data, "is_obsolete"),
-        )
-
-        node_xrefs: list[Reference] = list(
-            iterate_node_xrefs(
-                data=data,
-                strict=strict,
-                ontology_prefix=ontology_prefix,
-                node=reference,
-            )
-        )
-        for node_xref in node_xrefs:
-            _handle_xref(term, node_xref, macro_config=macro_config)
-
-        relations_references = list(
-            iterate_node_relationships(
-                data,
-                node=reference,
-                strict=strict,
-                ontology_prefix=ontology_prefix,
-                upgrade=upgrade,
-            )
-        )
-        for relation, reference in relations_references:
-            if relation.pair in typedefs:
-                typedef = typedefs[relation.pair]
-            elif relation.pair in default_typedefs:
-                typedef = default_typedefs[relation.pair]
-            else:
-                if relation.pair not in missing_typedefs:
-                    missing_typedefs.add(relation.pair)
-                    logger.warning("[%s] has no typedef for %s", ontology_prefix, relation)
-                    logger.debug("[%s] available typedefs: %s", ontology_prefix, set(typedefs))
-                continue
-            n_relations += 1
-            term.append_relationship(typedef, reference)
-
-        for t in iterate_node_properties(
-            data, node=reference, strict=strict, ontology_prefix=ontology_prefix, upgrade=upgrade
-        ):
-            n_properties += 1
-            term.append_property(t)
-
-        if comment := data.get("comment"):
-            term.append_comment(comment)
-
-        for replaced_by in data.get("replaced_by", []):
-            rr = _parse_identifier(
-                replaced_by, ontology_prefix=ontology_prefix, strict=strict, node=reference
-            )
-            if rr is None:
-                continue
-            term.append_replaced_by(rr)
-
-        terms.append(term)
-
-    subset_typedefs = _get_subsetdefs(graph.graph, ontology_prefix=ontology_prefix)
-
-    logger.info(
-        f"[{ontology_prefix}] got {n_references:,} references, {len(typedefs):,} typedefs, {len(terms):,} terms,"
-        f" {n_alt_ids:,} alt ids, {n_parents:,} parents, {n_synonyms:,} synonyms, {n_xrefs:,} xrefs,"
-        f" {n_relations:,} relations, {n_properties:,} properties, and {len(subset_typedefs)} subset typedefs.",
+    terms = _get_terms(
+        graph,
+        strict=strict,
+        ontology_prefix=ontology_prefix,
+        upgrade=upgrade,
+        typedefs=typedefs,
+        missing_typedefs=missing_typedefs,
+        synonym_typedefs=synonym_typedefs,
+        subset_typedefs=subset_typedefs,
+        macro_config=macro_config,
     )
 
     return make_ad_hoc_ontology(
@@ -299,18 +232,260 @@ def from_obonet(
         terms=terms,
         _property_values=property_values,
         _subsetdefs=subset_typedefs,
+        _imports=imports,
+        _idspaces=idspaces,
     )
 
 
-def _get_boolean(data, tag) -> bool | None:
+def _get_terms(
+    graph,
+    *,
+    strict: bool,
+    ontology_prefix: str,
+    upgrade: bool,
+    typedefs: Mapping[ReferenceTuple, TypeDef],
+    synonym_typedefs: Mapping[ReferenceTuple, SynonymTypeDef],
+    subset_typedefs,
+    missing_typedefs: set[ReferenceTuple],
+    macro_config: MacroConfig,
+) -> list[Term]:
+    terms = []
+    for reference, data in _iter_obo_graph(
+        graph=graph, strict=strict, ontology_prefix=ontology_prefix
+    ):
+        if reference.prefix != ontology_prefix:
+            continue
+        if not data:
+            # this allows us to skip anything that isn't really defined
+            # caveat: this misses terms that are just defined with an ID
+            continue
+
+        provenance = []
+        definition, definition_references = get_definition(
+            data, node=reference, strict=strict, ontology_prefix=ontology_prefix
+        )
+        provenance.extend(definition_references)
+
+        term = Term(
+            reference=reference,
+            definition=definition,
+            provenance=provenance,
+            builtin=_get_boolean(data, "builtin"),
+            is_anonymous=_get_boolean(data, "is_anonymous"),
+            is_obsolete=_get_boolean(data, "is_obsolete"),
+            namespace=data.get("namespace"),
+        )
+        _process_alts(term, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_parents(term, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_synonyms(
+            term,
+            data,
+            ontology_prefix=ontology_prefix,
+            strict=strict,
+            upgrade=upgrade,
+            synonym_typedefs=synonym_typedefs,
+        )
+        _process_xrefs(
+            term, data, ontology_prefix=ontology_prefix, strict=strict, macro_config=macro_config
+        )
+        _process_properties(
+            term,
+            data,
+            ontology_prefix=ontology_prefix,
+            strict=strict,
+            upgrade=upgrade,
+            typedefs=typedefs,
+        )
+        _process_relations(
+            term,
+            data,
+            ontology_prefix=ontology_prefix,
+            strict=strict,
+            upgrade=upgrade,
+            typedefs=typedefs,
+            missing_typedefs=missing_typedefs,
+        )
+        _process_replaced_by(term, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_subsets(term, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_union_of(term, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_equivalent_to(term, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_disjoint_from(term, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_consider(term, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_intersection_of(term, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_comment(term, data, ontology_prefix=ontology_prefix, strict=strict)
+
+        terms.append(term)
+    return terms
+
+
+def _process_comment(term: Stanza, data, *, ontology_prefix: str, strict: bool) -> None:
+    if comment := data.get("comment"):
+        term.append_comment(comment)
+
+
+def _process_union_of(term: Stanza, data, *, ontology_prefix: str, strict: bool) -> None:
+    for reference in iterate_node_reference_tag(
+        "union_of", data=data, ontology_prefix=ontology_prefix, strict=strict, node=term.reference
+    ):
+        term.append_union_of(reference)
+
+
+def _process_equivalent_to(term: Stanza, data, *, ontology_prefix: str, strict: bool) -> None:
+    for reference in iterate_node_reference_tag(
+        "equivalent_to",
+        data=data,
+        ontology_prefix=ontology_prefix,
+        strict=strict,
+        node=term.reference,
+    ):
+        term.append_equivalent_to(reference)
+
+
+def _process_disjoint_from(term: Stanza, data, *, ontology_prefix: str, strict: bool) -> None:
+    for reference in iterate_node_reference_tag(
+        "disjoint_from",
+        data=data,
+        ontology_prefix=ontology_prefix,
+        strict=strict,
+        node=term.reference,
+    ):
+        term.append_disjoint_from(reference)
+
+
+def _process_alts(term: Stanza, data, *, ontology_prefix: str, strict: bool) -> None:
+    for alt_reference in iterate_node_reference_tag(
+        "alt_id", data, node=term.reference, strict=strict, ontology_prefix=ontology_prefix
+    ):
+        term.append_alt(alt_reference)
+
+
+def _process_parents(term: Stanza, data, *, ontology_prefix: str, strict: bool) -> None:
+    for tag in ["is_a", "instance_of"]:
+        for parent in iterate_node_reference_tag(
+            tag, data, node=term.reference, strict=strict, ontology_prefix=ontology_prefix
+        ):
+            term.append_parent(parent)
+
+
+def _process_synonyms(
+    term: Stanza,
+    data,
+    *,
+    ontology_prefix: str,
+    strict: bool,
+    upgrade: bool,
+    synonym_typedefs: Mapping[ReferenceTuple, SynonymTypeDef],
+) -> None:
+    synonyms = list(
+        iterate_node_synonyms(
+            data,
+            synonym_typedefs,
+            node=term.reference,
+            strict=strict,
+            ontology_prefix=ontology_prefix,
+            upgrade=upgrade,
+        )
+    )
+    for synonym in synonyms:
+        term.append_synonym(synonym)
+
+
+def _process_xrefs(
+    term: Stanza,
+    data,
+    *,
+    ontology_prefix: str,
+    strict: bool,
+    macro_config: MacroConfig,
+) -> None:
+    node_xrefs: list[Reference] = list(
+        iterate_node_xrefs(
+            data=data,
+            strict=strict,
+            ontology_prefix=ontology_prefix,
+            node=term.reference,
+        )
+    )
+    for node_xref in node_xrefs:
+        _handle_xref(term, node_xref, macro_config=macro_config)
+
+
+def _process_properties(
+    term: Stanza, data, *, ontology_prefix: str, strict: bool, upgrade: bool, typedefs
+) -> None:
+    for ann in iterate_node_properties(
+        data, node=term.reference, strict=strict, ontology_prefix=ontology_prefix, upgrade=upgrade
+    ):
+        term.append_property(ann)
+
+
+def _process_relations(
+    term: Stanza,
+    data,
+    *,
+    ontology_prefix: str,
+    strict: bool,
+    upgrade: bool,
+    typedefs: Mapping[ReferenceTuple, TypeDef],
+    missing_typedefs: set[ReferenceTuple],
+) -> None:
+    relations_references = list(
+        iterate_node_relationships(
+            data,
+            node=term.reference,
+            strict=strict,
+            ontology_prefix=ontology_prefix,
+            upgrade=upgrade,
+        )
+    )
+    for relation, reference in relations_references:
+        if (
+            relation.pair not in typedefs
+            and relation.pair not in default_typedefs
+            and relation.pair not in missing_typedefs
+        ):
+            missing_typedefs.add(relation.pair)
+            logger.warning("[%s] has no typedef for %s", ontology_prefix, relation)
+            logger.debug("[%s] available typedefs: %s", ontology_prefix, set(typedefs))
+        term.append_relationship(relation, reference)
+
+
+def _process_replaced_by(stanza: Stanza, data, *, ontology_prefix: str, strict: bool) -> None:
+    for reference in iterate_node_reference_tag(
+        "replaced_by", data, node=stanza.reference, strict=strict, ontology_prefix=ontology_prefix
+    ):
+        stanza.append_replaced_by(reference)
+
+
+def _process_subsets(stanza: Stanza, data, *, ontology_prefix: str, strict: bool) -> None:
+    for reference in iterate_node_reference_tag(
+        "subset", data, node=stanza.reference, strict=strict, ontology_prefix=ontology_prefix
+    ):
+        stanza.append_subset(reference)
+
+
+def _get_boolean(data: Mapping[str, Any], tag: str) -> bool | None:
     value = data.get(tag)
     if value is None:
         return None
+    if isinstance(value, list):
+        value = value[0]
     if value == "false":
         return False
     if value == "true":
         return True
     raise ValueError(value)
+
+
+def _get_reference(
+    data: Mapping[str, Any], tag: str, *, ontology_prefix: str, strict: bool, **kwargs
+) -> Reference | None:
+    value = data.get(tag)
+    if value is None:
+        return None
+    if isinstance(value, list):
+        value = value[0]
+    return _parse_identifier(value, ontology_prefix=ontology_prefix, strict=strict, **kwargs)
 
 
 class MacroConfig:
@@ -330,7 +505,7 @@ class MacroConfig:
                 continue
             self.treat_xrefs_as_equivalent.add(prefix_norm)
 
-        self.treat_xrefs_as_genus_differentia: dict[str, Annotation] = {}
+        self.treat_xrefs_as_genus_differentia: dict[str, tuple[Reference, Reference]] = {}
         for line in data.get("treat-xrefs-as-genus-differentia", []):
             gd_prefix, gd_predicate, gd_target = line.split()
             gd_prefix_norm = bioregistry.normalize_prefix(gd_prefix)
@@ -346,9 +521,7 @@ class MacroConfig:
             )
             if gd_target_re is None:
                 continue
-            self.treat_xrefs_as_genus_differentia[gd_prefix_norm] = Annotation(
-                gd_predicate_re, gd_target_re
-            )
+            self.treat_xrefs_as_genus_differentia[gd_prefix_norm] = (gd_predicate_re, gd_target_re)
 
         self.treat_xrefs_as_relationship: dict[str, Reference] = {}
         for line in data.get("treat-xrefs-as-relationship", []):
@@ -398,7 +571,7 @@ def _get_subsetdefs(graph: nx.MultiDiGraph, ontology_prefix: str) -> list[tuple[
         if not right:
             logger.warning("[%s] subsetdef did not have two parts", ontology_prefix, subsetdef)
             continue
-        left_ref = _parse_identifier(left, ontology_prefix=ontology_prefix)
+        left_ref = _parse_identifier(left, ontology_prefix=ontology_prefix, name=right)
         if left_ref is None:
             logger.warning(
                 "[%s] subsetdef identifier could not be parsed", ontology_prefix, subsetdef
@@ -511,25 +684,34 @@ def iterate_graph_synonym_typedefs(
 ) -> Iterable[SynonymTypeDef]:
     """Get synonym type definitions from an :mod:`obonet` graph."""
     for line in graph.graph.get("synonymtypedef", []):
-        synonym_typedef_id, name = line.split(" ", 1)
+        # TODO handle trailing comments
+        line, _, specificity = (x.strip() for x in line.rpartition('"'))
+        if not specificity:
+            specificity = None
+        elif specificity not in t.get_args(SynonymScope):
+            if strict:
+                raise ValueError(f"invalid synonym specificty: {specificity}")
+            logger.warning("[%s] invalid synonym specificty: %s", ontology_prefix, specificity)
+            specificity = None
+
+        curie, name = line.split(" ", 1)
+        # the name should be in quotes, so strip them out
         name = name.strip().strip('"')
+        # TODO unquote the string?
         reference = _parse_identifier(
-            synonym_typedef_id,
+            curie,
             ontology_prefix=ontology_prefix,
             name=name,
             upgrade=upgrade,
             strict=strict,
         )
         if reference is None:
-            logger.warning(
-                "[%s] unable to parse synonym typedef ID %s", ontology_prefix, synonym_typedef_id
-            )
+            logger.warning("[%s] unable to parse synonym typedef ID %s", ontology_prefix, curie)
             continue
-        # TODO handle specificity
-        yield SynonymTypeDef(reference=reference)
+        yield SynonymTypeDef(reference=reference, specificity=specificity)
 
 
-def iterate_graph_typedefs(
+def iterate_typedefs(
     graph: nx.MultiDiGraph,
     *,
     ontology_prefix: str,
@@ -538,15 +720,21 @@ def iterate_graph_typedefs(
     macro_config: MacroConfig | None = None,
 ) -> Iterable[TypeDef]:
     """Get type definitions from an :mod:`obonet` graph."""
-    for typedef in graph.graph.get("typedefs", []):
-        if "id" in typedef:
-            typedef_id = typedef["id"]
-        elif "identifier" in typedef:
-            typedef_id = typedef["identifier"]
+    if macro_config is None:
+        macro_config = MacroConfig(strict=strict, ontology_prefix=ontology_prefix)
+    # can't really have a pre-defined set of synonym typedefs here!
+    synonym_typedefs: Mapping[ReferenceTuple, SynonymTypeDef] = {}
+    typedefs: Mapping[ReferenceTuple, TypeDef] = {}
+    missing_typedefs: set[ReferenceTuple] = set()
+    for data in graph.graph.get("typedefs", []):
+        if "id" in data:
+            typedef_id = data["id"]
+        elif "identifier" in data:
+            typedef_id = data["identifier"]
         else:
             raise KeyError("typedef is missing an `id`")
 
-        name = typedef.get("name")
+        name = data.get("name")
         if name is None:
             logger.debug("[%s] typedef %s is missing a name", ontology_prefix, typedef_id)
 
@@ -557,24 +745,151 @@ def iterate_graph_typedefs(
             logger.warning("[%s] unable to parse typedef ID %s", ontology_prefix, typedef_id)
             continue
 
-        yv = TypeDef(reference=reference)
+        typedef = TypeDef(
+            reference=reference,
+            namespace=data.get("namespace"),
+            is_metadata_tag=_get_boolean(data, "is_metadata_tag"),
+            is_class_level=_get_boolean(data, "is_class_level"),
+            builtin=_get_boolean(data, "builtin"),
+            is_obsolete=_get_boolean(data, "is_obsolete"),
+            is_anonymous=_get_boolean(data, "is_anonymous"),
+            is_anti_symmetric=_get_boolean(data, "is_anti_symmetric"),
+            is_symmetric=_get_boolean(data, "is_symmetric"),
+            is_reflexive=_get_boolean(data, "is_reflexive"),
+            is_cyclic=_get_boolean(data, "is_cyclic"),
+            is_transitive=_get_boolean(data, "is_transitive"),
+            is_functional=_get_boolean(data, "is_functional"),
+            is_inverse_functional=_get_boolean(data, "is_inverse_functional"),
+            domain=_get_reference(data, "domain", ontology_prefix=ontology_prefix, strict=strict),
+            range=_get_reference(data, "range", ontology_prefix=ontology_prefix, strict=strict),
+            inverse=_get_reference(
+                data, "inverse_of", ontology_prefix=ontology_prefix, strict=strict
+            ),
+        )
+        _process_alts(typedef, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_parents(typedef, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_synonyms(
+            typedef,
+            data,
+            ontology_prefix=ontology_prefix,
+            strict=strict,
+            upgrade=upgrade,
+            synonym_typedefs=synonym_typedefs,
+        )
+        _process_xrefs(
+            typedef, data, ontology_prefix=ontology_prefix, strict=strict, macro_config=macro_config
+        )
+        _process_properties(
+            typedef,
+            data,
+            ontology_prefix=ontology_prefix,
+            strict=strict,
+            upgrade=upgrade,
+            typedefs=typedefs,
+        )
+        _process_relations(
+            typedef,
+            data,
+            ontology_prefix=ontology_prefix,
+            strict=strict,
+            upgrade=upgrade,
+            typedefs=typedefs,
+            missing_typedefs=missing_typedefs,
+        )
+        _process_replaced_by(typedef, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_subsets(typedef, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_intersection_of(typedef, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_union_of(typedef, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_equivalent_to(typedef, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_parents(typedef, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_holds_over_chain(typedef, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_equivalent_to_chain(typedef, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_disjoint_from(typedef, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_consider(typedef, data, ontology_prefix=ontology_prefix, strict=strict)
+        _process_comment(typedef, data, ontology_prefix=ontology_prefix, strict=strict)
 
-        for xref_curie in typedef.get("xref", []):
-            _xref = Reference.from_curie_or_uri(
-                xref_curie,
-                strict=strict,
+        typedef.disjoint_over.extend(
+            iterate_node_reference_tag(
+                "disjoint_over",
+                data,
+                node=typedef.reference,
                 ontology_prefix=ontology_prefix,
-                node=reference,
+                strict=strict,
             )
-            if not _xref:
-                continue
-            _handle_xref(
-                yv,
-                _xref,
-                macro_config=macro_config,
+        )
+        typedef.transitive_over.extend(
+            iterate_node_reference_tag(
+                "transitive_over",
+                data,
+                node=typedef.reference,
+                ontology_prefix=ontology_prefix,
+                strict=strict,
             )
+        )
 
-        yield yv
+        yield typedef
+
+
+def _process_consider(stanza: Stanza, data, *, ontology_prefix: str, strict: bool = True):
+    for reference in iterate_node_reference_tag(
+        "consider",
+        data,
+        node=stanza.reference,
+        ontology_prefix=ontology_prefix,
+        strict=strict,
+    ):
+        stanza.append_see_also(reference)
+
+
+def _process_equivalent_to_chain(
+    typedef: TypeDef, data, *, ontology_prefix: str, strict: bool = True
+) -> None:
+    for chain in _iterate_chain(
+        "equivalent_to_chain", typedef, data, ontology_prefix=ontology_prefix, strict=strict
+    ):
+        typedef.equivalent_to_chain.append(chain)
+
+
+def _process_holds_over_chain(
+    typedef: TypeDef, data, *, ontology_prefix: str, strict: bool = True
+) -> None:
+    for chain in _iterate_chain(
+        "holds_over_chain", typedef, data, ontology_prefix=ontology_prefix, strict=strict
+    ):
+        typedef.holds_over_chain.append(chain)
+
+
+def _iterate_chain(
+    tag: str, typedef: TypeDef, data, *, ontology_prefix: str, strict: bool = True
+) -> Iterable[list[Reference]]:
+    for chain in data.get(tag, []):
+        # chain is a list of CURIEs
+        predicate_chain = _process_chain_helper(typedef, chain, ontology_prefix=ontology_prefix)
+        if predicate_chain is None:
+            logger.warning(
+                "[%s - %s] could not parse line: %s: %s",
+                ontology_prefix,
+                typedef.preferred_curie,
+                tag,
+                chain,
+            )
+        else:
+            yield predicate_chain
+
+
+def _process_chain_helper(
+    term: Stanza, chain: str, ontology_prefix: str, strict: bool = True
+) -> list[Reference] | None:
+    rv = []
+    for curie in chain.split():
+        curie = curie.strip()
+        r = _parse_identifier(
+            curie, ontology_prefix=ontology_prefix, strict=strict, node=term.reference
+        )
+        if r is None:
+            return None
+        rv.append(r)
+    return rv
 
 
 def get_definition(
@@ -852,34 +1167,67 @@ def _get_prop(
     )
 
 
-def iterate_node_parents(
+def iterate_node_reference_tag(
+    tag: str,
     data: Mapping[str, Any],
     *,
     node: Reference,
     strict: bool = True,
     ontology_prefix: str,
+    upgrade: bool = True,
 ) -> Iterable[Reference]:
-    """Extract parents from a :mod:`obonet` node's data."""
-    for parent_curie in data.get("is_a", []):
-        reference = Reference.from_curie_or_uri(
-            parent_curie, strict=strict, ontology_prefix=ontology_prefix, node=node
+    """Extract a list of CURIEs from the data."""
+    for identifier in data.get(tag, []):
+        reference = _parse_identifier(
+            identifier, strict=strict, node=node, ontology_prefix=ontology_prefix, upgrade=upgrade
         )
         if reference is None:
-            logger.warning("[%s] could not parse parent curie: %s", node.curie, parent_curie)
-            continue
-        yield reference
-
-
-def iterate_node_alt_ids(
-    data: Mapping[str, Any], *, node: Reference, strict: bool = True, ontology_prefix: str | None
-) -> Iterable[Reference]:
-    """Extract alternate identifiers from a :mod:`obonet` node's data."""
-    for curie in data.get("alt_id", []):
-        reference = Reference.from_curie_or_uri(
-            curie, strict=strict, node=node, ontology_prefix=ontology_prefix
-        )
-        if reference is not None:
+            logger.warning(
+                "[%] %s - could not parse identifier: %s", ontology_prefix, tag, identifier
+            )
+        else:
             yield reference
+
+
+def _process_intersection_of(
+    term: Stanza,
+    data: Mapping[str, Any],
+    *,
+    strict: bool = True,
+    ontology_prefix: str,
+    upgrade: bool = True,
+) -> None:
+    """Extract a list of CURIEs from the data."""
+    for line in data.get("intersection_of", []):
+        predicate_id, _, target_id = line.partition(" ")
+        predicate = _parse_identifier(
+            predicate_id,
+            strict=strict,
+            node=term.reference,
+            ontology_prefix=ontology_prefix,
+            upgrade=upgrade,
+        )
+        if predicate is None:
+            logger.warning("[%] %s - could not parse intersection_of: %s", ontology_prefix, line)
+            continue
+
+        if target_id:
+            # this means that there's a second part, so let's try parsing it
+            target = _parse_identifier(
+                target_id,
+                strict=strict,
+                node=term.reference,
+                ontology_prefix=ontology_prefix,
+                upgrade=upgrade,
+            )
+            if target is None:
+                logger.warning(
+                    "[%] could not parse intersection_of target: %s", ontology_prefix, line
+                )
+                continue
+            term.append_intersection_of(predicate, target)
+        else:
+            term.append_intersection_of(predicate)
 
 
 def iterate_node_relationships(
@@ -918,7 +1266,7 @@ def iterate_node_xrefs(
     *,
     data: Mapping[str, Any],
     strict: bool = True,
-    ontology_prefix: str | None,
+    ontology_prefix: str,
     node: Reference,
 ) -> Iterable[Reference]:
     """Extract xrefs from a :mod:`obonet` node's data."""

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -862,10 +862,12 @@ class Obo:
             if _yv_name := bioregistry.get_name(prefix):
                 yv += f' "{_yv_name}"'
             yield yv
-        # 12 TODO treat-xrefs-as-equivalent
-        # 13 TODO treat-xrefs-as-genus-differentia
-        # 14 TODO treat-xrefs-as-relationship
-        # 15 TODO treat-xrefs-as-is_a
+        # 12-15 are handled only during reading, and
+        # PyOBO unmacros things before outputting
+        # 12 treat-xrefs-as-equivalent
+        # 13 treat-xrefs-as-genus-differentia
+        # 14 treat-xrefs-as-relationship
+        # 15 treat-xrefs-as-is_a
         # 16 TODO remark
         # 17
         yield f"ontology: {self.ontology}"

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -164,10 +164,14 @@ class Synonym:
     ) -> str:
         if synonym_typedefs is None:
             synonym_typedefs = {}
-        _synonym_typedef_warn(ontology_prefix, self.type, synonym_typedefs)
-        # TODO inherit specificity from typedef?
-        # TODO validation of specificity against typedef
-        x = f'"{self._escape(self.name)}" {self.specificity or DEFAULT_SPECIFICITY}'
+        std = _synonym_typedef_warn(ontology_prefix, self.type, synonym_typedefs)
+        if std is not None and std.specificity is not None:
+            specificity = std.specificity
+        elif self.specificity:
+            specificity = self.specificity
+        else:
+            specificity = DEFAULT_SPECIFICITY
+        x = f'"{self._escape(self.name)}" {specificity}'
         if self.type is not None:
             x = f"{x} {reference_escape(self.type, ontology_prefix=ontology_prefix)}"
         return f"{x} [{comma_separate_references(self.provenance)}]"

--- a/src/pyobo/struct/struct_utils.py
+++ b/src/pyobo/struct/struct_utils.py
@@ -51,6 +51,7 @@ PropertiesHint: TypeAlias = dict[Reference, list[Reference | OBOLiteral]]
 RelationsHint: TypeAlias = dict[Reference, list[Reference]]
 AxiomsHint: TypeAlias = dict[Annotation, list[Annotation]]
 IntersectionOfHint: TypeAlias = list[Reference | Annotation]
+UnionOfHint: TypeAlias = list[Reference]
 
 
 class Stanza:
@@ -62,6 +63,8 @@ class Stanza:
     parents: list[Reference]
     provenance: list[Reference]
     intersection_of: IntersectionOfHint
+    equivalent_to: list[Reference]
+    union_of: UnionOfHint
     _axioms: AxiomsHint
 
     def append_relationship(
@@ -155,6 +158,16 @@ class Stanza:
             self.intersection_of.append(reference)
         else:
             self.intersection_of.append(_ensure_ref(reference))
+        return self
+
+    def append_union_of(self, reference: ReferenceHint) -> Self:
+        """Append to the "union of" list."""
+        self.union_of.append(_ensure_ref(reference))
+        return self
+
+    def append_equivalent_to(self, reference: ReferenceHint) -> Self:
+        """Append to the "equivalent to" list."""
+        self.equivalent_to.append(_ensure_ref(reference))
         return self
 
     def _iterate_intersection_of_obo(self, *, ontology_prefix: str) -> Iterable[str]:

--- a/src/pyobo/struct/struct_utils.py
+++ b/src/pyobo/struct/struct_utils.py
@@ -370,16 +370,10 @@ class Stanza:
             )
         self.synonyms.append(synonym)
 
-    def append_alt(self, alt: str | Reference) -> None:
+    def append_alt(self, alt: Reference) -> Self:
         """Add an alternative identifier."""
-        if isinstance(alt, str):
-            warnings.warn(
-                "use fully qualified reference when appending alts",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            alt = Reference(prefix=self.reference.prefix, identifier=alt)
         self.alt_ids.append(alt)
+        return self
 
     def append_see_also(self, reference: ReferenceHint) -> Self:
         """Add a see also property."""

--- a/src/pyobo/struct/struct_utils.py
+++ b/src/pyobo/struct/struct_utils.py
@@ -377,7 +377,6 @@ class Stanza:
         if isinstance(type, Referenced):
             type = type.reference
         if isinstance(synonym, str):
-            # FIXME resolve circular dep
             from pyobo.struct.struct import Synonym
 
             synonym = Synonym(

--- a/src/pyobo/struct/typedef.py
+++ b/src/pyobo/struct/typedef.py
@@ -26,6 +26,7 @@ from .struct_utils import (
     RelationsHint,
     Stanza,
     _chain_tag,
+    _tag_property_targets,
 )
 from .utils import _boolean_tag
 from ..resources.ro import load_ro
@@ -93,7 +94,7 @@ class TypeDef(Referenced, Stanza):
     is_anonymous: Annotated[bool | None, 2] = None
     # 3 - name is covered by reference
     namespace: Annotated[str | None, 4] = None
-    alt_id: Annotated[list[Reference], 5] = field(default_factory=list)
+    alt_ids: Annotated[list[Reference], 5] = field(default_factory=list)
     definition: Annotated[str | None, 6] = None
     comment: Annotated[str | None, 7] = None
     subsets: Annotated[list[Reference], 8] = field(default_factory=list)
@@ -104,7 +105,9 @@ class TypeDef(Referenced, Stanza):
     domain: Annotated[Reference | None, 12, "typedef-only"] = None
     range: Annotated[Reference | None, 13, "typedef-only"] = None
     builtin: Annotated[bool | None, 14] = None
-    holds_over_chain: Annotated[list[Reference] | None, 15, "typedef-only"] = None
+    holds_over_chain: Annotated[list[list[Reference]], 15, "typedef-only"] = field(
+        default_factory=list
+    )
     is_anti_symmetric: Annotated[bool | None, 16, "typedef-only"] = None
     is_cyclic: Annotated[bool | None, 17, "typedef-only"] = None
     is_reflexive: Annotated[bool | None, 18, "typedef-only"] = None
@@ -121,7 +124,7 @@ class TypeDef(Referenced, Stanza):
     inverse: Annotated[Reference | None, 28, "typedef-only"] = None
     # TODO check if there are any examples of this being multiple
     transitive_over: Annotated[list[Reference], 29, "typedef-only"] = field(default_factory=list)
-    equivalent_to_chain: Annotated[list[Reference], 30, "typedef-only"] = field(
+    equivalent_to_chain: Annotated[list[list[Reference]], 30, "typedef-only"] = field(
         default_factory=list
     )
     #: From the OBO spec:
@@ -129,13 +132,11 @@ class TypeDef(Referenced, Stanza):
     #:   For example: spatially_disconnected_from is disjoint_over part_of, in that two
     #:   disconnected entities have no parts in common. This can be translated to OWL as:
     #:   ``disjoint_over(R S), R(A B) ==> (S some A) disjointFrom (S some B)``
-    disjoint_over: Annotated[Reference | None, 31] = None
+    disjoint_over: Annotated[list[Reference], 31] = field(default_factory=list)
     relationships: Annotated[RelationsHint, 32] = field(default_factory=lambda: defaultdict(list))
     is_obsolete: Annotated[bool | None, 33] = None
     created_by: Annotated[str | None, 34] = None
     creation_date: Annotated[datetime.datetime | None, 35] = None
-    replaced_by: Annotated[list[Reference], 36] = field(default_factory=list)
-    consider: Annotated[list[Reference], 37] = field(default_factory=list)
     # TODO expand_assertion_to
     # TODO expand_expression_to
     #: Whether this relationship is a metadata tag. Properties that are marked as metadata tags are
@@ -220,7 +221,7 @@ class TypeDef(Referenced, Stanza):
         if self.namespace:
             yield f"namespace: {self.namespace}"
         # 5
-        yield from _reference_list_tag("alt_id", self.alt_id, ontology_prefix)
+        yield from _reference_list_tag("alt_id", self.alt_ids, ontology_prefix)
         # 6
         if self.definition:
             yield f'def: "{self.definition}"'
@@ -235,7 +236,10 @@ class TypeDef(Referenced, Stanza):
         # 10
         yield from self._iterate_xref_obo(ontology_prefix=ontology_prefix)
         # 11
-        yield from self._iterate_obo_properties(ontology_prefix=ontology_prefix)
+        yield from self._iterate_obo_properties(
+            ontology_prefix=ontology_prefix,
+            skip_predicates={term_replaced_by.reference, see_also.reference},
+        )
         # 12
         if self.domain:
             yield f"domain: {reference_escape(self.domain, ontology_prefix=ontology_prefix, add_name_comment=True)}"
@@ -277,7 +281,10 @@ class TypeDef(Referenced, Stanza):
         yield from _reference_list_tag("transitive_over", self.transitive_over, ontology_prefix)
         # 30
         yield from _chain_tag("equivalent_to_chain", self.equivalent_to_chain, ontology_prefix)
-        # 31 TODO disjoint_over, see https://github.com/search?q=%22disjoint_over%3A%22+path%3A*.obo&type=code
+        # 31 disjoint_over, see https://github.com/search?q=%22disjoint_over%3A%22+path%3A*.obo&type=code
+        yield from _reference_list_tag(
+            "disjoint_over", self.disjoint_over, ontology_prefix=ontology_prefix
+        )
         # 32
         yield from self._iterate_obo_relations(ontology_prefix=ontology_prefix)
         # 33
@@ -289,9 +296,13 @@ class TypeDef(Referenced, Stanza):
         if self.creation_date is not None:
             yield f"creation_date: {self.creation_date.isoformat()}"
         # 36
-        yield from _reference_list_tag("replaced_by", self.replaced_by, ontology_prefix)
+        yield from _tag_property_targets(
+            "replaced_by", self, term_replaced_by, ontology_prefix=ontology_prefix
+        )
         # 37
-        yield from _reference_list_tag("consider", self.consider, ontology_prefix=ontology_prefix)
+        yield from _tag_property_targets(
+            "consider", self, see_also, ontology_prefix=ontology_prefix
+        )
         # 38 TODO expand_assertion_to
         # 39 TODO expand_expression_to
         # 40
@@ -350,6 +361,9 @@ has_part = TypeDef(
     comment="Inverse of part_of",
     inverse=Reference(prefix=BFO_PREFIX, identifier="0000050", name="part of"),
 )
+occurs_in = TypeDef(
+    reference=Reference(prefix=BFO_PREFIX, identifier="BFO:0000066", name="occurs in")
+)
 participates_in = TypeDef(
     reference=Reference(prefix=RO_PREFIX, identifier="0000056", name="participates in"),
     comment="Inverse of has participant",
@@ -406,12 +420,10 @@ is_a = TypeDef(
     reference=Reference(prefix="rdfs", identifier="subClassOf", name="subclass of"),
 )
 see_also = TypeDef(
-    reference=Reference(prefix="rdfs", identifier="seeAlso", name="see also"),
+    reference=v.see_also,
     is_metadata_tag=True,
 )
-comment = TypeDef(
-    reference=Reference(prefix="rdfs", identifier="comment", name="comment"), is_metadata_tag=True
-)
+comment = TypeDef(reference=v.comment, is_metadata_tag=True)
 has_member = TypeDef(
     reference=Reference(prefix=RO_PREFIX, identifier="0002351", name="has member"),
 )
@@ -471,8 +483,10 @@ has_gene_product = TypeDef(
 gene_product_member_of = TypeDef(
     reference=Reference(prefix="debio", identifier="0000001", name="gene product is a member of"),
     holds_over_chain=[
-        has_gene_product.reference,
-        member_of.reference,
+        [
+            has_gene_product.reference,
+            member_of.reference,
+        ]
     ],
 )
 
@@ -481,7 +495,7 @@ has_salt = TypeDef(
 )
 
 term_replaced_by = TypeDef(
-    reference=Reference(prefix=IAO_PREFIX, identifier="0100001", name="term replaced by"),
+    reference=v.term_replaced_by,
     is_metadata_tag=True,
 )
 example_of_usage = TypeDef(

--- a/src/pyobo/struct/typedef.py
+++ b/src/pyobo/struct/typedef.py
@@ -155,6 +155,7 @@ class TypeDef(Referenced, Stanza):
         self,
         ontology_prefix: str,
         synonym_typedefs: Mapping[ReferenceTuple, SynonymTypeDef] | None = None,
+        typedefs: Mapping[ReferenceTuple, TypeDef] | None = None,
     ) -> Iterable[str]:
         """Iterate over the lines to write in an OBO file.
 
@@ -209,6 +210,11 @@ class TypeDef(Referenced, Stanza):
         40. is_metadata_tag
         41. is_class_level
         """
+        if synonym_typedefs is None:
+            synonym_typedefs = {}
+        if typedefs is None:
+            typedefs = {}
+
         yield "\n[Typedef]"
         # 1
         yield f"id: {reference_escape(self.reference, ontology_prefix=ontology_prefix)}"
@@ -239,6 +245,7 @@ class TypeDef(Referenced, Stanza):
         yield from self._iterate_obo_properties(
             ontology_prefix=ontology_prefix,
             skip_predicates={term_replaced_by.reference, see_also.reference},
+            typedefs=typedefs,
         )
         # 12
         if self.domain:
@@ -286,7 +293,7 @@ class TypeDef(Referenced, Stanza):
             "disjoint_over", self.disjoint_over, ontology_prefix=ontology_prefix
         )
         # 32
-        yield from self._iterate_obo_relations(ontology_prefix=ontology_prefix)
+        yield from self._iterate_obo_relations(ontology_prefix=ontology_prefix, typedefs=typedefs)
         # 33
         yield from _boolean_tag("is_obsolete", self.is_obsolete)
         # 34

--- a/src/pyobo/struct/vocabulary.py
+++ b/src/pyobo/struct/vocabulary.py
@@ -18,3 +18,8 @@ has_dbxref = Reference(
     prefix="oboInOwl", identifier="hasDbXref", name="has database cross-reference"
 )
 equivalent_class = Reference(prefix="owl", identifier="equivalentClass", name="equivalent class")
+term_replaced_by = Reference(prefix="IAO", identifier="0100001", name="term replaced by")
+see_also = Reference(prefix="rdfs", identifier="seeAlso", name="see also")
+comment = Reference(prefix="rdfs", identifier="comment", name="comment")
+
+CHARLIE = Reference(prefix="orcid", identifier="0000-0003-4423-4370")

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -11,12 +11,11 @@ from pyobo.reader import (
     _extract_definition,
     _extract_synonym,
     iterate_graph_synonym_typedefs,
-    iterate_graph_typedefs,
-    iterate_node_parents,
     iterate_node_properties,
     iterate_node_relationships,
     iterate_node_synonyms,
     iterate_node_xrefs,
+    iterate_typedefs,
 )
 from pyobo.struct.struct import acronym
 from tests.constants import TEST_CHEBI_OBO_PATH, chebi_patch
@@ -35,9 +34,7 @@ class TestParseObonet(unittest.TestCase):
         """Test getting type definitions from an :mod:`obonet` graph."""
         pairs = {
             typedef.pair
-            for typedef in iterate_graph_typedefs(
-                self.graph, ontology_prefix="chebi", upgrade=False
-            )
+            for typedef in iterate_typedefs(self.graph, ontology_prefix="chebi", upgrade=False)
         }
         self.assertIn(ReferenceTuple("obo", "chebi#has_major_microspecies_at_pH_7_3"), pairs)
 
@@ -219,18 +216,6 @@ class TestParseObonet(unittest.TestCase):
         self.assertIsInstance(value, str)
         self.assertEqual("261.28318", value)
 
-    def test_get_node_parents(self):
-        """Test getting parents from a node in a :mod:`obonet` graph."""
-        data = self.graph.nodes["CHEBI:51990"]
-        parents = list(
-            iterate_node_parents(
-                data, node=Reference(prefix="chebi", identifier="XXX"), ontology_prefix="chebi"
-            )
-        )
-        self.assertEqual(2, len(parents))
-        self.assertEqual({"24060", "51992"}, {parent.identifier for parent in parents})
-        self.assertEqual({"chebi"}, {parent.prefix for parent in parents})
-
     def test_get_node_xrefs(self):
         """Test getting parents from a node in a :mod:`obonet` graph."""
         data = self.graph.nodes["CHEBI:51990"]
@@ -286,11 +271,6 @@ class TestGet(unittest.TestCase):
         """Set up the test with the mock ChEBI OBO file."""
         with chebi_patch:
             self.ontology = get_ontology("chebi")
-
-    def test_get_terms(self):
-        """Test getting an OBO document."""
-        terms = list(self.ontology)
-        self.assertEqual(18, len(terms))
 
     def test_get_id_alts_mapping(self):
         """Make sure the alternative ids are mapped properly.

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -59,54 +59,8 @@ class TestUtils(unittest.TestCase):
         self.assertIsNone(get_first_nonescaped_quote('\\"hello\\"'))
 
 
-class TestReader(unittest.TestCase):
-    """Test the reader."""
-
-    def test_unknown_ontology_prefix(self) -> None:
-        """Test an ontology with an unknown prefix."""
-        with self.assertRaises(ValueError) as exc:
-            _read("""\
-                ontology: nope
-
-                [Term]
-                id: CHEBI:1234
-            """)
-        self.assertEqual("unknown prefix: nope", exc.exception.args[0])
-
-    def test_missing_date_version(self) -> None:
-        """Test an ontology with a missing date and version."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-        """)
-        self.assertIsNone(ontology.date)
-        self.assertIsNone(ontology.data_version)
-
-    def test_bad_date_format(self) -> None:
-        """Test an ontology with a malformed date and no version."""
-        ontology = _read("""\
-            ontology: chebi
-            date: aabbccddeee
-
-            [Term]
-            id: CHEBI:1234
-        """)
-        self.assertIsNone(ontology.date)
-        self.assertIsNone(ontology.data_version)
-
-    def test_date_no_version(self) -> None:
-        """Test an ontology with a date but no version."""
-        ontology = _read("""\
-            ontology: chebi
-            date: 20:11:2024 18:44
-
-            [Term]
-            id: CHEBI:1234
-        """)
-        self.assertEqual(datetime.datetime(2024, 11, 20, 18, 44), ontology.date)
-        self.assertEqual("2024-11-20", ontology.data_version)
+class _Base(unittest.TestCase):
+    """"""
 
     def get_only_term(self, ontology: Obo) -> Term:
         """Assert there is only a single term in the ontology and return it."""
@@ -120,7 +74,218 @@ class TestReader(unittest.TestCase):
         self.assertEqual(1, len(ontology.typedefs))
         return ontology.typedefs[0]
 
-    def test_minimal(self) -> None:
+
+class TestReaderOntologyMetadata(_Base):
+    """Test the reader on ontology metadata."""
+
+    def test_0_missing_date_version(self) -> None:
+        """Test an ontology with a missing date and version."""
+        ontology = _read("""\
+            ontology: chebi
+        """)
+        self.assertIsNone(ontology.date)
+        self.assertIsNone(ontology.data_version)
+
+    def test_1_format_version(self) -> None:
+        """Test ``format-version`` tag."""
+        raise NotImplementedError
+
+    # for data-version, see the full test case below
+
+    def test_3_bad_date_format(self) -> None:
+        """Test an ontology with a malformed date and no version."""
+        ontology = _read("""\
+            ontology: chebi
+            date: aabbccddeee
+        """)
+        self.assertIsNone(ontology.date)
+        self.assertIsNone(ontology.data_version)
+
+    def test_3_date_no_version(self) -> None:
+        """Test an ontology with a date but no version."""
+        ontology = _read("""\
+            ontology: chebi
+            date: 20:11:2024 18:44
+        """)
+        self.assertEqual(datetime.datetime(2024, 11, 20, 18, 44), ontology.date)
+        self.assertEqual("2024-11-20", ontology.data_version)
+
+    def test_4_saved_by(self) -> None:
+        """Test the ``saved-by`` tag."""
+        raise NotImplementedError
+
+    def test_5_auto_generated_by(self) -> None:
+        """Test the ``auto-generated-by`` tag."""
+        raise NotImplementedError
+
+    def test_6_import(self) -> None:
+        """Test the ``import`` tag."""
+        raise NotImplementedError
+
+    def test_7_subset(self) -> None:
+        """Test parsing a subset definition."""
+        ontology = _read("""\
+            ontology: chebi
+            subsetdef: TEST "comment"
+        """)
+        self.assertEqual(
+            [(default_reference("chebi", "TEST"), "comment")],
+            ontology.subsetdefs,
+        )
+
+    def test_12_xref_equivalent(self) -> None:
+        """Test the ``treat-xrefs-as-equivalent`` macro."""
+        ontology = _read("""\
+            ontology: go
+            treat-xrefs-as-equivalent: CL
+
+            [Term]
+            id: GO:0005623
+            name: cell
+            xref: CL:0000000
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(0, len(term.xrefs))
+        self.assertEqual(0, len(term.parents))
+        self.assertEqual(0, len(term.properties))
+        self.assertEqual(1, len(term.relationships))
+        self.assertEqual(0, len(term.intersection_of))
+        self.assertIn(equivalent_class.reference, term.relationships)
+        self.assertEqual(
+            [Reference(prefix="CL", identifier="0000000")],
+            term.relationships[equivalent_class.reference],
+        )
+
+    def test_13_xref_genus_differentia(self) -> None:
+        """Test the ``treat-xrefs-as-is_a `` macro.
+
+        The test should become the same as:
+
+        .. code::
+
+            [Term]
+            id: ZFA:0000134
+            intersection_of: CL:0000540
+            intersection_of: BFO:0000050 NCBITaxon:7955
+        """
+        ontology = _read("""\
+              ontology: zfa
+              treat-xrefs-as-genus-differentia: CL BFO:0000050 NCBITaxon:7955
+
+              [Term]
+              id: ZFA:0000134
+              xref: CL:0000540
+          """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(0, len(term.xrefs))
+        self.assertEqual(0, len(term.parents))
+        self.assertEqual(0, len(term.properties))
+        self.assertEqual(0, len(term.relationships))
+        self.assertEqual(2, len(term.intersection_of))
+        self.assertEqual(
+            [
+                Reference(prefix="CL", identifier="0000540"),
+                Annotation(part_of.reference, Reference(prefix="NCBITaxon", identifier="7955")),
+            ],
+            term.intersection_of,
+        )
+
+    def test_14_xref_relation(self) -> None:
+        """Test the ``treat-xrefs-as-relationship  `` macro."""
+        ontology = _read("""\
+            ontology: go
+            treat-xrefs-as-relationship: CL BFO:0000000
+
+            [Term]
+            id: GO:0005623
+            name: cell
+            xref: CL:0000000
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(0, len(term.xrefs))
+        self.assertEqual(0, len(term.parents))
+        self.assertEqual(0, len(term.properties))
+        self.assertEqual(1, len(term.relationships))
+        self.assertEqual(0, len(term.intersection_of))
+        pred = Reference(prefix="BFO", identifier="0000000")
+        self.assertIn(pred, term.relationships)
+        self.assertEqual([Reference(prefix="CL", identifier="0000000")], term.relationships[pred])
+
+    def test_15_xref_is_a_for_term(self) -> None:
+        """Test the ``treat-xrefs-as-is_a `` macro."""
+        ontology = _read("""\
+            ontology: go
+            treat-xrefs-as-is_a: CL
+
+            [Term]
+            id: GO:0005623
+            name: cell
+            xref: CL:0000000
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(0, len(term.xrefs), msg=term.xrefs)
+        self.assertEqual(1, len(term.parents))
+        self.assertEqual(0, len(term.properties))
+        self.assertEqual(0, len(term.relationships))
+        self.assertEqual(0, len(term.intersection_of))
+        self.assertEqual([Reference(prefix="CL", identifier="0000000")], term.parents)
+
+    def test_15_xref_is_a_for_typedef(self) -> None:
+        """Test the ``treat-xrefs-as-is_a `` macro."""
+        ontology = _read("""\
+            ontology: ro
+            treat-xrefs-as-is_a: skos
+
+            [Typedef]
+            id: RO:0000000
+            xref: skos:closeMatch
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertEqual(0, len(typedef.xrefs), msg=typedef.xrefs)
+        self.assertEqual(1, len(typedef.parents))
+        self.assertEqual(0, len(typedef.relationships))
+        self.assertEqual(0, len(typedef.intersection_of))
+        self.assertEqual([Reference(prefix="skos", identifier="closeMatch")], typedef.parents)
+
+    def test_17_unknown_ontology_prefix(self) -> None:
+        """Test an ontology with an unknown prefix."""
+        with self.assertRaises(ValueError) as exc:
+            _read("""\
+                ontology: nope
+            """)
+        self.assertEqual("unknown prefix: nope", exc.exception.args[0])
+
+    def test_18_properties(self) -> None:
+        """Test parsing properties."""
+        ontology = _read("""\
+            ontology: chebi
+            property_value: heyo also_heyo
+        """)
+        self.assertEqual(
+            [(default_reference("chebi", "heyo"), default_reference("chebi", "also_heyo"))],
+            ontology.property_values,
+        )
+
+    def test_18_root(self) -> None:
+        """Test root terms."""
+        ontology = _read("""\
+            ontology: go
+            property_value: IAO:0000700 GO:0050069
+
+            [Term]
+            id: GO:0050069
+        """)
+        # FIXME support default reference, like property_value: IAO:0000700 adhoc
+        self.assertEqual(
+            [Reference(prefix="GO", identifier="0050069")],
+            ontology.root_terms,
+        )
+
+
+class TestReaderTerm(_Base):
+    """Test the reader."""
+
+    def test_0_minimal(self) -> None:
         """Test an ontology with a version but no date."""
         ontology = _read("""\
             data-version: 185
@@ -141,350 +306,7 @@ class TestReader(unittest.TestCase):
         xref = term.xrefs[0]
         self.assertEqual("drugbank:DB1234567", xref.curie)
 
-    def test_relationship_qualified_undefined(self) -> None:
-        """Test parsing a relationship that's loaded in the defaults."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            name: Test Name
-            relationship: RO:0018033 CHEBI:5678
-        """)
-        term = self.get_only_term(ontology)
-        reference = term.get_relationship(is_conjugate_base_of)
-        self.assertIsNotNone(reference)
-        self.assertEqual("chebi:5678", reference.curie)
-
-    def test_relationship_qualified_defined(self) -> None:
-        """Test relationship parsing that's defined."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            name: Test Name
-            relationship: RO:0018033 CHEBI:5678
-
-            [Typedef]
-            id: RO:0018033
-            name: is conjugate base of
-        """)
-        term = self.get_only_term(ontology)
-        reference = term.get_relationship(is_conjugate_base_of)
-        self.assertIsNotNone(reference)
-        self.assertEqual("chebi:5678", reference.curie)
-
-    def test_relationship_unqualified(self) -> None:
-        """Test relationship parsing that relies on default referencing."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            name: Test Name
-            relationship: xyz CHEBI:5678
-
-            [Typedef]
-            id: xyz
-        """)
-        term = self.get_only_term(ontology)
-        self.assertIsNone(term.get_relationship(is_conjugate_base_of))
-        r = default_reference("chebi", "xyz")
-        td = TypeDef(reference=r)
-        reference = term.get_relationship(td)
-        self.assertIsNotNone(reference)
-        self.assertEqual("chebi:5678", reference.curie)
-
-        rr = list(ontology.iterate_filtered_relations(td))
-        self.assertEqual(1, len(rr))
-
-        rr2 = list(ontology.iterate_filtered_relations(is_conjugate_base_of))
-        self.assertEqual(0, len(rr2))
-
-    def test_relationship_missing(self) -> None:
-        """Test parsing a relationship that isn't defined."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            name: Test Name
-            relationship: nope CHEBI:5678
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(0, len(list(term.iterate_relations())))
-
-    def test_relationship_bad_target(self) -> None:
-        """Test an ontology with a version but no date."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            relationship: RO:0018033 missing
-
-            [Typedef]
-            id: RO:0018033
-            name: is conjugate base of
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(0, len(list(term.iterate_relations())))
-
-    def test_property_malformed(self) -> None:
-        """Test parsing a malformed property."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            property_value: nope
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(0, len(list(term.iterate_properties())))
-
-    def test_property_literal_bare(self) -> None:
-        """Test parsing a property with a literal object."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            property_value: level "high"
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.properties))
-        self.assertEqual("high", term.get_property(default_reference("chebi", "level")))
-
-        df = ontology.get_properties_df()
-        self.assertEqual(4, len(df.columns))
-        self.assertEqual(1, len(df))
-        row = dict(df.iloc[0])
-        self.assertEqual(
-            {"chebi_id": "1234", "property": "level", "value": "high", "datatype": "xsd:string"},
-            row,
-        )
-
-    def test_property_literal_typed(self) -> None:
-        """Test parsing a property with a literal object."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            property_value: xyz "121.323" xsd:decimal
-
-            [Typedef]
-            id: xyz
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.properties))
-        ref = default_reference("chebi", "xyz")
-        self.assertIn(ref, term.properties)
-        self.assertEqual("121.323", term.get_property(ref))
-
-        df = ontology.get_properties_df()
-        self.assertEqual(4, len(df.columns))
-        self.assertEqual(1, len(df))
-        row = dict(df.iloc[0])
-        self.assertEqual("1234", row["chebi_id"])
-        self.assertEqual("xyz", row["property"])
-        self.assertEqual("121.323", row["value"])
-        self.assertEqual("xsd:decimal", row["datatype"])
-
-    def test_property_bad_datatype(self) -> None:
-        """Test parsing a property with an unparsable datatype."""
-        text = """\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            property_value: mass "121.323" NOPE:NOPE
-        """
-        with self.assertRaises(ValueError):
-            _read(text)
-        ontology = _read(text, strict=False)
-        term = self.get_only_term(ontology)
-        self.assertEqual(0, len(term.properties))
-
-    def test_property_literal_url_questionable(self) -> None:
-        """Test parsing a property with a literal object."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            property_value: http://purl.obolibrary.org/obo/chebi/mass "121.323" xsd:decimal
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.properties))
-        self.assertEqual("121.323", term.get_property(default_reference("chebi", "mass")))
-
-        df = ontology.get_properties_df()
-        self.assertEqual(4, len(df.columns))
-        self.assertEqual(1, len(df))
-        row = dict(df.iloc[0])
-        self.assertEqual("1234", row["chebi_id"])
-        self.assertEqual("mass", row["property"])
-        self.assertEqual("121.323", row["value"])
-        self.assertEqual("xsd:decimal", row["datatype"])
-
-    def test_property_literal_url_default(self) -> None:
-        """Test parsing a property with a literal object."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            property_value: http://purl.obolibrary.org/obo/chebi#mass "121.323" xsd:decimal
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.properties))
-        self.assertEqual("121.323", term.get_property(default_reference("chebi", "mass")))
-
-        df = ontology.get_properties_df()
-        self.assertEqual(4, len(df.columns))
-        self.assertEqual(1, len(df))
-        row = dict(df.iloc[0])
-        self.assertEqual("1234", row["chebi_id"])
-        self.assertEqual("mass", row["property"])
-        self.assertEqual("121.323", row["value"])
-        self.assertEqual("xsd:decimal", row["datatype"])
-
-    def test_property_literal_obo_purl(self) -> None:
-        """Test using a full OBO PURL as the property."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            property_value: http://purl.obolibrary.org/obo/RO_0018033 CHEBI:5678
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.properties))
-        self.assertIn(Reference(prefix="RO", identifier="0018033"), term.properties)
-        self.assertEqual("CHEBI:5678", term.get_property(is_conjugate_base_of))
-
-        df = ontology.get_properties_df()
-        self.assertEqual(4, len(df.columns))
-        self.assertEqual(1, len(df))
-        row = dict(df.iloc[0])
-        self.assertEqual(
-            {"chebi_id": "1234", "property": "RO:0018033", "value": "CHEBI:5678", "datatype": ""},
-            row,
-        )
-
-    def test_property_object_url(self) -> None:
-        """Test parsing an object URI."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            property_value: http://purl.obolibrary.org/obo/RO_0018033 http://purl.obolibrary.org/obo/CHEBI_5678
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.properties))
-        self.assertEqual("CHEBI:5678", term.get_property(is_conjugate_base_of))
-
-        df = ontology.get_properties_df()
-        self.assertEqual(4, len(df.columns))
-        self.assertEqual(1, len(df))
-        row = dict(df.iloc[0])
-        self.assertEqual(
-            {"chebi_id": "1234", "property": "RO:0018033", "value": "CHEBI:5678", "datatype": ""},
-            row,
-        )
-
-    def test_property_object_url_invalid(self) -> None:
-        """Test parsing an object URI."""
-        text = """\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            property_value: http://purl.obolibrary.org/obo/RO_0018033 http://example.org/nope:nope
-        """
-        with self.assertRaises(ValueError):
-            _read(text)
-        ontology = _read(text, strict=False)
-        term = self.get_only_term(ontology)
-        self.assertEqual(0, len(term.properties))
-
-    def test_property_literal_url(self) -> None:
-        """Test using a full OBO PURL as the property."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            property_value: https://w3id.org/biolink/vocab/something CHEBI:5678
-        """)
-        td = TypeDef.from_triple(prefix="biolink", identifier="something")
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.properties))
-        self.assertEqual("CHEBI:5678", term.get_property(td))
-
-    def test_property_unparsable_object(self) -> None:
-        """Test when an object can't be parsed."""
-        text = """\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            property_value: https://w3id.org/biolink/vocab/something NOPE:NOPE
-            """
-
-        with self.assertRaises(ValueError):
-            _read(text)
-
-        ontology = _read(text, strict=False)
-        term = self.get_only_term(ontology)
-        self.assertEqual(0, len(term.properties))
-
-    def test_property_literal_url_unregistered(self) -> None:
-        """Test using a full OBO PURL as the property."""
-        with self.assertRaises(UnparsableIRIError):
-            _read(
-                """\
-                ontology: chebi
-
-                [Term]
-                id: CHEBI:1234
-                property_value: https://example.com/nope/nope CHEBI:5678
-                """,
-                strict=True,
-            )
-
-        ontology = _read(
-            """\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            property_value: https://example.com/nope/nope CHEBI:5678
-            """,
-            strict=False,
-        )
-
-        term = self.get_only_term(ontology)
-        self.assertEqual(0, len(term.properties))
-
-    def test_property_literal_object(self) -> None:
-        """Test parsing a property with a literal object."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            property_value: rdfs:seeAlso hgnc:1234
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(list(term.properties)))
-        self.assertIn(see_also.reference, term.properties)
-        self.assertEqual("hgnc:1234", term.get_property(see_also))
-
-    def test_node_unparsable(self) -> None:
+    def test_1_node_unparsable(self) -> None:
         """Test loading an ontology with unparsable nodes."""
         text = """\
             ontology: chebi
@@ -497,31 +319,44 @@ class TestReader(unittest.TestCase):
         ontology = _read(text, strict=False)
         self.assertEqual(0, len(list(ontology.iter_terms())))
 
-    def test_malformed_typedef(self) -> None:
-        """Test loading an ontology with unparsable nodes."""
-        with self.assertRaises(KeyError) as exc:
-            _read("""\
-                ontology: chebi
-
-                [Typedef]
-                name: nope
-            """)
-        self.assertEqual("typedef is missing an `id`", exc.exception.args[0])
-
-    def test_typedef_xref(self) -> None:
-        """Test loading an ontology with unparsable nodes."""
+    def test_1_is_anonymous_missing(self) -> None:
+        """Test the ``is-anonymous`` tag."""
         ontology = _read("""\
             ontology: chebi
 
-            [Typedef]
-            id: RO:0018033
-            name: is conjugate base of
-            xref: debio:0000010
+            [Term]
+            id: CHEBI:1234
         """)
-        self.assertEqual(1, len(ontology.typedefs))
-        self.assertEqual(is_conjugate_base_of.pair, ontology.typedefs[0].pair)
+        term = self.get_only_term(ontology)
+        self.assertIsNone(term.is_anonymous)
 
-    def test_definition_missing_start_quote(self) -> None:
+    def test_1_is_anonymous_true(self) -> None:
+        """Test the ``is-anonymous`` tag."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            is_anonymous: true
+        """)
+        term = self.get_only_term(ontology)
+        self.assertIsNotNone(term.is_anonymous)
+        self.assertTrue(term.is_anonymous)
+
+    def test_1_is_anonymous_false(self) -> None:
+        """Test the ``is-anonymous`` tag."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            is_anonymous: false
+        """)
+        term = self.get_only_term(ontology)
+        self.assertIsNotNone(term.is_anonymous)
+        self.assertFalse(term.is_anonymous)
+
+    def test_6_definition_missing_start_quote(self) -> None:
         """Test parsing a definition missing a starting quote."""
         ontology = _read("""\
             ontology: chebi
@@ -533,389 +368,7 @@ class TestReader(unittest.TestCase):
         term = self.get_only_term(ontology)
         self.assertIsNone(term.definition)
 
-    def test_definition_missing_end_quote(self) -> None:
-        """Test parsing a definition missing an ending quote."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            def: "malformed definition without quotes
-        """)
-        term = self.get_only_term(ontology)
-        self.assertIsNone(term.definition)
-
-    def test_definition_no_provenance(self) -> None:
-        """Test parsing a term with a definition and no provenance brackets."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            def: "definition of CHEBI:1234"
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual("definition of CHEBI:1234", term.definition)
-
-    def test_definition_empty_provenance(self) -> None:
-        """Test parsing a term with a definition and empty provenance."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            def: "definition of CHEBI:1234" []
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual("definition of CHEBI:1234", term.definition)
-
-    def test_definition_with_provenance(self) -> None:
-        """Test parsing a term with a definition and provenance."""
-        ontology = _read(f"""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            def: "definition of CHEBI:1234" [{CHARLIE.curie}]
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual("definition of CHEBI:1234", term.definition)
-        self.assertEqual(1, len(term.provenance))
-        self.assertEqual(CHARLIE, term.provenance[0])
-
-    def test_provenance_no_definition(self) -> None:
-        """Test parsing a term with provenance but no definition."""
-        ontology = _read(f"""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            def: "" [{CHARLIE.curie}]
-        """)
-        term = self.get_only_term(ontology)
-        self.assertIsNone(term.definition)
-        self.assertEqual(1, len(term.provenance))
-        self.assertEqual(CHARLIE, term.provenance[0])
-
-    def test_synonym_minimal(self) -> None:
-        """Test parsing a synonym just the text."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I"
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("LTEC I", synonym.name)
-        self.assertIsNone(synonym.specificity)
-        self.assertIsNone(synonym.type)
-        self.assertEqual([], synonym.provenance)
-
-    def test_synonym_with_specificity(self) -> None:
-        """Test parsing a synonym with specificity."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I" NARROW
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("LTEC I", synonym.name)
-        self.assertEqual("NARROW", synonym.specificity)
-        self.assertIsNone(synonym.type)
-        self.assertEqual([], synonym.provenance)
-
-    def test_synonym_with_type_missing_def(self) -> None:
-        """Test parsing a synonym with type, but missing type def."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I" OMO:1234567
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        #  this is because no typedef existed
-        self.assertIsNone(synonym.type)
-
-    def test_synonym_with_type(self) -> None:
-        """Test parsing a synonym with type."""
-        ontology = _read("""\
-            ontology: chebi
-            synonymtypedef: OMO:1234567 ""
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I" OMO:1234567
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("LTEC I", synonym.name)
-        self.assertIsNone(synonym.specificity)
-        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
-        self.assertEqual([], synonym.provenance)
-
-    def test_synonym_with_type_and_specificity(self) -> None:
-        """Test parsing a synonym with specificity and type."""
-        ontology = _read("""\
-            ontology: chebi
-            synonymtypedef: OMO:1234567 ""
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I" NARROW OMO:1234567
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("LTEC I", synonym.name)
-        self.assertEqual("NARROW", synonym.specificity)
-        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
-        self.assertEqual([], synonym.provenance)
-
-    def test_synonym_with_empty_prov(self) -> None:
-        """Test parsing a synonym with specificity,type, and explicit empty provenance."""
-        ontology = _read("""\
-            ontology: chebi
-            synonymtypedef: OMO:1234567 ""
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I" NARROW OMO:1234567 []
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("LTEC I", synonym.name)
-        self.assertEqual("NARROW", synonym.specificity)
-        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
-        self.assertEqual([], synonym.provenance)
-
-    def test_synonym_no_type(self) -> None:
-        """Test parsing a synonym with specificity and provenance."""
-        ontology = _read(f"""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I" EXACT [Orphanet:93938,{CHARLIE.curie}]
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("LTEC I", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertIsNone(synonym.type)
-        self.assertEqual(
-            [
-                Reference(prefix="orphanet", identifier="93938"),
-                CHARLIE,
-            ],
-            synonym.provenance,
-        )
-
-    def test_synonym_full(self) -> None:
-        """Test parsing a synonym with specificity, type, and provenance."""
-        ontology = _read(f"""\
-            ontology: chebi
-            synonymtypedef: OMO:1234567 ""
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I" EXACT OMO:1234567 [Orphanet:93938,{CHARLIE.curie}]
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("LTEC I", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
-        self.assertEqual(
-            [
-                Reference(prefix="orphanet", identifier="93938"),
-                CHARLIE,
-            ],
-            synonym.provenance,
-        )
-
-    def test_synonym_dashed(self) -> None:
-        """Test parsing a synonym with specificity, type, and provenance."""
-        ontology = _read("""\
-            ontology: chebi
-            synonymtypedef: OMO:1234567 ""
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "Brown-Pearce tumour" EXACT OMO:0003005 []
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("Brown-Pearce tumour", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertEqual(Reference(prefix="omo", identifier="0003005"), synonym.type)
-        self.assertEqual([], synonym.provenance)
-
-    def test_synonym_url(self) -> None:
-        """Test parsing a synonym defined with a PURL."""
-        ontology = _read(f"""\
-            ontology: chebi
-            synonymtypedef: http://purl.obolibrary.org/obo/OMO_1234567 ""
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I" EXACT OMO:1234567 [Orphanet:93938,{CHARLIE.curie}]
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("LTEC I", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
-        self.assertEqual(
-            [
-                Reference(prefix="orphanet", identifier="93938"),
-                CHARLIE,
-            ],
-            synonym.provenance,
-        )
-
-    def test_synonym_casing(self) -> None:
-        """Test parsing a synonym when an alternate case is used."""
-        ontology = _read(f"""\
-            ontology: chebi
-            synonymtypedef: OMO:1234567 ""
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I" EXACT omo:1234567 [Orphanet:93938,{CHARLIE.curie}]
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("LTEC I", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
-        self.assertEqual(
-            [
-                Reference(prefix="orphanet", identifier="93938"),
-                CHARLIE,
-            ],
-            synonym.provenance,
-        )
-
-    def test_synonym_default(self) -> None:
-        """Test parsing a synonym that has a built-in prefix."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "DoguAnadoluKirmizisi" EXACT most_common_name []
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("DoguAnadoluKirmizisi", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertIsNone(synonym.type)
-
-        # now, we define it properly
-        ontology = _read("""\
-            ontology: chebi
-            synonymtypedef: most_common_name "most common name"
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "DoguAnadoluKirmizisi" EXACT most_common_name []
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("DoguAnadoluKirmizisi", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertEqual(default_reference("chebi", "most_common_name"), synonym.type)
-
-    def test_synonym_builtin(self) -> None:
-        """Test parsing a synonym with specificity, type, and provenance."""
-        text = """\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "COP" EXACT ABBREVIATION []
-        """
-
-        ontology = _read(text, upgrade=False)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("COP", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertIsNone(synonym.type)
-
-        ontology = _read(text, upgrade=True)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("COP", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertEqual(abbreviation.reference, synonym.type)
-
-    @unittest.skip(reason=REASON_OBONET_IMPL)
-    def test_synonym_with_annotations(self) -> None:
-        """Test parsing a synonym with annotations."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "10*3.{copies}/mL" EXACT [] {http://purl.obolibrary.org/obo/NCIT_P383="AB", http://purl.obolibrary.org/obo/NCIT_P384="UCUM"}
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("10*3.{copies}/mL", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertIsNone(synonym.type)
-        self.assertEqual([], synonym.provenance)
-        # TODO update this when adding annotation parsing!
-        self.assertEqual([], synonym.annotations)
-
-    def test_parent(self) -> None:
-        """Test parsing out a parent."""
-        ontology = _read("""\
-            ontology: chebi
-            date: 20:11:2024 18:44
-
-            [Term]
-            id: CHEBI:1234
-            is_a: CHEBI:5678
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual([Reference(prefix="CHEBI", identifier="5678")], term.parents)
-
-        ontology = _read("""\
-            ontology: chebi
-            date: 20:11:2024 18:44
-
-            [Term]
-            id: CHEBI:1234
-            is_a: http://purl.obolibrary.org/obo/CHEBI_5678
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual([Reference(prefix="CHEBI", identifier="5678")], term.parents)
-
-    def test_mappings(self) -> None:
+    def test_10_xrefs(self) -> None:
         """Test getting mappings."""
         ontology = _read("""\
             ontology: chebi
@@ -955,7 +408,758 @@ class TestReader(unittest.TestCase):
             {(a.pair, b.pair) for a, b in term.get_mappings(include_xrefs=True)},
         )
 
-    def test_default_relation(self):
+    def test_12_property_malformed(self) -> None:
+        """Test parsing a malformed property."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            property_value: nope
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(0, len(list(term.iterate_properties())))
+
+    def test_12_property_literal_bare(self) -> None:
+        """Test parsing a property with a literal object."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            property_value: level "high"
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.properties))
+        self.assertEqual("high", term.get_property(default_reference("chebi", "level")))
+
+        df = ontology.get_properties_df()
+        self.assertEqual(4, len(df.columns))
+        self.assertEqual(1, len(df))
+        row = dict(df.iloc[0])
+        self.assertEqual(
+            {"chebi_id": "1234", "property": "level", "value": "high", "datatype": "xsd:string"},
+            row,
+        )
+
+    def test_12_property_literal_typed(self) -> None:
+        """Test parsing a property with a literal object."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            property_value: xyz "121.323" xsd:decimal
+
+            [Typedef]
+            id: xyz
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.properties))
+        ref = default_reference("chebi", "xyz")
+        self.assertIn(ref, term.properties)
+        self.assertEqual("121.323", term.get_property(ref))
+
+        df = ontology.get_properties_df()
+        self.assertEqual(4, len(df.columns))
+        self.assertEqual(1, len(df))
+        row = dict(df.iloc[0])
+        self.assertEqual("1234", row["chebi_id"])
+        self.assertEqual("xyz", row["property"])
+        self.assertEqual("121.323", row["value"])
+        self.assertEqual("xsd:decimal", row["datatype"])
+
+    def test_12_property_bad_datatype(self) -> None:
+        """Test parsing a property with an unparsable datatype."""
+        text = """\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            property_value: mass "121.323" NOPE:NOPE
+        """
+        with self.assertRaises(ValueError):
+            _read(text)
+        ontology = _read(text, strict=False)
+        term = self.get_only_term(ontology)
+        self.assertEqual(0, len(term.properties))
+
+    def test_12_property_literal_url_questionable(self) -> None:
+        """Test parsing a property with a literal object."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            property_value: http://purl.obolibrary.org/obo/chebi/mass "121.323" xsd:decimal
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.properties))
+        self.assertEqual("121.323", term.get_property(default_reference("chebi", "mass")))
+
+        df = ontology.get_properties_df()
+        self.assertEqual(4, len(df.columns))
+        self.assertEqual(1, len(df))
+        row = dict(df.iloc[0])
+        self.assertEqual("1234", row["chebi_id"])
+        self.assertEqual("mass", row["property"])
+        self.assertEqual("121.323", row["value"])
+        self.assertEqual("xsd:decimal", row["datatype"])
+
+    def test_12_property_literal_url_default(self) -> None:
+        """Test parsing a property with a literal object."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            property_value: http://purl.obolibrary.org/obo/chebi#mass "121.323" xsd:decimal
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.properties))
+        self.assertEqual("121.323", term.get_property(default_reference("chebi", "mass")))
+
+        df = ontology.get_properties_df()
+        self.assertEqual(4, len(df.columns))
+        self.assertEqual(1, len(df))
+        row = dict(df.iloc[0])
+        self.assertEqual("1234", row["chebi_id"])
+        self.assertEqual("mass", row["property"])
+        self.assertEqual("121.323", row["value"])
+        self.assertEqual("xsd:decimal", row["datatype"])
+
+    def test_12_property_literal_obo_purl(self) -> None:
+        """Test using a full OBO PURL as the property."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            property_value: http://purl.obolibrary.org/obo/RO_0018033 CHEBI:5678
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.properties))
+        self.assertIn(Reference(prefix="RO", identifier="0018033"), term.properties)
+        self.assertEqual("CHEBI:5678", term.get_property(is_conjugate_base_of))
+
+        df = ontology.get_properties_df()
+        self.assertEqual(4, len(df.columns))
+        self.assertEqual(1, len(df))
+        row = dict(df.iloc[0])
+        self.assertEqual(
+            {"chebi_id": "1234", "property": "RO:0018033", "value": "CHEBI:5678", "datatype": ""},
+            row,
+        )
+
+    def test_12_property_object_url(self) -> None:
+        """Test parsing an object URI."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            property_value: http://purl.obolibrary.org/obo/RO_0018033 http://purl.obolibrary.org/obo/CHEBI_5678
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.properties))
+        self.assertEqual("CHEBI:5678", term.get_property(is_conjugate_base_of))
+
+        df = ontology.get_properties_df()
+        self.assertEqual(4, len(df.columns))
+        self.assertEqual(1, len(df))
+        row = dict(df.iloc[0])
+        self.assertEqual(
+            {"chebi_id": "1234", "property": "RO:0018033", "value": "CHEBI:5678", "datatype": ""},
+            row,
+        )
+
+    def test_12_property_object_url_invalid(self) -> None:
+        """Test parsing an object URI."""
+        text = """\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            property_value: http://purl.obolibrary.org/obo/RO_0018033 http://example.org/nope:nope
+        """
+        with self.assertRaises(ValueError):
+            _read(text)
+        ontology = _read(text, strict=False)
+        term = self.get_only_term(ontology)
+        self.assertEqual(0, len(term.properties))
+
+    def test_12_property_literal_url(self) -> None:
+        """Test using a full OBO PURL as the property."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            property_value: https://w3id.org/biolink/vocab/something CHEBI:5678
+        """)
+        td = TypeDef.from_triple(prefix="biolink", identifier="something")
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.properties))
+        self.assertEqual("CHEBI:5678", term.get_property(td))
+
+    def test_12_property_unparsable_object(self) -> None:
+        """Test when an object can't be parsed."""
+        text = """\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            property_value: https://w3id.org/biolink/vocab/something NOPE:NOPE
+            """
+
+        with self.assertRaises(ValueError):
+            _read(text)
+
+        ontology = _read(text, strict=False)
+        term = self.get_only_term(ontology)
+        self.assertEqual(0, len(term.properties))
+
+    def test_12_property_literal_url_unregistered(self) -> None:
+        """Test using a full OBO PURL as the property."""
+        with self.assertRaises(UnparsableIRIError):
+            _read(
+                """\
+                ontology: chebi
+
+                [Term]
+                id: CHEBI:1234
+                property_value: https://example.com/nope/nope CHEBI:5678
+                """,
+                strict=True,
+            )
+
+        ontology = _read(
+            """\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            property_value: https://example.com/nope/nope CHEBI:5678
+            """,
+            strict=False,
+        )
+
+        term = self.get_only_term(ontology)
+        self.assertEqual(0, len(term.properties))
+
+    def test_12_property_literal_object(self) -> None:
+        """Test parsing a property with a literal object."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            property_value: rdfs:seeAlso hgnc:1234
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(list(term.properties)))
+        self.assertIn(see_also.reference, term.properties)
+        self.assertEqual("hgnc:1234", term.get_property(see_also))
+
+    def test_13_parent(self) -> None:
+        """Test parsing out a parent."""
+        ontology = _read("""\
+            ontology: chebi
+            date: 20:11:2024 18:44
+
+            [Term]
+            id: CHEBI:1234
+            is_a: CHEBI:5678
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual([Reference(prefix="CHEBI", identifier="5678")], term.parents)
+
+        ontology = _read("""\
+            ontology: chebi
+            date: 20:11:2024 18:44
+
+            [Term]
+            id: CHEBI:1234
+            is_a: http://purl.obolibrary.org/obo/CHEBI_5678
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual([Reference(prefix="CHEBI", identifier="5678")], term.parents)
+
+    def test_18_relationship_qualified_undefined(self) -> None:
+        """Test parsing a relationship that's loaded in the defaults."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            relationship: RO:0018033 CHEBI:5678
+        """)
+        term = self.get_only_term(ontology)
+        reference = term.get_relationship(is_conjugate_base_of)
+        self.assertIsNotNone(reference)
+        self.assertEqual("chebi:5678", reference.curie)
+
+    def test_18_relationship_qualified_defined(self) -> None:
+        """Test relationship parsing that's defined."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            relationship: RO:0018033 CHEBI:5678
+
+            [Typedef]
+            id: RO:0018033
+            name: is conjugate base of
+        """)
+        term = self.get_only_term(ontology)
+        reference = term.get_relationship(is_conjugate_base_of)
+        self.assertIsNotNone(reference)
+        self.assertEqual("chebi:5678", reference.curie)
+
+    def test_18_relationship_unqualified(self) -> None:
+        """Test relationship parsing that relies on default referencing."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            name: Test Name
+            relationship: xyz CHEBI:5678
+
+            [Typedef]
+            id: xyz
+        """)
+        term = self.get_only_term(ontology)
+        self.assertIsNone(term.get_relationship(is_conjugate_base_of))
+        r = default_reference("chebi", "xyz")
+        td = TypeDef(reference=r)
+        reference = term.get_relationship(td)
+        self.assertIsNotNone(reference)
+        self.assertEqual("chebi:5678", reference.curie)
+
+        rr = list(ontology.iterate_filtered_relations(td))
+        self.assertEqual(1, len(rr))
+
+        rr2 = list(ontology.iterate_filtered_relations(is_conjugate_base_of))
+        self.assertEqual(0, len(rr2))
+
+    def test_18_relationship_missing(self) -> None:
+        """Test parsing a relationship that isn't defined."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            name: Test Name
+            relationship: nope CHEBI:5678
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(0, len(list(term.iterate_relations())))
+
+    def test_18_relationship_bad_target(self) -> None:
+        """Test an ontology with a version but no date."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            relationship: RO:0018033 missing
+
+            [Typedef]
+            id: RO:0018033
+            name: is conjugate base of
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(0, len(list(term.iterate_relations())))
+
+
+class TestReaderTypedef(_Base):
+    """Tests for typedefs."""
+
+    def test_1_missing_identifier(self) -> None:
+        """Test loading an ontology with unparsable nodes."""
+        with self.assertRaises(KeyError) as exc:
+            _read("""\
+                ontology: chebi
+
+                [Typedef]
+                name: nope
+            """)
+        self.assertEqual("typedef is missing an `id`", exc.exception.args[0])
+
+    def test_6_definition_missing_end_quote(self) -> None:
+        """Test parsing a definition missing an ending quote."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            def: "malformed definition without quotes
+        """)
+        term = self.get_only_term(ontology)
+        self.assertIsNone(term.definition)
+
+    def test_6_definition_no_provenance(self) -> None:
+        """Test parsing a term with a definition and no provenance brackets."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            def: "definition of CHEBI:1234"
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual("definition of CHEBI:1234", term.definition)
+
+    def test_6_definition_empty_provenance(self) -> None:
+        """Test parsing a term with a definition and empty provenance."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            def: "definition of CHEBI:1234" []
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual("definition of CHEBI:1234", term.definition)
+
+    def test_6_definition_with_provenance(self) -> None:
+        """Test parsing a term with a definition and provenance."""
+        ontology = _read(f"""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            def: "definition of CHEBI:1234" [{CHARLIE.curie}]
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual("definition of CHEBI:1234", term.definition)
+        self.assertEqual(1, len(term.provenance))
+        self.assertEqual(CHARLIE, term.provenance[0])
+
+    def test_6_provenance_no_definition(self) -> None:
+        """Test parsing a term with provenance but no definition."""
+        ontology = _read(f"""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            def: "" [{CHARLIE.curie}]
+        """)
+        term = self.get_only_term(ontology)
+        self.assertIsNone(term.definition)
+        self.assertEqual(1, len(term.provenance))
+        self.assertEqual(CHARLIE, term.provenance[0])
+
+    def test_9_synonym_minimal(self) -> None:
+        """Test parsing a synonym just the text."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I"
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("LTEC I", synonym.name)
+        self.assertIsNone(synonym.specificity)
+        self.assertIsNone(synonym.type)
+        self.assertEqual([], synonym.provenance)
+
+    def test_9_synonym_with_specificity(self) -> None:
+        """Test parsing a synonym with specificity."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I" NARROW
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("LTEC I", synonym.name)
+        self.assertEqual("NARROW", synonym.specificity)
+        self.assertIsNone(synonym.type)
+        self.assertEqual([], synonym.provenance)
+
+    def test_9_synonym_with_type_missing_def(self) -> None:
+        """Test parsing a synonym with type, but missing type def."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I" OMO:1234567
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        #  this is because no typedef existed
+        self.assertIsNone(synonym.type)
+
+    def test_9_synonym_with_type(self) -> None:
+        """Test parsing a synonym with type."""
+        ontology = _read("""\
+            ontology: chebi
+            synonymtypedef: OMO:1234567 ""
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I" OMO:1234567
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("LTEC I", synonym.name)
+        self.assertIsNone(synonym.specificity)
+        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
+        self.assertEqual([], synonym.provenance)
+
+    def test_9_synonym_with_type_and_specificity(self) -> None:
+        """Test parsing a synonym with specificity and type."""
+        ontology = _read("""\
+            ontology: chebi
+            synonymtypedef: OMO:1234567 ""
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I" NARROW OMO:1234567
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("LTEC I", synonym.name)
+        self.assertEqual("NARROW", synonym.specificity)
+        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
+        self.assertEqual([], synonym.provenance)
+
+    def test_9_synonym_with_empty_prov(self) -> None:
+        """Test parsing a synonym with specificity,type, and explicit empty provenance."""
+        ontology = _read("""\
+            ontology: chebi
+            synonymtypedef: OMO:1234567 ""
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I" NARROW OMO:1234567 []
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("LTEC I", synonym.name)
+        self.assertEqual("NARROW", synonym.specificity)
+        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
+        self.assertEqual([], synonym.provenance)
+
+    def test_9_synonym_no_type(self) -> None:
+        """Test parsing a synonym with specificity and provenance."""
+        ontology = _read(f"""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I" EXACT [Orphanet:93938,{CHARLIE.curie}]
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("LTEC I", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertIsNone(synonym.type)
+        self.assertEqual(
+            [
+                Reference(prefix="orphanet", identifier="93938"),
+                CHARLIE,
+            ],
+            synonym.provenance,
+        )
+
+    def test_9_synonym_full(self) -> None:
+        """Test parsing a synonym with specificity, type, and provenance."""
+        ontology = _read(f"""\
+            ontology: chebi
+            synonymtypedef: OMO:1234567 ""
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I" EXACT OMO:1234567 [Orphanet:93938,{CHARLIE.curie}]
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("LTEC I", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
+        self.assertEqual(
+            [
+                Reference(prefix="orphanet", identifier="93938"),
+                CHARLIE,
+            ],
+            synonym.provenance,
+        )
+
+    def test_9_synonym_dashed(self) -> None:
+        """Test parsing a synonym with specificity, type, and provenance."""
+        ontology = _read("""\
+            ontology: chebi
+            synonymtypedef: OMO:1234567 ""
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "Brown-Pearce tumour" EXACT OMO:0003005 []
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("Brown-Pearce tumour", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertEqual(Reference(prefix="omo", identifier="0003005"), synonym.type)
+        self.assertEqual([], synonym.provenance)
+
+    def test_9_synonym_url(self) -> None:
+        """Test parsing a synonym defined with a PURL."""
+        ontology = _read(f"""\
+            ontology: chebi
+            synonymtypedef: http://purl.obolibrary.org/obo/OMO_1234567 ""
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I" EXACT OMO:1234567 [Orphanet:93938,{CHARLIE.curie}]
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("LTEC I", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
+        self.assertEqual(
+            [
+                Reference(prefix="orphanet", identifier="93938"),
+                CHARLIE,
+            ],
+            synonym.provenance,
+        )
+
+    def test_9_synonym_casing(self) -> None:
+        """Test parsing a synonym when an alternate case is used."""
+        ontology = _read(f"""\
+            ontology: chebi
+            synonymtypedef: OMO:1234567 ""
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I" EXACT omo:1234567 [Orphanet:93938,{CHARLIE.curie}]
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("LTEC I", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
+        self.assertEqual(
+            [
+                Reference(prefix="orphanet", identifier="93938"),
+                CHARLIE,
+            ],
+            synonym.provenance,
+        )
+
+    def test_9_synonym_default(self) -> None:
+        """Test parsing a synonym that has a built-in prefix."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "DoguAnadoluKirmizisi" EXACT most_common_name []
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("DoguAnadoluKirmizisi", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertIsNone(synonym.type)
+
+        # now, we define it properly
+        ontology = _read("""\
+            ontology: chebi
+            synonymtypedef: most_common_name "most common name"
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "DoguAnadoluKirmizisi" EXACT most_common_name []
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("DoguAnadoluKirmizisi", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertEqual(default_reference("chebi", "most_common_name"), synonym.type)
+
+    def test_9_synonym_builtin(self) -> None:
+        """Test parsing a synonym with specificity, type, and provenance."""
+        text = """\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "COP" EXACT ABBREVIATION []
+        """
+
+        ontology = _read(text, upgrade=False)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("COP", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertIsNone(synonym.type)
+
+        ontology = _read(text, upgrade=True)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("COP", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertEqual(abbreviation.reference, synonym.type)
+
+    @unittest.skip(reason=REASON_OBONET_IMPL)
+    def test_9_synonym_with_annotations(self) -> None:
+        """Test parsing a synonym with annotations."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "10*3.{copies}/mL" EXACT [] {http://purl.obolibrary.org/obo/NCIT_P383="AB", http://purl.obolibrary.org/obo/NCIT_P384="UCUM"}
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("10*3.{copies}/mL", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertIsNone(synonym.type)
+        self.assertEqual([], synonym.provenance)
+        # TODO update this when adding annotation parsing!
+        self.assertEqual([], synonym.annotations)
+
+    def test_10_typedef_xref(self) -> None:
+        """Test loading an ontology with unparsable nodes."""
+        ontology = _read("""\
+            ontology: chebi
+
+            [Typedef]
+            id: RO:0018033
+            name: is conjugate base of
+            xref: debio:0000010
+        """)
+        self.assertEqual(1, len(ontology.typedefs))
+        self.assertEqual(is_conjugate_base_of.pair, ontology.typedefs[0].pair)
+
+    def test_18_default_relation(self):
         """Test parsing a default relation."""
         ontology = _read("""\
             ontology: chebi
@@ -969,7 +1173,7 @@ class TestReader(unittest.TestCase):
         self.assertIn(derives_from.reference, term.relationships)
 
     @unittest.skip(reason=REASON_OBONET_IMPL)
-    def test_sssom_axiom(self) -> None:
+    def test_18_sssom_axiom(self) -> None:
         """Test SSSOM axioms."""
         ontology = _read("""\
             ontology: go
@@ -986,159 +1190,8 @@ class TestReader(unittest.TestCase):
         self.assertIsNotNone(context.contributor)
         self.assertEqual("0000-0003-4423-4370", context.contributor.identifier)
 
-    def test_root(self) -> None:
-        """Test root terms."""
-        ontology = _read("""\
-            ontology: go
-            property_value: IAO:0000700 GO:0050069
 
-            [Term]
-            id: GO:0050069
-        """)
-        # FIXME support default reference, like property_value: IAO:0000700 adhoc
-        self.assertEqual(
-            [Reference(prefix="GO", identifier="0050069")],
-            ontology.root_terms,
-        )
-
-    def test_subset(self) -> None:
-        """Test parsing a subset definition."""
-        ontology = _read("""\
-            ontology: chebi
-            subsetdef: TEST "comment"
-        """)
-        self.assertEqual(
-            [(default_reference("chebi", "TEST"), "comment")],
-            ontology.subsetdefs,
-        )
-
-    def test_properties(self) -> None:
-        """Test parsing properties."""
-        ontology = _read("""\
-            ontology: chebi
-            property_value: heyo also_heyo
-        """)
-        self.assertEqual(
-            [(default_reference("chebi", "heyo"), default_reference("chebi", "also_heyo"))],
-            ontology.property_values,
-        )
-
-    def test_xref_equivalent(self) -> None:
-        """Test the ``treat-xrefs-as-equivalent`` macro."""
-        ontology = _read("""\
-            ontology: go
-            treat-xrefs-as-equivalent: CL
-
-            [Term]
-            id: GO:0005623
-            name: cell
-            xref: CL:0000000
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(0, len(term.xrefs))
-        self.assertEqual(0, len(term.parents))
-        self.assertEqual(0, len(term.properties))
-        self.assertEqual(1, len(term.relationships))
-        self.assertEqual(0, len(term.intersection_of))
-        self.assertIn(equivalent_class.reference, term.relationships)
-        self.assertEqual(
-            [Reference(prefix="CL", identifier="0000000")],
-            term.relationships[equivalent_class.reference],
-        )
-
-    def test_xref_is_a_for_term(self) -> None:
-        """Test the ``treat-xrefs-as-is_a `` macro."""
-        ontology = _read("""\
-            ontology: go
-            treat-xrefs-as-is_a: CL
-
-            [Term]
-            id: GO:0005623
-            name: cell
-            xref: CL:0000000
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(0, len(term.xrefs), msg=term.xrefs)
-        self.assertEqual(1, len(term.parents))
-        self.assertEqual(0, len(term.properties))
-        self.assertEqual(0, len(term.relationships))
-        self.assertEqual(0, len(term.intersection_of))
-        self.assertEqual([Reference(prefix="CL", identifier="0000000")], term.parents)
-
-    def test_xref_is_a_for_typedef(self) -> None:
-        """Test the ``treat-xrefs-as-is_a `` macro."""
-        ontology = _read("""\
-            ontology: ro
-            treat-xrefs-as-is_a: skos
-
-            [Typedef]
-            id: RO:0000000
-            xref: skos:closeMatch
-        """)
-        typedef = self.get_only_typedef(ontology)
-        self.assertEqual(0, len(typedef.xrefs), msg=typedef.xrefs)
-        self.assertEqual(1, len(typedef.parents))
-        self.assertEqual(0, len(typedef.relationships))
-        self.assertEqual(0, len(typedef.intersection_of))
-        self.assertEqual([Reference(prefix="skos", identifier="closeMatch")], typedef.parents)
-
-    def test_xref_relation(self) -> None:
-        """Test the ``treat-xrefs-as-relationship  `` macro."""
-        ontology = _read("""\
-            ontology: go
-            treat-xrefs-as-relationship: CL BFO:0000000
-
-            [Term]
-            id: GO:0005623
-            name: cell
-            xref: CL:0000000
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(0, len(term.xrefs))
-        self.assertEqual(0, len(term.parents))
-        self.assertEqual(0, len(term.properties))
-        self.assertEqual(1, len(term.relationships))
-        self.assertEqual(0, len(term.intersection_of))
-        pred = Reference(prefix="BFO", identifier="0000000")
-        self.assertIn(pred, term.relationships)
-        self.assertEqual([Reference(prefix="CL", identifier="0000000")], term.relationships[pred])
-
-    def test_xref_genus_differentia(self) -> None:
-        """Test the ``treat-xrefs-as-is_a `` macro.
-
-        The test should become the same as:
-
-        .. code::
-
-            [Term]
-            id: ZFA:0000134
-            intersection_of: CL:0000540
-            intersection_of: BFO:0000050 NCBITaxon:7955
-        """
-        ontology = _read("""\
-            ontology: zfa
-            treat-xrefs-as-genus-differentia: CL BFO:0000050 NCBITaxon:7955
-
-            [Term]
-            id: ZFA:0000134
-            xref: CL:0000540
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(0, len(term.xrefs))
-        self.assertEqual(0, len(term.parents))
-        self.assertEqual(0, len(term.properties))
-        self.assertEqual(0, len(term.relationships))
-        self.assertEqual(2, len(term.intersection_of))
-        self.assertEqual(
-            [
-                Reference(prefix="CL", identifier="0000540"),
-                Annotation(part_of.reference, Reference(prefix="NCBITaxon", identifier="7955")),
-            ],
-            term.intersection_of,
-        )
-
-
-class TestVersionHandling(unittest.TestCase):
+class TestVersionHandling(_Base):
     """Test version handling."""
 
     def test_no_version_no_data(self):

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -264,7 +264,7 @@ class TestReaderTerm(unittest.TestCase):
             comment: comment
         """)
         term = self.get_only_term(ontology)
-        comments = term.iterate_property_targets(comment)
+        comments = term.get_property_values(comment)
         self.assertEqual(1, len(comments))
         self.assertIsInstance(comments[0], OBOLiteral)
         self.assertEqual("comment", comments[0].value)
@@ -630,7 +630,7 @@ class TestReaderTerm(unittest.TestCase):
             property_value: nope
         """)
         term = self.get_only_term(ontology)
-        self.assertEqual(0, len(list(term.iterate_properties())))
+        self.assertEqual(0, len(list(term.get_property_annotations())))
 
     def test_12_property_literal_bare(self) -> None:
         """Test parsing a property with a literal object."""
@@ -1096,7 +1096,7 @@ class TestReaderTerm(unittest.TestCase):
             replaced_by: CHEBI:5678
         """)
         term = self.get_only_term(ontology)
-        replaced = term.iterate_property_targets(term_replaced_by)
+        replaced = term.get_property_values(term_replaced_by)
         self.assertEqual(1, len(replaced))
         self.assertEqual(Reference(prefix="CHEBI", identifier="5678"), replaced[0])
 
@@ -1110,7 +1110,7 @@ class TestReaderTerm(unittest.TestCase):
             consider: CHEBI:5678
         """)
         term = self.get_only_term(ontology)
-        consider = term.iterate_property_targets(see_also)
+        consider = term.get_property_values(see_also)
         self.assertEqual(1, len(consider))
         self.assertEqual(
             Reference(prefix="CHEBI", identifier="5678"),

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,48 +1,29 @@
 """Tests for the reader."""
 
-import datetime
 import unittest
-from io import StringIO
-from textwrap import dedent
-
-from obonet import read_obo
 
 from pyobo import Obo, Reference, Term
 from pyobo.identifier_utils import UnparsableIRIError
-from pyobo.reader import from_obonet, get_first_nonescaped_quote
+from pyobo.reader import from_str, get_first_nonescaped_quote
 from pyobo.struct import default_reference
 from pyobo.struct.reference import OBOLiteral
 from pyobo.struct.struct import abbreviation
-from pyobo.struct.struct_utils import Annotation
 from pyobo.struct.typedef import (
     TypeDef,
     comment,
     derives_from,
-    equivalent_class,
     exact_match,
     has_dbxref,
     is_conjugate_base_of,
-    part_of,
     see_also,
     term_replaced_by,
 )
+from pyobo.struct.vocabulary import CHARLIE
 
-CHARLIE = Reference(prefix="orcid", identifier="0000-0003-4423-4370")
 REASON_OBONET_IMPL = (
     "This needs to be fixed upstream, since obonet's parser "
     "for synonyms fails on the open squiggly bracket {"
 )
-
-
-def _read(
-    text: str, *, strict: bool = True, version: str | None = None, upgrade: bool = True
-) -> Obo:
-    text = dedent(text).strip()
-    io = StringIO()
-    io.write(text)
-    io.seek(0)
-    graph = read_obo(io)
-    return from_obonet(graph, strict=strict, version=version, upgrade=upgrade)
 
 
 class TestUtils(unittest.TestCase):
@@ -62,235 +43,62 @@ class TestUtils(unittest.TestCase):
         self.assertIsNone(get_first_nonescaped_quote('\\"hello\\"'))
 
 
-class _Base(unittest.TestCase):
-    """Base test case."""
+class TestReaderTerm(unittest.TestCase):
+    """Test the reader."""
 
     def get_only_term(self, ontology: Obo) -> Term:
         """Assert there is only a single term in the ontology and return it."""
         terms = list(ontology.iter_terms())
-        self.assertEqual(1, len(terms))
+        self.assertNotEqual(0, len(terms), msg="was not able to parse the only term")
+        self.assertEqual(
+            1, len(terms), msg="got too many terms:\n\n{}".format("\n".join(str(t) for t in terms))
+        )
         term = terms[0]
         return term
 
-    def get_only_typedef(self, ontology: Obo) -> TypeDef:
-        """Assert there is only a single typedef in the ontology and return it."""
-        self.assertEqual(1, len(ontology.typedefs))
-        return ontology.typedefs[0]
-
-
-class TestReaderOntologyMetadata(_Base):
-    """Test the reader on ontology metadata."""
-
-    def test_0_missing_date_version(self) -> None:
-        """Test an ontology with a missing date and version."""
-        ontology = _read("""\
+    def assert_boolean_flag(self, tag: str) -> None:
+        """Test a boolean flag."""
+        ontology = from_str("""\
             ontology: chebi
-        """)
-        self.assertIsNone(ontology.date)
-        self.assertIsNone(ontology.data_version)
-
-    def test_1_format_version(self) -> None:
-        """Test ``format-version`` tag."""
-        raise NotImplementedError
-
-    # for data-version, see the full test case below
-
-    def test_3_bad_date_format(self) -> None:
-        """Test an ontology with a malformed date and no version."""
-        ontology = _read("""\
-            ontology: chebi
-            date: aabbccddeee
-        """)
-        self.assertIsNone(ontology.date)
-        self.assertIsNone(ontology.data_version)
-
-    def test_3_date_no_version(self) -> None:
-        """Test an ontology with a date but no version."""
-        ontology = _read("""\
-            ontology: chebi
-            date: 20:11:2024 18:44
-        """)
-        self.assertEqual(datetime.datetime(2024, 11, 20, 18, 44), ontology.date)
-        self.assertEqual("2024-11-20", ontology.data_version)
-
-    def test_4_saved_by(self) -> None:
-        """Test the ``saved-by`` tag."""
-        raise NotImplementedError
-
-    def test_5_auto_generated_by(self) -> None:
-        """Test the ``auto-generated-by`` tag."""
-        raise NotImplementedError
-
-    def test_6_import(self) -> None:
-        """Test the ``import`` tag."""
-        raise NotImplementedError
-
-    def test_7_subset(self) -> None:
-        """Test parsing a subset definition."""
-        ontology = _read("""\
-            ontology: chebi
-            subsetdef: TEST "comment"
-        """)
-        self.assertEqual(
-            [(default_reference("chebi", "TEST"), "comment")],
-            ontology.subsetdefs,
-        )
-
-    def test_12_xref_equivalent(self) -> None:
-        """Test the ``treat-xrefs-as-equivalent`` macro."""
-        ontology = _read("""\
-            ontology: go
-            treat-xrefs-as-equivalent: CL
 
             [Term]
-            id: GO:0005623
-            name: cell
-            xref: CL:0000000
+            id: CHEBI:1234
+            name: test
         """)
         term = self.get_only_term(ontology)
-        self.assertEqual(0, len(term.xrefs))
-        self.assertEqual(0, len(term.parents))
-        self.assertEqual(0, len(term.properties))
-        self.assertEqual(1, len(term.relationships))
-        self.assertEqual(0, len(term.intersection_of))
-        self.assertIn(equivalent_class.reference, term.relationships)
-        self.assertEqual(
-            [Reference(prefix="CL", identifier="0000000")],
-            term.relationships[equivalent_class.reference],
-        )
+        self.assertTrue(hasattr(term, tag))
+        value = getattr(term, tag)
+        self.assertIsNone(value)
 
-    def test_13_xref_genus_differentia(self) -> None:
-        """Test the ``treat-xrefs-as-is_a `` macro.
-
-        The test should become the same as:
-
-        .. code::
-
-            [Term]
-            id: ZFA:0000134
-            intersection_of: CL:0000540
-            intersection_of: BFO:0000050 NCBITaxon:7955
-        """
-        ontology = _read("""\
-              ontology: zfa
-              treat-xrefs-as-genus-differentia: CL BFO:0000050 NCBITaxon:7955
-
-              [Term]
-              id: ZFA:0000134
-              xref: CL:0000540
-          """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(0, len(term.xrefs))
-        self.assertEqual(0, len(term.parents))
-        self.assertEqual(0, len(term.properties))
-        self.assertEqual(0, len(term.relationships))
-        self.assertEqual(2, len(term.intersection_of))
-        self.assertEqual(
-            [
-                Reference(prefix="CL", identifier="0000540"),
-                Annotation(part_of.reference, Reference(prefix="NCBITaxon", identifier="7955")),
-            ],
-            term.intersection_of,
-        )
-
-    def test_14_xref_relation(self) -> None:
-        """Test the ``treat-xrefs-as-relationship  `` macro."""
-        ontology = _read("""\
-            ontology: go
-            treat-xrefs-as-relationship: CL BFO:0000000
-
-            [Term]
-            id: GO:0005623
-            name: cell
-            xref: CL:0000000
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(0, len(term.xrefs))
-        self.assertEqual(0, len(term.parents))
-        self.assertEqual(0, len(term.properties))
-        self.assertEqual(1, len(term.relationships))
-        self.assertEqual(0, len(term.intersection_of))
-        pred = Reference(prefix="BFO", identifier="0000000")
-        self.assertIn(pred, term.relationships)
-        self.assertEqual([Reference(prefix="CL", identifier="0000000")], term.relationships[pred])
-
-    def test_15_xref_is_a_for_term(self) -> None:
-        """Test the ``treat-xrefs-as-is_a `` macro."""
-        ontology = _read("""\
-            ontology: go
-            treat-xrefs-as-is_a: CL
-
-            [Term]
-            id: GO:0005623
-            name: cell
-            xref: CL:0000000
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(0, len(term.xrefs), msg=term.xrefs)
-        self.assertEqual(1, len(term.parents))
-        self.assertEqual(0, len(term.properties))
-        self.assertEqual(0, len(term.relationships))
-        self.assertEqual(0, len(term.intersection_of))
-        self.assertEqual([Reference(prefix="CL", identifier="0000000")], term.parents)
-
-    def test_15_xref_is_a_for_typedef(self) -> None:
-        """Test the ``treat-xrefs-as-is_a `` macro."""
-        ontology = _read("""\
-            ontology: ro
-            treat-xrefs-as-is_a: skos
-
-            [Typedef]
-            id: RO:0000000
-            xref: skos:closeMatch
-        """)
-        typedef = self.get_only_typedef(ontology)
-        self.assertEqual(0, len(typedef.xrefs), msg=typedef.xrefs)
-        self.assertEqual(1, len(typedef.parents))
-        self.assertEqual(0, len(typedef.relationships))
-        self.assertEqual(0, len(typedef.intersection_of))
-        self.assertEqual([Reference(prefix="skos", identifier="closeMatch")], typedef.parents)
-
-    def test_17_unknown_ontology_prefix(self) -> None:
-        """Test an ontology with an unknown prefix."""
-        with self.assertRaises(ValueError) as exc:
-            _read("""\
-                ontology: nope
-            """)
-        self.assertEqual("unknown prefix: nope", exc.exception.args[0])
-
-    def test_18_properties(self) -> None:
-        """Test parsing properties."""
-        ontology = _read("""\
+        ontology = from_str(f"""\
             ontology: chebi
-            property_value: heyo also_heyo
-        """)
-        self.assertEqual(
-            [(default_reference("chebi", "heyo"), default_reference("chebi", "also_heyo"))],
-            ontology.property_values,
-        )
-
-    def test_18_root(self) -> None:
-        """Test root terms."""
-        ontology = _read("""\
-            ontology: go
-            property_value: IAO:0000700 GO:0050069
 
             [Term]
-            id: GO:0050069
+            id: CHEBI:1234
+            {tag}: true
         """)
-        # FIXME support default reference, like property_value: IAO:0000700 adhoc
-        self.assertEqual(
-            [Reference(prefix="GO", identifier="0050069")],
-            ontology.root_terms,
-        )
+        term = self.get_only_term(ontology)
+        self.assertTrue(hasattr(term, tag))
+        value = getattr(term, tag)
+        self.assertIsNotNone(value)
+        self.assertTrue(value)
 
+        ontology = from_str(f"""\
+            ontology: chebi
 
-class TestReaderTerm(_Base):
-    """Test the reader."""
+            [Term]
+            id: CHEBI:1234
+            {tag}: false
+        """)
+        term = self.get_only_term(ontology)
+        self.assertTrue(hasattr(term, tag))
+        value = getattr(term, tag)
+        self.assertIsNotNone(value)
+        self.assertFalse(value)
 
     def test_0_minimal(self) -> None:
         """Test an ontology with a version but no date."""
-        ontology = _read("""\
+        ontology = from_str("""\
             data-version: 185
             ontology: chebi
 
@@ -318,50 +126,61 @@ class TestReaderTerm(_Base):
             id: nope:1234
         """
         with self.assertRaises(ValueError):
-            _read(text)
-        ontology = _read(text, strict=False)
+            from_str(text)
+        ontology = from_str(text, strict=False)
         self.assertEqual(0, len(list(ontology.iter_terms())))
 
-    def test_1_is_anonymous_missing(self) -> None:
+    def test_2_is_anonymous(self) -> None:
         """Test the ``is-anonymous`` tag."""
-        ontology = _read("""\
+        self.assert_boolean_flag("is_anonymous")
+
+    def test_3_name(self) -> None:
+        """Test the ``name`` tag."""
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
             id: CHEBI:1234
+            name: test-name
         """)
         term = self.get_only_term(ontology)
-        self.assertIsNone(term.is_anonymous)
+        self.assertEqual("test-name", term.name)
 
-    def test_1_is_anonymous_true(self) -> None:
-        """Test the ``is-anonymous`` tag."""
-        ontology = _read("""\
+    def test_4_namespace(self) -> None:
+        """Test the ``namespacae`` tag."""
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
             id: CHEBI:1234
-            is_anonymous: true
+            namespace: test-namespace
         """)
         term = self.get_only_term(ontology)
-        self.assertIsNotNone(term.is_anonymous)
-        self.assertTrue(term.is_anonymous)
+        self.assertEqual("test-namespace", term.namespace)
 
-    def test_1_is_anonymous_false(self) -> None:
-        """Test the ``is-anonymous`` tag."""
-        ontology = _read("""\
+    def test_5_alt_id(self) -> None:
+        """Test the ``alt_id`` tag."""
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
             id: CHEBI:1234
-            is_anonymous: false
+            alt_id: CHEBI:1
+            alt_id: CHEBI:2
         """)
         term = self.get_only_term(ontology)
-        self.assertIsNotNone(term.is_anonymous)
-        self.assertFalse(term.is_anonymous)
+        self.assertEqual(2, len(term.alt_ids))
+        self.assertEqual(
+            [
+                Reference(prefix="CHEBI", identifier="1"),
+                Reference(prefix="CHEBI", identifier="2"),
+            ],
+            term.alt_ids,
+        )
 
     def test_6_definition_missing_start_quote(self) -> None:
         """Test parsing a definition missing a starting quote."""
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
@@ -371,9 +190,73 @@ class TestReaderTerm(_Base):
         term = self.get_only_term(ontology)
         self.assertIsNone(term.definition)
 
+    def test_6_definition_missing_end_quote(self) -> None:
+        """Test parsing a definition missing an ending quote."""
+        ontology = from_str("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            def: "malformed definition without quotes
+        """)
+        term = self.get_only_term(ontology)
+        self.assertIsNone(term.definition)
+
+    def test_6_definition_no_provenance(self) -> None:
+        """Test parsing a term with a definition and no provenance brackets."""
+        ontology = from_str("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            def: "definition of CHEBI:1234"
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual("definition of CHEBI:1234", term.definition)
+
+    def test_6_definition_empty_provenance(self) -> None:
+        """Test parsing a term with a definition and empty provenance."""
+        ontology = from_str("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            def: "definition of CHEBI:1234" []
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual("definition of CHEBI:1234", term.definition)
+
+    def test_6_definition_with_provenance(self) -> None:
+        """Test parsing a term with a definition and provenance."""
+        ontology = from_str(f"""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            def: "definition of CHEBI:1234" [{CHARLIE.curie}]
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual("definition of CHEBI:1234", term.definition)
+        self.assertEqual(1, len(term.provenance))
+        self.assertEqual(CHARLIE, term.provenance[0])
+
+    def test_6_provenance_no_definition(self) -> None:
+        """Test parsing a term with provenance but no definition."""
+        ontology = from_str(f"""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            def: "" [{CHARLIE.curie}]
+        """)
+        term = self.get_only_term(ontology)
+        self.assertIsNone(term.definition)
+        self.assertEqual(1, len(term.provenance))
+        self.assertEqual(CHARLIE, term.provenance[0])
+
     def test_7_comment(self) -> None:
         """Test parsing a definition missing a starting quote."""
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
@@ -381,14 +264,321 @@ class TestReaderTerm(_Base):
             comment: comment
         """)
         term = self.get_only_term(ontology)
-        comments = term.iterate_property(comment)
+        comments = term.iterate_property_targets(comment)
         self.assertEqual(1, len(comments))
         self.assertIsInstance(comments[0], OBOLiteral)
         self.assertEqual("comment", comments[0].value)
 
+    def test_8_subset(self) -> None:
+        """Test parsing subsets."""
+        ontology = from_str("""\
+            ontology: go
+
+            [Term]
+            id: GO:0050069
+            subset: TESTSET
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.subsets))
+        self.assertEqual(default_reference("go", "TESTSET"), term.subsets[0])
+
+    def test_9_synonym_minimal(self) -> None:
+        """Test parsing a synonym just the text."""
+        ontology = from_str("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I"
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("LTEC I", synonym.name)
+        self.assertIsNone(synonym.specificity)
+        self.assertIsNone(synonym.type)
+        self.assertEqual([], synonym.provenance)
+
+    def test_9_synonym_with_specificity(self) -> None:
+        """Test parsing a synonym with specificity."""
+        ontology = from_str("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I" NARROW
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("LTEC I", synonym.name)
+        self.assertEqual("NARROW", synonym.specificity)
+        self.assertIsNone(synonym.type)
+        self.assertEqual([], synonym.provenance)
+
+    def test_9_synonym_with_type_missing_def(self) -> None:
+        """Test parsing a synonym with type, but missing type def."""
+        ontology = from_str("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I" OMO:1234567
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        #  this is because no typedef existed
+        self.assertIsNone(synonym.type)
+
+    def test_9_synonym_with_type(self) -> None:
+        """Test parsing a synonym with type."""
+        ontology = from_str("""\
+            ontology: chebi
+            synonymtypedef: OMO:1234567 ""
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I" OMO:1234567
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("LTEC I", synonym.name)
+        self.assertIsNone(synonym.specificity)
+        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
+        self.assertEqual([], synonym.provenance)
+
+    def test_9_synonym_with_type_and_specificity(self) -> None:
+        """Test parsing a synonym with specificity and type."""
+        ontology = from_str("""\
+            ontology: chebi
+            synonymtypedef: OMO:1234567 ""
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I" NARROW OMO:1234567
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("LTEC I", synonym.name)
+        self.assertEqual("NARROW", synonym.specificity)
+        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
+        self.assertEqual([], synonym.provenance)
+
+    def test_9_synonym_with_empty_prov(self) -> None:
+        """Test parsing a synonym with specificity,type, and explicit empty provenance."""
+        ontology = from_str("""\
+            ontology: chebi
+            synonymtypedef: OMO:1234567 ""
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I" NARROW OMO:1234567 []
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("LTEC I", synonym.name)
+        self.assertEqual("NARROW", synonym.specificity)
+        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
+        self.assertEqual([], synonym.provenance)
+
+    def test_9_synonym_no_type(self) -> None:
+        """Test parsing a synonym with specificity and provenance."""
+        ontology = from_str(f"""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I" EXACT [Orphanet:93938,{CHARLIE.curie}]
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("LTEC I", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertIsNone(synonym.type)
+        self.assertEqual(
+            [
+                Reference(prefix="orphanet", identifier="93938"),
+                CHARLIE,
+            ],
+            synonym.provenance,
+        )
+
+    def test_9_synonym_full(self) -> None:
+        """Test parsing a synonym with specificity, type, and provenance."""
+        ontology = from_str(f"""\
+            ontology: chebi
+            synonymtypedef: OMO:1234567 ""
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I" EXACT OMO:1234567 [Orphanet:93938,{CHARLIE.curie}]
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("LTEC I", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
+        self.assertEqual(
+            [
+                Reference(prefix="orphanet", identifier="93938"),
+                CHARLIE,
+            ],
+            synonym.provenance,
+        )
+
+    def test_9_synonym_dashed(self) -> None:
+        """Test parsing a synonym with specificity, type, and provenance."""
+        ontology = from_str("""\
+            ontology: chebi
+            synonymtypedef: OMO:1234567 ""
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "Brown-Pearce tumour" EXACT OMO:0003005 []
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("Brown-Pearce tumour", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertEqual(Reference(prefix="omo", identifier="0003005"), synonym.type)
+        self.assertEqual([], synonym.provenance)
+
+    def test_9_synonym_url(self) -> None:
+        """Test parsing a synonym defined with a PURL."""
+        ontology = from_str(f"""\
+            ontology: chebi
+            synonymtypedef: http://purl.obolibrary.org/obo/OMO_1234567 ""
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I" EXACT OMO:1234567 [Orphanet:93938,{CHARLIE.curie}]
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("LTEC I", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
+        self.assertEqual(
+            [
+                Reference(prefix="orphanet", identifier="93938"),
+                CHARLIE,
+            ],
+            synonym.provenance,
+        )
+
+    def test_9_synonym_casing(self) -> None:
+        """Test parsing a synonym when an alternate case is used."""
+        ontology = from_str(f"""\
+            ontology: chebi
+            synonymtypedef: OMO:1234567 ""
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "LTEC I" EXACT omo:1234567 [Orphanet:93938,{CHARLIE.curie}]
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("LTEC I", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
+        self.assertEqual(
+            [
+                Reference(prefix="orphanet", identifier="93938"),
+                CHARLIE,
+            ],
+            synonym.provenance,
+        )
+
+    def test_9_synonym_default(self) -> None:
+        """Test parsing a synonym that has a built-in prefix."""
+        ontology = from_str("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "DoguAnadoluKirmizisi" EXACT most_common_name []
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("DoguAnadoluKirmizisi", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertIsNone(synonym.type)
+
+        # now, we define it properly
+        ontology = from_str("""\
+            ontology: chebi
+            synonymtypedef: most_common_name "most common name"
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "DoguAnadoluKirmizisi" EXACT most_common_name []
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("DoguAnadoluKirmizisi", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertEqual(default_reference("chebi", "most_common_name"), synonym.type)
+
+    def test_9_synonym_builtin(self) -> None:
+        """Test parsing a synonym with specificity, type, and provenance."""
+        text = """\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "COP" EXACT ABBREVIATION []
+        """
+
+        ontology = from_str(text, upgrade=False)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("COP", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertIsNone(synonym.type)
+
+        ontology = from_str(text, upgrade=True)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("COP", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertEqual(abbreviation.reference, synonym.type)
+
+    @unittest.skip(reason=REASON_OBONET_IMPL)
+    def test_9_synonym_with_annotations(self) -> None:
+        """Test parsing a synonym with annotations."""
+        ontology = from_str("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1234
+            synonym: "10*3.{copies}/mL" EXACT [] {http://purl.obolibrary.org/obo/NCIT_P383="AB", http://purl.obolibrary.org/obo/NCIT_P384="UCUM"}
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(term.synonyms))
+        synonym = term.synonyms[0]
+        self.assertEqual("10*3.{copies}/mL", synonym.name)
+        self.assertEqual("EXACT", synonym.specificity)
+        self.assertIsNone(synonym.type)
+        self.assertEqual([], synonym.provenance)
+        # TODO update this when adding annotation parsing!
+        self.assertEqual([], synonym.annotations)
+
     def test_10_xrefs(self) -> None:
         """Test getting mappings."""
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
@@ -405,7 +595,7 @@ class TestReaderTerm(_Base):
             {(a.pair, b.pair) for a, b in term.get_mappings(include_xrefs=False)},
         )
 
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
@@ -426,46 +616,13 @@ class TestReaderTerm(_Base):
             {(a.pair, b.pair) for a, b in term.get_mappings(include_xrefs=True)},
         )
 
-    def test_11_builtin_missing(self) -> None:
+    def test_11_builtin(self) -> None:
         """Test the ``builtin`` tag."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-        """)
-        term = self.get_only_term(ontology)
-        self.assertIsNone(term.builtin)
-
-    def test_11_builtin_true(self) -> None:
-        """Test the ``builtin`` tag."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            builtin: true
-        """)
-        term = self.get_only_term(ontology)
-        self.assertIsNotNone(term.builtin)
-        self.assertTrue(term.builtin)
-
-    def test_11_builtin_false(self) -> None:
-        """Test the ``builtin`` tag."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            builtin: false
-        """)
-        term = self.get_only_term(ontology)
-        self.assertIsNotNone(term.builtin)
-        self.assertFalse(term.builtin)
+        self.assert_boolean_flag("builtin")
 
     def test_12_property_malformed(self) -> None:
         """Test parsing a malformed property."""
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
@@ -477,7 +634,7 @@ class TestReaderTerm(_Base):
 
     def test_12_property_literal_bare(self) -> None:
         """Test parsing a property with a literal object."""
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
@@ -499,7 +656,7 @@ class TestReaderTerm(_Base):
 
     def test_12_property_literal_typed(self) -> None:
         """Test parsing a property with a literal object."""
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
@@ -534,14 +691,14 @@ class TestReaderTerm(_Base):
             property_value: mass "121.323" NOPE:NOPE
         """
         with self.assertRaises(ValueError):
-            _read(text)
-        ontology = _read(text, strict=False)
+            from_str(text)
+        ontology = from_str(text, strict=False)
         term = self.get_only_term(ontology)
         self.assertEqual(0, len(term.properties))
 
     def test_12_property_literal_url_questionable(self) -> None:
         """Test parsing a property with a literal object."""
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
@@ -563,7 +720,7 @@ class TestReaderTerm(_Base):
 
     def test_12_property_literal_url_default(self) -> None:
         """Test parsing a property with a literal object."""
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
@@ -585,7 +742,7 @@ class TestReaderTerm(_Base):
 
     def test_12_property_literal_obo_purl(self) -> None:
         """Test using a full OBO PURL as the property."""
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
@@ -608,7 +765,7 @@ class TestReaderTerm(_Base):
 
     def test_12_property_object_url(self) -> None:
         """Test parsing an object URI."""
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
@@ -638,14 +795,14 @@ class TestReaderTerm(_Base):
             property_value: http://purl.obolibrary.org/obo/RO_0018033 http://example.org/nope:nope
         """
         with self.assertRaises(ValueError):
-            _read(text)
-        ontology = _read(text, strict=False)
+            from_str(text)
+        ontology = from_str(text, strict=False)
         term = self.get_only_term(ontology)
         self.assertEqual(0, len(term.properties))
 
     def test_12_property_literal_url(self) -> None:
         """Test using a full OBO PURL as the property."""
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
@@ -668,16 +825,16 @@ class TestReaderTerm(_Base):
             """
 
         with self.assertRaises(ValueError):
-            _read(text)
+            from_str(text)
 
-        ontology = _read(text, strict=False)
+        ontology = from_str(text, strict=False)
         term = self.get_only_term(ontology)
         self.assertEqual(0, len(term.properties))
 
     def test_12_property_literal_url_unregistered(self) -> None:
         """Test using a full OBO PURL as the property."""
         with self.assertRaises(UnparsableIRIError):
-            _read(
+            from_str(
                 """\
                 ontology: chebi
 
@@ -688,7 +845,7 @@ class TestReaderTerm(_Base):
                 strict=True,
             )
 
-        ontology = _read(
+        ontology = from_str(
             """\
             ontology: chebi
 
@@ -704,7 +861,7 @@ class TestReaderTerm(_Base):
 
     def test_12_property_literal_object(self) -> None:
         """Test parsing a property with a literal object."""
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
@@ -718,7 +875,7 @@ class TestReaderTerm(_Base):
 
     def test_13_parent(self) -> None:
         """Test parsing out a parent."""
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
             date: 20:11:2024 18:44
 
@@ -729,7 +886,7 @@ class TestReaderTerm(_Base):
         term = self.get_only_term(ontology)
         self.assertEqual([Reference(prefix="CHEBI", identifier="5678")], term.parents)
 
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
             date: 20:11:2024 18:44
 
@@ -740,9 +897,85 @@ class TestReaderTerm(_Base):
         term = self.get_only_term(ontology)
         self.assertEqual([Reference(prefix="CHEBI", identifier="5678")], term.parents)
 
+    def test_14_intersection_of(self) -> None:
+        """Test the ``intersection_of`` tag."""
+        ontology = from_str("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1
+            intersection_of: CHEBI:2
+            intersection_of: RO:1 CHEBI:3
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(
+            [
+                Reference(prefix="CHEBI", identifier="2"),
+                (Reference(prefix="RO", identifier="1"), Reference(prefix="CHEBI", identifier="3")),
+            ],
+            term.intersection_of,
+        )
+
+    def test_15_union_of(self) -> None:
+        """Test the ``union_of`` tag."""
+        ontology = from_str("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1
+            union_of: CHEBI:2
+            union_of: CHEBI:3
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(
+            [
+                Reference(prefix="CHEBI", identifier="2"),
+                Reference(prefix="CHEBI", identifier="3"),
+            ],
+            term.union_of,
+        )
+
+    def test_16_equivalent_to(self) -> None:
+        """Test the ``equivalent_to`` tag."""
+        ontology = from_str("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1
+            equivalent_to: CHEBI:2
+            equivalent_to: CHEBI:3
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(
+            [
+                Reference(prefix="CHEBI", identifier="2"),
+                Reference(prefix="CHEBI", identifier="3"),
+            ],
+            term.equivalent_to,
+        )
+
+    def test_17_disjoint_from(self) -> None:
+        """Test the ``disjoint_from`` tag."""
+        ontology = from_str("""\
+            ontology: chebi
+
+            [Term]
+            id: CHEBI:1
+            disjoint_from: CHEBI:2
+            disjoint_from: CHEBI:3
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(
+            [
+                Reference(prefix="CHEBI", identifier="2"),
+                Reference(prefix="CHEBI", identifier="3"),
+            ],
+            term.disjoint_from,
+        )
+
     def test_18_relationship_qualified_undefined(self) -> None:
         """Test parsing a relationship that's loaded in the defaults."""
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
@@ -756,7 +989,7 @@ class TestReaderTerm(_Base):
 
     def test_18_relationship_qualified_defined(self) -> None:
         """Test relationship parsing that's defined."""
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
@@ -774,7 +1007,7 @@ class TestReaderTerm(_Base):
 
     def test_18_relationship_unqualified(self) -> None:
         """Test relationship parsing that relies on default referencing."""
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
@@ -799,22 +1032,9 @@ class TestReaderTerm(_Base):
         rr2 = list(ontology.iterate_filtered_relations(is_conjugate_base_of))
         self.assertEqual(0, len(rr2))
 
-    def test_18_relationship_missing(self) -> None:
-        """Test parsing a relationship that isn't defined."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            name: Test Name
-            relationship: nope CHEBI:5678
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(0, len(list(term.iterate_relations())))
-
     def test_18_relationship_bad_target(self) -> None:
         """Test an ontology with a version but no date."""
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
@@ -828,446 +1048,9 @@ class TestReaderTerm(_Base):
         term = self.get_only_term(ontology)
         self.assertEqual(0, len(list(term.iterate_relations())))
 
-    def test_21_obsolete_missing(self) -> None:
-        """Test the ``is_obsolete`` tag."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-        """)
-        term = self.get_only_term(ontology)
-        self.assertIsNone(term.is_obsolete)
-
-    def test_21_obsolete_true(self) -> None:
-        """Test the ``builtin`` tag."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            is_obsolete: true
-        """)
-        term = self.get_only_term(ontology)
-        self.assertIsNotNone(term.is_obsolete)
-        self.assertTrue(term.is_obsolete)
-
-    def test_21_obsolete_false(self) -> None:
-        """Test the ``is_obsolete`` tag."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            is_obsolete: false
-        """)
-        term = self.get_only_term(ontology)
-        self.assertIsNotNone(term.is_obsolete)
-        self.assertFalse(term.is_obsolete)
-
-    def test_22_replaced_by(self) -> None:
-        """Test the ``replaced-by`` tag."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            replaced_by: CHEBI:5678
-        """)
-        term = self.get_only_term(ontology)
-        replaced = term.iterate_property(term_replaced_by)
-        self.assertEqual(1, len(replaced))
-        self.assertEqual(Reference(prefix="CHEBI", identifier="5678"), replaced[0])
-
-
-class TestReaderTypedef(_Base):
-    """Tests for typedefs."""
-
-    def test_1_missing_identifier(self) -> None:
-        """Test loading an ontology with unparsable nodes."""
-        with self.assertRaises(KeyError) as exc:
-            _read("""\
-                ontology: chebi
-
-                [Typedef]
-                name: nope
-            """)
-        self.assertEqual("typedef is missing an `id`", exc.exception.args[0])
-
-    def test_6_definition_missing_end_quote(self) -> None:
-        """Test parsing a definition missing an ending quote."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            def: "malformed definition without quotes
-        """)
-        term = self.get_only_term(ontology)
-        self.assertIsNone(term.definition)
-
-    def test_6_definition_no_provenance(self) -> None:
-        """Test parsing a term with a definition and no provenance brackets."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            def: "definition of CHEBI:1234"
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual("definition of CHEBI:1234", term.definition)
-
-    def test_6_definition_empty_provenance(self) -> None:
-        """Test parsing a term with a definition and empty provenance."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            def: "definition of CHEBI:1234" []
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual("definition of CHEBI:1234", term.definition)
-
-    def test_6_definition_with_provenance(self) -> None:
-        """Test parsing a term with a definition and provenance."""
-        ontology = _read(f"""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            def: "definition of CHEBI:1234" [{CHARLIE.curie}]
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual("definition of CHEBI:1234", term.definition)
-        self.assertEqual(1, len(term.provenance))
-        self.assertEqual(CHARLIE, term.provenance[0])
-
-    def test_6_provenance_no_definition(self) -> None:
-        """Test parsing a term with provenance but no definition."""
-        ontology = _read(f"""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            def: "" [{CHARLIE.curie}]
-        """)
-        term = self.get_only_term(ontology)
-        self.assertIsNone(term.definition)
-        self.assertEqual(1, len(term.provenance))
-        self.assertEqual(CHARLIE, term.provenance[0])
-
-    def test_9_synonym_minimal(self) -> None:
-        """Test parsing a synonym just the text."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I"
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("LTEC I", synonym.name)
-        self.assertIsNone(synonym.specificity)
-        self.assertIsNone(synonym.type)
-        self.assertEqual([], synonym.provenance)
-
-    def test_9_synonym_with_specificity(self) -> None:
-        """Test parsing a synonym with specificity."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I" NARROW
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("LTEC I", synonym.name)
-        self.assertEqual("NARROW", synonym.specificity)
-        self.assertIsNone(synonym.type)
-        self.assertEqual([], synonym.provenance)
-
-    def test_9_synonym_with_type_missing_def(self) -> None:
-        """Test parsing a synonym with type, but missing type def."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I" OMO:1234567
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        #  this is because no typedef existed
-        self.assertIsNone(synonym.type)
-
-    def test_9_synonym_with_type(self) -> None:
-        """Test parsing a synonym with type."""
-        ontology = _read("""\
-            ontology: chebi
-            synonymtypedef: OMO:1234567 ""
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I" OMO:1234567
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("LTEC I", synonym.name)
-        self.assertIsNone(synonym.specificity)
-        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
-        self.assertEqual([], synonym.provenance)
-
-    def test_9_synonym_with_type_and_specificity(self) -> None:
-        """Test parsing a synonym with specificity and type."""
-        ontology = _read("""\
-            ontology: chebi
-            synonymtypedef: OMO:1234567 ""
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I" NARROW OMO:1234567
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("LTEC I", synonym.name)
-        self.assertEqual("NARROW", synonym.specificity)
-        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
-        self.assertEqual([], synonym.provenance)
-
-    def test_9_synonym_with_empty_prov(self) -> None:
-        """Test parsing a synonym with specificity,type, and explicit empty provenance."""
-        ontology = _read("""\
-            ontology: chebi
-            synonymtypedef: OMO:1234567 ""
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I" NARROW OMO:1234567 []
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("LTEC I", synonym.name)
-        self.assertEqual("NARROW", synonym.specificity)
-        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
-        self.assertEqual([], synonym.provenance)
-
-    def test_9_synonym_no_type(self) -> None:
-        """Test parsing a synonym with specificity and provenance."""
-        ontology = _read(f"""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I" EXACT [Orphanet:93938,{CHARLIE.curie}]
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("LTEC I", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertIsNone(synonym.type)
-        self.assertEqual(
-            [
-                Reference(prefix="orphanet", identifier="93938"),
-                CHARLIE,
-            ],
-            synonym.provenance,
-        )
-
-    def test_9_synonym_full(self) -> None:
-        """Test parsing a synonym with specificity, type, and provenance."""
-        ontology = _read(f"""\
-            ontology: chebi
-            synonymtypedef: OMO:1234567 ""
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I" EXACT OMO:1234567 [Orphanet:93938,{CHARLIE.curie}]
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("LTEC I", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
-        self.assertEqual(
-            [
-                Reference(prefix="orphanet", identifier="93938"),
-                CHARLIE,
-            ],
-            synonym.provenance,
-        )
-
-    def test_9_synonym_dashed(self) -> None:
-        """Test parsing a synonym with specificity, type, and provenance."""
-        ontology = _read("""\
-            ontology: chebi
-            synonymtypedef: OMO:1234567 ""
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "Brown-Pearce tumour" EXACT OMO:0003005 []
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("Brown-Pearce tumour", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertEqual(Reference(prefix="omo", identifier="0003005"), synonym.type)
-        self.assertEqual([], synonym.provenance)
-
-    def test_9_synonym_url(self) -> None:
-        """Test parsing a synonym defined with a PURL."""
-        ontology = _read(f"""\
-            ontology: chebi
-            synonymtypedef: http://purl.obolibrary.org/obo/OMO_1234567 ""
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I" EXACT OMO:1234567 [Orphanet:93938,{CHARLIE.curie}]
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("LTEC I", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
-        self.assertEqual(
-            [
-                Reference(prefix="orphanet", identifier="93938"),
-                CHARLIE,
-            ],
-            synonym.provenance,
-        )
-
-    def test_9_synonym_casing(self) -> None:
-        """Test parsing a synonym when an alternate case is used."""
-        ontology = _read(f"""\
-            ontology: chebi
-            synonymtypedef: OMO:1234567 ""
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "LTEC I" EXACT omo:1234567 [Orphanet:93938,{CHARLIE.curie}]
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("LTEC I", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertEqual(Reference(prefix="omo", identifier="1234567"), synonym.type)
-        self.assertEqual(
-            [
-                Reference(prefix="orphanet", identifier="93938"),
-                CHARLIE,
-            ],
-            synonym.provenance,
-        )
-
-    def test_9_synonym_default(self) -> None:
-        """Test parsing a synonym that has a built-in prefix."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "DoguAnadoluKirmizisi" EXACT most_common_name []
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("DoguAnadoluKirmizisi", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertIsNone(synonym.type)
-
-        # now, we define it properly
-        ontology = _read("""\
-            ontology: chebi
-            synonymtypedef: most_common_name "most common name"
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "DoguAnadoluKirmizisi" EXACT most_common_name []
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("DoguAnadoluKirmizisi", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertEqual(default_reference("chebi", "most_common_name"), synonym.type)
-
-    def test_9_synonym_builtin(self) -> None:
-        """Test parsing a synonym with specificity, type, and provenance."""
-        text = """\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "COP" EXACT ABBREVIATION []
-        """
-
-        ontology = _read(text, upgrade=False)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("COP", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertIsNone(synonym.type)
-
-        ontology = _read(text, upgrade=True)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("COP", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertEqual(abbreviation.reference, synonym.type)
-
-    @unittest.skip(reason=REASON_OBONET_IMPL)
-    def test_9_synonym_with_annotations(self) -> None:
-        """Test parsing a synonym with annotations."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Term]
-            id: CHEBI:1234
-            synonym: "10*3.{copies}/mL" EXACT [] {http://purl.obolibrary.org/obo/NCIT_P383="AB", http://purl.obolibrary.org/obo/NCIT_P384="UCUM"}
-        """)
-        term = self.get_only_term(ontology)
-        self.assertEqual(1, len(term.synonyms))
-        synonym = term.synonyms[0]
-        self.assertEqual("10*3.{copies}/mL", synonym.name)
-        self.assertEqual("EXACT", synonym.specificity)
-        self.assertIsNone(synonym.type)
-        self.assertEqual([], synonym.provenance)
-        # TODO update this when adding annotation parsing!
-        self.assertEqual([], synonym.annotations)
-
-    def test_10_typedef_xref(self) -> None:
-        """Test loading an ontology with unparsable nodes."""
-        ontology = _read("""\
-            ontology: chebi
-
-            [Typedef]
-            id: RO:0018033
-            name: is conjugate base of
-            xref: debio:0000010
-        """)
-        self.assertEqual(1, len(ontology.typedefs))
-        self.assertEqual(is_conjugate_base_of.pair, ontology.typedefs[0].pair)
-
     def test_18_default_relation(self):
         """Test parsing a default relation."""
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: chebi
 
             [Term]
@@ -1281,7 +1064,7 @@ class TestReaderTypedef(_Base):
     @unittest.skip(reason=REASON_OBONET_IMPL)
     def test_18_sssom_axiom(self) -> None:
         """Test SSSOM axioms."""
-        ontology = _read("""\
+        ontology = from_str("""\
             ontology: go
 
             [Term]
@@ -1296,109 +1079,46 @@ class TestReaderTypedef(_Base):
         self.assertIsNotNone(context.contributor)
         self.assertEqual("0000-0003-4423-4370", context.contributor.identifier)
 
+    # TODO created_by
+    # TODO creation_date
 
-class TestVersionHandling(_Base):
-    """Test version handling."""
+    def test_21_is_obsolete(self) -> None:
+        """Test the ``is_obsolete`` tag."""
+        self.assert_boolean_flag("is_obsolete")
 
-    def test_no_version_no_data(self):
-        """Test when nothing is given."""
-        ontology = _read("""\
+    def test_22_replaced_by(self) -> None:
+        """Test the ``replaced-by`` tag."""
+        ontology = from_str("""\
             ontology: chebi
-        """)
-        self.assertIsNone(ontology.data_version)
 
-    def test_static_rewrite(self):
-        """Test using custom configuration for version lookup."""
-        ontology = _read("""\
-            ontology: orth
+            [Term]
+            id: CHEBI:1234
+            replaced_by: CHEBI:5678
         """)
-        self.assertEqual("2", ontology.data_version, msg="The static rewrite wasn't applied")
+        term = self.get_only_term(ontology)
+        replaced = term.iterate_property_targets(term_replaced_by)
+        self.assertEqual(1, len(replaced))
+        self.assertEqual(Reference(prefix="CHEBI", identifier="5678"), replaced[0])
 
-    def test_simple_version(self):
-        """Test handling a simple version."""
-        ontology = _read("""\
+    def test_23_consider(self) -> None:
+        """Test the ``consider`` tag."""
+        ontology = from_str("""\
             ontology: chebi
-            data-version: 123
-        """)
-        self.assertEqual("123", ontology.data_version)
 
-    def test_releases_prefix_simple(self):
-        """Test a parsing a simple version starting with `releases/`."""
-        ontology = _read("""\
-            ontology: chebi
-            data-version: releases/123
+            [Term]
+            id: CHEBI:1234
+            consider: CHEBI:5678
         """)
+        term = self.get_only_term(ontology)
+        consider = term.iterate_property_targets(see_also)
+        self.assertEqual(1, len(consider))
         self.assertEqual(
-            "123",
-            ontology.data_version,
-            msg="The prefix `releases/` wasn't properly automatically stripped",
+            Reference(prefix="CHEBI", identifier="5678"),
+            consider[0],
+            msg=rf"""\Didn't get consider from the right place:
+
+            properties: {dict(term.properties)}
+
+            relationships: {dict(term.relationships)}
+            """,
         )
-
-    def test_releases_prefix_complex(self):
-        """Test parsing a complex string starting with `releases/`."""
-        ontology = _read("""\
-            ontology: chebi
-            data-version: releases/123/chebi.owl
-        """)
-        self.assertEqual(
-            "123",
-            ontology.data_version,
-            msg="The prefix `releases/` wasn't properly automatically stripped",
-        )
-
-    def test_no_version_with_date(self):
-        """Test when the date is substituted for a missing version."""
-        ontology = _read("""\
-            ontology: chebi
-            date: 20:11:2024 18:44
-        """)
-        self.assertEqual("2024-11-20", ontology.data_version)
-
-    def test_bad_version(self):
-        """Test that a version with slashes raises an error."""
-        with self.assertRaises(ValueError):
-            _read("""\
-                ontology: chebi
-                data-version: /////
-            """)
-
-    def test_data_prefix_strip(self):
-        """Test when a prefix gets stripped from the beginning of a version."""
-        ontology = _read("""\
-            ontology: sasap
-            data-version: http://purl.dataone.org/odo/SASAP/0.3.1
-        """)
-        self.assertEqual(
-            "0.3.1", ontology.data_version, msg="The custom defined prefix wasn't stripped"
-        )
-
-    def test_version_full_rewrite(self):
-        """Test when a version gets fully replaced from a custom configuration."""
-        ontology = _read("""\
-            ontology: owl
-            data-version: $Date: 2009/11/15 10:54:12 $
-        """)
-        self.assertEqual(
-            "2009-11-15", ontology.data_version, msg="The custom rewrite wasn't invooked"
-        )
-
-    def test_version_injected(self):
-        """Test when a missing version gets overwritten."""
-        ontology = _read(
-            """\
-            ontology: chebi
-        """,
-            version="123",
-        )
-        self.assertEqual("123", ontology.data_version)
-
-    def test_version_overwrite_mismatch(self):
-        """Test when a version gets overwritten, but it's not matching."""
-        ontology = _read(
-            """\
-            ontology: chebi
-            data-version: 122
-        """,
-            version="123",
-        )
-        self.assertEqual("123", ontology.data_version)

--- a/tests/test_reader_ontology.py
+++ b/tests/test_reader_ontology.py
@@ -1,0 +1,408 @@
+"""Test the reader on ontology metadata."""
+
+import datetime
+import unittest
+
+from pyobo import Obo, Reference, SynonymTypeDef, Term, TypeDef, default_reference
+from pyobo.reader import from_str
+from pyobo.struct import part_of
+from pyobo.struct.reference import OBOLiteral
+from pyobo.struct.struct_utils import Annotation
+from pyobo.struct.typedef import comment, equivalent_class
+
+
+class TestReaderOntologyMetadata(unittest.TestCase):
+    """Test the reader on ontology metadata."""
+
+    def get_only_term(self, ontology: Obo) -> Term:
+        """Assert there is only a single term in the ontology and return it."""
+        terms = list(ontology.iter_terms())
+        self.assertEqual(1, len(terms))
+        term = terms[0]
+        return term
+
+    def get_only_typedef(self, ontology: Obo) -> TypeDef:
+        """Assert there is only a single typedef in the ontology and return it."""
+        self.assertEqual(1, len(ontology.typedefs))
+        return ontology.typedefs[0]
+
+    def test_0_missing_date_version(self) -> None:
+        """Test an ontology with a missing date and version."""
+        ontology = from_str("""\
+            ontology: chebi
+        """)
+        self.assertIsNone(ontology.date)
+        self.assertIsNone(ontology.data_version)
+
+    # 1 format-version is unnecessary
+    # 2 for data-version, see the full test case below
+
+    def test_3_bad_date_format(self) -> None:
+        """Test an ontology with a malformed date and no version."""
+        ontology = from_str("""\
+            ontology: chebi
+            date: aabbccddeee
+        """)
+        self.assertIsNone(ontology.date)
+        self.assertIsNone(ontology.data_version)
+
+    def test_3_date_no_version(self) -> None:
+        """Test an ontology with a date but no version."""
+        ontology = from_str("""\
+            ontology: chebi
+            date: 20:11:2024 18:44
+        """)
+        self.assertEqual(datetime.datetime(2024, 11, 20, 18, 44), ontology.date)
+        self.assertEqual("2024-11-20", ontology.data_version)
+
+    # 4 saved-by not necessary
+    # 5 auto-generated-by
+
+    def test_6_import(self) -> None:
+        """Test the ``import`` tag."""
+        ontology = from_str("""\
+            ontology: go
+            import: chebi
+            import: http://purl.obolibrary.org/obo/envo.owl
+        """)
+        self.assertEqual(["chebi", "http://purl.obolibrary.org/obo/envo.owl"], ontology.imports)
+
+    def test_7_subset(self) -> None:
+        """Test parsing a subset definition."""
+        ontology = from_str("""\
+            ontology: chebi
+            subsetdef: TEST "comment"
+        """)
+        self.assertEqual(
+            [(default_reference("chebi", "TEST"), "comment")],
+            ontology.subsetdefs,
+        )
+
+    def test_8_synonym_typedef(self) -> None:
+        """Test the ``synonym_typedef`` tag."""
+        ontology = from_str("""\
+            ontology: chebi
+            synonymtypedef: ST1 "ST1 Name" EXACT
+            synonymtypedef: ST2 "ST2 Name" NARROW
+            synonymtypedef: ST3 "ST3 Name"
+            synonymtypedef: OMO:0000001 "E1 Name" EXACT
+            synonymtypedef: OMO:0000002 "E2 Name" NARROW
+            synonymtypedef: OMO:0000003 "E3 Name"
+        """)
+        self.assertEqual(6, len(ontology.synonym_typedefs))
+        self.assertEqual(
+            [
+                SynonymTypeDef(
+                    reference=default_reference("chebi", "ST1", name="ST1 Name"),
+                    specificity="EXACT",
+                ),
+                SynonymTypeDef(
+                    reference=default_reference("chebi", "ST2", name="ST2 Name"),
+                    specificity="NARROW",
+                ),
+                SynonymTypeDef(
+                    reference=default_reference("chebi", "ST3", name="ST3 Name"), specificity=None
+                ),
+                SynonymTypeDef(
+                    reference=Reference(prefix="OMO", identifier="0000001", name="E1 Name"),
+                    specificity="EXACT",
+                ),
+                SynonymTypeDef(
+                    reference=Reference(prefix="OMO", identifier="0000002", name="E2 Name"),
+                    specificity="NARROW",
+                ),
+                SynonymTypeDef(
+                    reference=Reference(prefix="OMO", identifier="0000003", name="E3 Name"),
+                    specificity=None,
+                ),
+            ],
+            ontology.synonym_typedefs,
+        )
+
+    # TODO default-namespace
+    # TODO namespace-id-rule
+
+    def test_11_idspace(self) -> None:
+        """Test the ``idspace`` tag."""
+        ontology = from_str("""\
+            ontology: go
+            idspace: hgnc https://bioregistry.io/hgnc:
+            idspace: ex https://example.org/ "example"
+        """)
+        self.assertEqual(
+            {
+                "hgnc": "https://bioregistry.io/hgnc:",
+                "ex": "https://example.org/",
+            },
+            ontology.idspaces,
+        )
+
+    def test_12_xref_equivalent(self) -> None:
+        """Test the ``treat-xrefs-as-equivalent`` macro."""
+        ontology = from_str("""\
+            ontology: go
+            treat-xrefs-as-equivalent: CL
+
+            [Term]
+            id: GO:0005623
+            name: cell
+            xref: CL:0000000
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(0, len(term.xrefs))
+        self.assertEqual(0, len(term.parents))
+        self.assertEqual(0, len(term.properties))
+        self.assertEqual(1, len(term.relationships))
+        self.assertEqual(0, len(term.intersection_of))
+        self.assertIn(equivalent_class.reference, term.relationships)
+        self.assertEqual(
+            [Reference(prefix="CL", identifier="0000000")],
+            term.relationships[equivalent_class.reference],
+        )
+
+    def test_13_xref_genus_differentia(self) -> None:
+        """Test the ``treat-xrefs-as-is_a `` macro.
+
+        The test should become the same as:
+
+        .. code::
+
+            [Term]
+            id: ZFA:0000134
+            intersection_of: CL:0000540
+            intersection_of: BFO:0000050 NCBITaxon:7955
+        """
+        ontology = from_str("""\
+              ontology: zfa
+              treat-xrefs-as-genus-differentia: CL BFO:0000050 NCBITaxon:7955
+
+              [Term]
+              id: ZFA:0000134
+              xref: CL:0000540
+          """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(0, len(term.xrefs))
+        self.assertEqual(0, len(term.parents))
+        self.assertEqual(0, len(term.properties))
+        self.assertEqual(0, len(term.relationships))
+        self.assertEqual(2, len(term.intersection_of))
+        self.assertEqual(
+            [
+                Reference(prefix="CL", identifier="0000540"),
+                Annotation(part_of.reference, Reference(prefix="NCBITaxon", identifier="7955")),
+            ],
+            term.intersection_of,
+        )
+
+    def test_14_xref_relation(self) -> None:
+        """Test the ``treat-xrefs-as-relationship  `` macro."""
+        ontology = from_str("""\
+            ontology: go
+            treat-xrefs-as-relationship: CL BFO:0000000
+
+            [Term]
+            id: GO:0005623
+            name: cell
+            xref: CL:0000000
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(0, len(term.xrefs))
+        self.assertEqual(0, len(term.parents))
+        self.assertEqual(0, len(term.properties))
+        self.assertEqual(1, len(term.relationships))
+        self.assertEqual(0, len(term.intersection_of))
+        pred = Reference(prefix="BFO", identifier="0000000")
+        self.assertIn(pred, term.relationships)
+        self.assertEqual([Reference(prefix="CL", identifier="0000000")], term.relationships[pred])
+
+    def test_15_xref_is_a_for_term(self) -> None:
+        """Test the ``treat-xrefs-as-is_a `` macro."""
+        ontology = from_str("""\
+            ontology: go
+            treat-xrefs-as-is_a: CL
+
+            [Term]
+            id: GO:0005623
+            name: cell
+            xref: CL:0000000
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(0, len(term.xrefs), msg=term.xrefs)
+        self.assertEqual(1, len(term.parents))
+        self.assertEqual(0, len(term.properties))
+        self.assertEqual(0, len(term.relationships))
+        self.assertEqual(0, len(term.intersection_of))
+        self.assertEqual([Reference(prefix="CL", identifier="0000000")], term.parents)
+
+    def test_15_xref_is_a_for_typedef(self) -> None:
+        """Test the ``treat-xrefs-as-is_a `` macro."""
+        ontology = from_str("""\
+            ontology: ro
+            treat-xrefs-as-is_a: skos
+
+            [Typedef]
+            id: RO:0000000
+            xref: skos:closeMatch
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertEqual(0, len(typedef.xrefs), msg=typedef.xrefs)
+        self.assertEqual(0, len(typedef.relationships))
+        self.assertEqual(0, len(typedef.intersection_of))
+        self.assertEqual(1, len(typedef.parents))
+        self.assertEqual([Reference(prefix="skos", identifier="closeMatch")], typedef.parents)
+
+    def test_16_remark(self) -> None:
+        """Test the ``remark`` tag."""
+        ontology = from_str("""\
+            ontology: ro
+            remark: hello 1
+            remark: hello 2
+        """)
+        self.assertEqual(
+            [
+                Annotation(comment.reference, OBOLiteral.string("hello 1")),
+                Annotation(comment.reference, OBOLiteral.string("hello 2")),
+            ],
+            ontology.property_values,
+        )
+
+    def test_17_unknown_ontology_prefix(self) -> None:
+        """Test an ontology with an unknown prefix."""
+        with self.assertRaises(ValueError) as exc:
+            from_str("""\
+                ontology: nope
+            """)
+        self.assertEqual("unknown prefix: nope", exc.exception.args[0])
+
+    def test_18_properties(self) -> None:
+        """Test parsing properties."""
+        ontology = from_str("""\
+            ontology: chebi
+            property_value: heyo also_heyo
+        """)
+        self.assertEqual(
+            [(default_reference("chebi", "heyo"), default_reference("chebi", "also_heyo"))],
+            ontology.property_values,
+        )
+
+    def test_18_root(self) -> None:
+        """Test root terms."""
+        ontology = from_str("""\
+            ontology: go
+            property_value: IAO:0000700 GO:0050069
+
+            [Term]
+            id: GO:0050069
+        """)
+        # FIXME support default reference, like property_value: IAO:0000700 adhoc
+        self.assertEqual(
+            [Reference(prefix="GO", identifier="0050069")],
+            ontology.root_terms,
+        )
+
+
+class TestVersionHandling(unittest.TestCase):
+    """Test version handling."""
+
+    def test_no_version_no_data(self):
+        """Test when nothing is given."""
+        ontology = from_str("""\
+            ontology: chebi
+        """)
+        self.assertIsNone(ontology.data_version)
+
+    def test_static_rewrite(self):
+        """Test using custom configuration for version lookup."""
+        ontology = from_str("""\
+            ontology: orth
+        """)
+        self.assertEqual("2", ontology.data_version, msg="The static rewrite wasn't applied")
+
+    def test_simple_version(self):
+        """Test handling a simple version."""
+        ontology = from_str("""\
+            ontology: chebi
+            data-version: 123
+        """)
+        self.assertEqual("123", ontology.data_version)
+
+    def test_releases_prefix_simple(self):
+        """Test a parsing a simple version starting with `releases/`."""
+        ontology = from_str("""\
+            ontology: chebi
+            data-version: releases/123
+        """)
+        self.assertEqual(
+            "123",
+            ontology.data_version,
+            msg="The prefix `releases/` wasn't properly automatically stripped",
+        )
+
+    def test_releases_prefix_complex(self):
+        """Test parsing a complex string starting with `releases/`."""
+        ontology = from_str("""\
+            ontology: chebi
+            data-version: releases/123/chebi.owl
+        """)
+        self.assertEqual(
+            "123",
+            ontology.data_version,
+            msg="The prefix `releases/` wasn't properly automatically stripped",
+        )
+
+    def test_no_version_with_date(self):
+        """Test when the date is substituted for a missing version."""
+        ontology = from_str("""\
+            ontology: chebi
+            date: 20:11:2024 18:44
+        """)
+        self.assertEqual("2024-11-20", ontology.data_version)
+
+    def test_bad_version(self):
+        """Test that a version with slashes raises an error."""
+        with self.assertRaises(ValueError):
+            from_str("""\
+                ontology: chebi
+                data-version: /////
+            """)
+
+    def test_data_prefix_strip(self):
+        """Test when a prefix gets stripped from the beginning of a version."""
+        ontology = from_str("""\
+            ontology: sasap
+            data-version: http://purl.dataone.org/odo/SASAP/0.3.1
+        """)
+        self.assertEqual(
+            "0.3.1", ontology.data_version, msg="The custom defined prefix wasn't stripped"
+        )
+
+    def test_version_full_rewrite(self):
+        """Test when a version gets fully replaced from a custom configuration."""
+        ontology = from_str("""\
+            ontology: owl
+            data-version: $Date: 2009/11/15 10:54:12 $
+        """)
+        self.assertEqual(
+            "2009-11-15", ontology.data_version, msg="The custom rewrite wasn't invooked"
+        )
+
+    def test_version_injected(self):
+        """Test when a missing version gets overwritten."""
+        ontology = from_str(
+            """\
+            ontology: chebi
+        """,
+            version="123",
+        )
+        self.assertEqual("123", ontology.data_version)
+
+    def test_version_overwrite_mismatch(self):
+        """Test when a version gets overwritten, but it's not matching."""
+        ontology = from_str(
+            """\
+            ontology: chebi
+            data-version: 122
+        """,
+            version="123",
+        )
+        self.assertEqual("123", ontology.data_version)

--- a/tests/test_reader_typedef.py
+++ b/tests/test_reader_typedef.py
@@ -1,0 +1,455 @@
+"""Test reading typedefs."""
+
+import unittest
+
+from pyobo import Obo, Reference, TypeDef, default_reference
+from pyobo.reader import from_str
+from pyobo.struct import part_of
+from pyobo.struct.reference import OBOLiteral
+from pyobo.struct.typedef import is_conjugate_base_of, occurs_in, see_also
+from pyobo.struct.vocabulary import CHARLIE, has_contributor
+
+REASON_OBONET_IMPL = (
+    "This needs to be fixed upstream, since obonet's parser "
+    "for synonyms fails on the open squiggly bracket {"
+)
+
+
+class TestReaderTypedef(unittest.TestCase):
+    """Tests for typedefs."""
+
+    def get_only_typedef(self, ontology: Obo) -> TypeDef:
+        """Assert there is only a single typedef in the ontology and return it."""
+        self.assertEqual(1, len(ontology.typedefs))
+        return ontology.typedefs[0]
+
+    def assert_boolean_tag(self, tag: str) -> None:
+        """Assert the boolean flag works right."""
+        ontology = from_str(f"""\
+            ontology: ro
+
+            [Typedef]
+            id: BFO:0000066
+            {tag}: true
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertTrue(hasattr(typedef, tag))
+        value = getattr(typedef, tag)
+        self.assertIsNotNone(value)
+        self.assertTrue(value)
+
+        ontology = from_str(f"""\
+            ontology: ro
+
+            [Typedef]
+            id: BFO:0000066
+            {tag}: false
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertTrue(hasattr(typedef, tag))
+        value = getattr(typedef, tag)
+        self.assertIsNotNone(value)
+        self.assertFalse(value)
+
+    def test_1_missing_identifier(self) -> None:
+        """Test loading an ontology with unparsable nodes."""
+        with self.assertRaises(KeyError) as exc:
+            from_str("""\
+                ontology: chebi
+
+                [Typedef]
+                name: nope
+            """)
+        self.assertEqual("typedef is missing an `id`", exc.exception.args[0])
+
+    def test_2_is_anonymous(self) -> None:
+        """Test the ``is_anonymous`` tag."""
+        self.assert_boolean_tag("is_anonymous")
+
+    def test_3_name(self) -> None:
+        """Test the name tag."""
+        ontology = from_str("""\
+            ontology: chebi
+
+            [Typedef]
+            id: CHEBI:1234
+            name: test
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertEqual("test", typedef.name)
+
+    def test_4_namespace(self) -> None:
+        """Test the ``namespace`` tag."""
+        ontology = from_str("""\
+            ontology: RO
+
+            [Typedef]
+            id: RO:1
+            namespace: test-namespace
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertEqual("test-namespace", typedef.namespace)
+
+    def test_5_alt_id(self) -> None:
+        """Test the ``alt_id`` tag."""
+        ontology = from_str("""\
+            ontology: RO
+
+            [Typedef]
+            id: RO:1
+            alt_id: RO:2
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertEqual(
+            [Reference(prefix="RO", identifier="2")],
+            typedef.alt_ids,
+        )
+
+    def test_7_comment(self) -> None:
+        """Test the ``subset`` tag."""
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: RO:1234
+            comment: comment
+        """)
+        self.get_only_typedef(ontology)
+
+    def test_8_subset(self) -> None:
+        """Test the ``subset`` tag."""
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: RO:1234
+            subset: test-subset
+        """)
+        term = self.get_only_typedef(ontology)
+        self.assertEqual([default_reference("ro", "test-subset")], term.subsets)
+
+    def test_10_typedef_xref(self) -> None:
+        """Test loading an ontology with unparsable nodes."""
+        ontology = from_str("""\
+            ontology: chebi
+
+            [Typedef]
+            id: RO:0018033
+            name: is conjugate base of
+            xref: debio:0000010
+        """)
+        self.assertEqual(1, len(ontology.typedefs))
+        self.assertEqual(is_conjugate_base_of.pair, ontology.typedefs[0].pair)
+
+    def test_11_property_value(self) -> None:
+        """Test the ``property_value`` tag."""
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: RO:0018033
+            property_value: dcterms:contributor orcid:0000-0003-4423-4370 ! contributor Charles Tapley Hoyt
+            property_value: debio:0000020 "abc" xsd:string
+        """)
+        td1 = Reference(prefix="debio", identifier="0000020")
+        typedef = self.get_only_typedef(ontology)
+        self.assertEqual(2, len(typedef.properties))
+        self.assertIn(has_contributor, typedef.properties)
+        self.assertEqual([CHARLIE], typedef.properties[has_contributor])
+        self.assertIn(td1, typedef.properties)
+        self.assertEqual(1, len(typedef.properties[td1]))
+        self.assertEqual(OBOLiteral.string("abc"), typedef.properties[td1][0])
+
+    def test_12_domain(self) -> None:
+        """Test the ``domain`` tag."""
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: BFO:0000066
+            domain: BFO:0000003 ! occurrent
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertIsNotNone(typedef.domain)
+        self.assertEqual(Reference.from_curie("BFO:0000003"), typedef.domain)
+
+    def test_13_range(self) -> None:
+        """Test the ``range`` tag."""
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: BFO:0000066
+            range: BFO:0000004
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertIsNotNone(typedef.range)
+        self.assertEqual(Reference.from_curie("BFO:0000004"), typedef.range)
+
+    def test_14_builtin(self) -> None:
+        """Test the builtin tag."""
+        self.assert_boolean_tag("builtin")
+
+    def test_15_holds_over_chain(self) -> None:
+        """Test the ``holds_over_chain`` tag."""
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: BFO:0000066
+            name: occurs in
+            holds_over_chain: BFO:0000050 BFO:0000066 ! part of occurs in
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertEqual(
+            [
+                [
+                    part_of.reference,
+                    occurs_in.reference,
+                ]
+            ],
+            typedef.holds_over_chain,
+        )
+
+    def test_16_is_anti_symmetric(self) -> None:
+        """Test the ``is_anti_symmetric`` tag."""
+        self.assert_boolean_tag("is_anti_symmetric")
+
+    def test_17_is_cyclic(self) -> None:
+        """Test the ``is_cyclic`` tag."""
+        self.assert_boolean_tag("is_cyclic")
+
+    def test_18_is_reflexive(self) -> None:
+        """Test the ``is_reflexive`` tag."""
+        self.assert_boolean_tag("is_reflexive")
+
+    def test_19_is_symmetric(self) -> None:
+        """Test the ``is_symmetric`` tag."""
+        self.assert_boolean_tag("is_symmetric")
+
+    def test_20_is_transitive(self) -> None:
+        """Test the ``is_transitive`` tag."""
+        self.assert_boolean_tag("is_transitive")
+
+    def test_21_is_functional(self) -> None:
+        """Test the ``is_functional`` tag."""
+        self.assert_boolean_tag("is_functional")
+
+    def test_22_is_inverse_functional(self) -> None:
+        """Test the ``is_inverse_functional`` tag."""
+        self.assert_boolean_tag("is_inverse_functional")
+
+    def test_23_is_a(self) -> None:
+        """Test the ``is_a`` tag."""
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: BFO:0000050
+            name: part of
+            is_a: RO:0002131 ! overlaps
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertEqual(1, len(typedef.parents))
+        self.assertEqual(Reference(prefix="RO", identifier="0002131"), typedef.parents[0])
+
+    def test_24_intersection_of(self) -> None:
+        """Test the ``intersection_of`` tag."""
+        ontology = from_str("""\
+            ontology: go
+
+            [Typedef]
+            id: GO:0000085
+            name: G2 phase of mitotic cell cycle
+            intersection_of: GO:0051319 ! G2 phase
+            intersection_of: BFO:0000050 GO:0000278 ! part of mitotic cell cycle
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertEqual(2, len(typedef.intersection_of))
+        self.assertEqual(
+            [
+                Reference.from_curie("GO:0051319"),
+                (Reference.from_curie("BFO:0000050"), Reference.from_curie("GO:0000278")),
+            ],
+            typedef.intersection_of,
+        )
+
+    def test_25_union_of(self) -> None:
+        """Test the ``union_of`` tag."""
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: GO:0000001
+            union_of: GO:0000002
+            union_of: GO:0000003
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertEqual(2, len(typedef.union_of))
+        self.assertEqual(
+            [
+                Reference(prefix="GO", identifier="0000002"),
+                Reference(prefix="GO", identifier="0000003"),
+            ],
+            typedef.union_of,
+        )
+
+    def test_26_equivalent_to(self) -> None:
+        """Test the ``equivalent_to`` tag."""
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: GO:0000001
+            equivalent_to: GO:0000002
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertEqual([Reference(prefix="GO", identifier="0000002")], typedef.equivalent_to)
+
+    def test_27_disjoint_from(self) -> None:
+        """Test the ``disjoint_from`` tag."""
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: BFO:0000066
+            disjoint_from: RO:1
+            disjoint_from: RO:2
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertEqual(
+            [Reference(prefix="RO", identifier="1"), Reference(prefix="RO", identifier="2")],
+            typedef.disjoint_from,
+        )
+
+    def test_28_inverse_of(self) -> None:
+        """Test the ``inverse_of`` tag."""
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: BFO:0000066
+            inverse_of: BFO:0000067 ! contains process
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertEqual(Reference(prefix="BFO", identifier="0000067"), typedef.inverse)
+
+    def test_29_transitive_over(self) -> None:
+        """Test the ``transitive_over`` tag."""
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: BFO:0000066
+            transitive_over: BFO:0000050 ! part of
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertEqual(
+            [Reference(prefix="BFO", identifier="0000050", name="part of")], typedef.transitive_over
+        )
+
+    def test_30_equivalent_to_chain(self) -> None:
+        """Test the ``equivalent_to_chain`` tag."""
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: GO:1
+            equivalent_to_chain: GO:2 GO:3
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertEqual(
+            [
+                [
+                    Reference(prefix="GO", identifier="2"),
+                    Reference(prefix="GO", identifier="3"),
+                ]
+            ],
+            typedef.equivalent_to_chain,
+        )
+
+    def test_31_disjoint_over(self) -> None:
+        """Test the ``disjoint_over`` tag."""
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: BFO:0000066
+            disjoint_over: RO:1
+            disjoint_over: RO:2
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertEqual(
+            [Reference(prefix="RO", identifier="1"), Reference(prefix="RO", identifier="2")],
+            typedef.disjoint_over,
+        )
+
+    def test_32_relationship(self) -> None:
+        """Test the ``relationship`` tag."""
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: BFO:0000066
+            relationship: RO:1 RO:2
+        """)
+        typedef = self.get_only_typedef(ontology)
+        r1 = Reference(prefix="RO", identifier="1")
+        r2 = Reference(prefix="RO", identifier="2")
+        self.assertIn(r1, typedef.relationships)
+        self.assertEqual(1, len(typedef.relationships[r1]))
+        self.assertEqual(r2, typedef.relationships[r1][0])
+
+    def test_33_is_obsolete(self) -> None:
+        """Test the ``is_obsolete`` tag."""
+        self.assert_boolean_tag("is_obsolete")
+
+    def test_34_created_by(self) -> None:
+        """Test the ``created_by`` tag."""
+
+    def test_35_creation_date(self) -> None:
+        """Test the ``creation_date`` tag."""
+
+    def test_36_replaced_by(self) -> None:
+        """Test the ``replaced_by`` tag."""
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: BFO:0000066
+            replaced_by: RO:1
+        """)
+        r = self.get_only_typedef(ontology)
+        self.assertEqual(
+            [Reference(prefix="RO", identifier="1")],
+            r.get_replaced_by(),
+            msg=str(dict(r.properties)),
+        )
+
+    def test_37_consider(self) -> None:
+        """Test the ``consider`` tag."""
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: BFO:0000066
+            consider: RO:1
+        """)
+        typedef = self.get_only_typedef(ontology)
+        r = typedef.iterate_property_targets_references(see_also)
+        self.assertEqual(1, len(r))
+        self.assertEqual(Reference(prefix="RO", identifier="1"), r[0])
+
+    def test_38_expand_assertion_to(self) -> None:
+        """Test the ``expand_assertion_to`` tag."""
+
+    def test_39_expand_expression_to(self) -> None:
+        """Test the ``expand_expression_to`` tag."""
+
+    def test_40_is_metadata_tag(self) -> None:
+        """Test the ``is_metadata_tag`` tag."""
+        self.assert_boolean_tag("is_metadata_tag")
+
+    def test_41_is_class_level(self) -> None:
+        """Test the ``is_class_level`` tag."""
+        self.assert_boolean_tag("is_class_level")

--- a/tests/test_reader_typedef.py
+++ b/tests/test_reader_typedef.py
@@ -436,7 +436,7 @@ class TestReaderTypedef(unittest.TestCase):
             consider: RO:1
         """)
         typedef = self.get_only_typedef(ontology)
-        r = typedef.iterate_property_targets_references(see_also)
+        r = typedef.get_property_objects(see_also)
         self.assertEqual(1, len(r))
         self.assertEqual(Reference(prefix="RO", identifier="1"), r[0])
 

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -115,16 +115,7 @@ class TestTerm(unittest.TestCase):
         """Assert the lines are equal."""
         self.assertEqual(dedent(text).strip(), "\n".join(lines).strip())
 
-    def test_species(self) -> None:
-        """Test setting and getting species."""
-        term = Term(reference=Reference(prefix="hgnc", identifier="1234"))
-        term.set_species("9606", "Homo sapiens")
-        species = term.get_species()
-        self.assertIsNotNone(species)
-        self.assertEqual(NCBITAXON_PREFIX, species.prefix)
-        self.assertEqual("9606", species.identifier)
-
-    def test_term_minimal(self) -> None:
+    def test_1_term_minimal(self) -> None:
         """Test emitting properties."""
         term = Term(
             reference=Reference(
@@ -140,7 +131,53 @@ class TestTerm(unittest.TestCase):
             term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
         )
 
-    def test_term_with_name(self) -> None:
+    def test_1_default_term(self) -> None:
+        """Test when a term uses a default reference."""
+        term = Term(reference=default_reference("gard", identifier="genetics", name="Genetics"))
+        self.assert_lines(
+            """\
+            [Term]
+            id: genetics
+            name: Genetics
+            """,
+            term.iterate_obo_lines(ontology_prefix="gard", typedefs={}),
+        )
+
+    def test_2_is_anonymous(self) -> None:
+        """Test the ``is_anonymous`` tag."""
+        term = Term(
+            reference=Reference(
+                prefix=LYSINE_DEHYDROGENASE_ACT.prefix,
+                identifier=LYSINE_DEHYDROGENASE_ACT.identifier,
+            ),
+            is_anonymous=True,
+        )
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            is_anonymous: true
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
+        )
+
+        term2 = Term(
+            reference=Reference(
+                prefix=LYSINE_DEHYDROGENASE_ACT.prefix,
+                identifier=LYSINE_DEHYDROGENASE_ACT.identifier,
+            ),
+            is_anonymous=False,
+        )
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            is_anonymous: false
+            """,
+            term2.iterate_obo_lines(ontology_prefix="go", typedefs={}),
+        )
+
+    def test_3_term_with_name(self) -> None:
         """Test emitting properties."""
         term = Term(reference=LYSINE_DEHYDROGENASE_ACT)
         self.assert_lines(
@@ -152,248 +189,23 @@ class TestTerm(unittest.TestCase):
             term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
         )
 
-    def test_property_literal(self) -> None:
-        """Test emitting property literals."""
-        term = Term(reference=LYSINE_DEHYDROGENASE_ACT)
-        term.annotate_literal(RO_DUMMY, "value")
-        self.assert_lines(
-            """\
-            [Term]
-            id: GO:0050069
-            name: lysine dehydrogenase activity
-            property_value: RO:1234567 "value" xsd:string
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
-        )
-
-    def test_property_integer(self) -> None:
-        """Test emitting property literals that were annotated as a boolean."""
-        term = Term(reference=LYSINE_DEHYDROGENASE_ACT)
-        term.annotate_integer(RO_DUMMY, 1234)
-        self.assert_lines(
-            """\
-            [Term]
-            id: GO:0050069
-            name: lysine dehydrogenase activity
-            property_value: RO:1234567 "1234" xsd:integer
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
-        )
-
-    def test_property_bool(self) -> None:
-        """Test emitting property literals that were annotated as a boolean."""
-        term = Term(reference=LYSINE_DEHYDROGENASE_ACT)
-        term.annotate_boolean(RO_DUMMY, True)
-        self.assert_lines(
-            """\
-            [Term]
-            id: GO:0050069
-            name: lysine dehydrogenase activity
-            property_value: RO:1234567 "true" xsd:boolean
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
-        )
-
-    def test_property_year(self) -> None:
-        """Test emitting property literals that were annotated as a year."""
-        term = Term(reference=LYSINE_DEHYDROGENASE_ACT)
-        term.annotate_year(RO_DUMMY, "1993")
-        self.assert_lines(
-            """\
-            [Term]
-            id: GO:0050069
-            name: lysine dehydrogenase activity
-            property_value: RO:1234567 "1993" xsd:gYear
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
-        )
-
-    def test_property_object(self) -> None:
-        """Test emitting property literals."""
-        term = Term(reference=LYSINE_DEHYDROGENASE_ACT)
-        term.annotate_object(RO_DUMMY, Reference(prefix="hgnc", identifier="123"))
-        self.assert_lines(
-            """\
-            [Term]
-            id: GO:0050069
-            name: lysine dehydrogenase activity
-            property_value: RO:1234567 hgnc:123
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
-        )
-
-    def test_relation(self) -> None:
-        """Test emitting a relationship."""
-        term = Term(LYSINE_DEHYDROGENASE_ACT)
-        term.append_relationship(RO_DUMMY, Reference(prefix="eccode", identifier="1.4.1.15"))
-        self.assert_lines(
-            """\
-            [Term]
-            id: GO:0050069
-            name: lysine dehydrogenase activity
-            relationship: RO:1234567 eccode:1.4.1.15
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
-        )
-
-    def test_xref(self) -> None:
-        """Test emitting a relationship."""
-        term = Term(LYSINE_DEHYDROGENASE_ACT)
-        term.append_xref(Reference(prefix="eccode", identifier="1.4.1.15"))
-        self.assert_lines(
-            """\
-            [Term]
-            id: GO:0050069
-            name: lysine dehydrogenase activity
-            xref: eccode:1.4.1.15
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
-        )
-
-        ontology = _ontology_from_term("go", term)
-        mappings_df = ontology.get_mappings_df()
-        self.assertEqual(
-            ["subject_id", "object_id", "predicate_id", "mapping_justification"],
-            list(mappings_df.columns),
-        )
-        self.assertEqual(
-            ["GO:0050069", "eccode:1.4.1.15", "oboInOwl:hasDbXref", "semapv:UnspecifiedMatching"],
-            list(mappings_df.values[0]),
-        )
-
-    def test_parent(self) -> None:
-        """Test emitting a relationship."""
-        term = Term(LYSINE_DEHYDROGENASE_ACT)
-        term.append_parent(Reference(prefix="GO", identifier="1234568"))
-        self.assert_lines(
-            """\
-            [Term]
-            id: GO:0050069
-            name: lysine dehydrogenase activity
-            is_a: GO:1234568
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
-        )
-
-    def test_append_exact_match(self) -> None:
-        """Test emitting a relationship."""
-        term = Term(LYSINE_DEHYDROGENASE_ACT)
-        term.append_exact_match(
-            Reference(prefix="eccode", identifier="1.4.1.15", name="lysine dehydrogenase")
+    def test_4_namespace(self) -> None:
+        """Test the ``namespace`` tag."""
+        term = Term(
+            reference=LYSINE_DEHYDROGENASE_ACT,
+            namespace="gomf",
         )
         self.assert_lines(
             """\
             [Term]
             id: GO:0050069
             name: lysine dehydrogenase activity
-            property_value: skos:exactMatch eccode:1.4.1.15 ! exact match lysine dehydrogenase
+            namespace: gomf
             """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
         )
 
-        ontology = _ontology_from_term("go", term)
-        mappings_df = ontology.get_mappings_df()
-        self.assertEqual(
-            ["subject_id", "object_id", "predicate_id", "mapping_justification"],
-            list(mappings_df.columns),
-        )
-        self.assertEqual(
-            ["GO:0050069", "eccode:1.4.1.15", "skos:exactMatch", "semapv:UnspecifiedMatching"],
-            list(mappings_df.values[0]),
-        )
-
-        term = Term(LYSINE_DEHYDROGENASE_ACT)
-        term.append_exact_match(
-            Reference(prefix="eccode", identifier="1.4.1.15", name="lysine dehydrogenase")
-        )
-        self.assert_lines(
-            """\
-            [Term]
-            id: GO:0050069
-            name: lysine dehydrogenase activity
-            property_value: skos:exactMatch eccode:1.4.1.15 ! exact match lysine dehydrogenase
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
-        )
-
-        term = Term(LYSINE_DEHYDROGENASE_ACT)
-        term.annotate_object(
-            exact_match,
-            Reference(prefix="eccode", identifier="1.4.1.15", name="lysine dehydrogenase"),
-        )
-        self.assert_lines(
-            """\
-            [Term]
-            id: GO:0050069
-            name: lysine dehydrogenase activity
-            property_value: skos:exactMatch eccode:1.4.1.15 ! exact match lysine dehydrogenase
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
-        )
-
-    def test_set_species(self) -> None:
-        """Test emitting a relationship."""
-        term = Term(LYSINE_DEHYDROGENASE_ACT)
-        term.set_species("9606", "Homo sapiens")
-        self.assert_lines(
-            """\
-            [Term]
-            id: GO:0050069
-            name: lysine dehydrogenase activity
-            relationship: RO:0002162 NCBITaxon:9606 ! in taxon Homo sapiens
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
-        )
-
-        species = term.get_species()
-        self.assertIsNotNone(species)
-        self.assertEqual("ncbitaxon", species.prefix)
-        self.assertEqual("9606", species.identifier)
-
-    def test_comment(self) -> None:
-        """Test appending a comment."""
-        term = Term(LYSINE_DEHYDROGENASE_ACT)
-        term.append_comment("I like this record")
-        self.assert_lines(
-            """\
-            [Term]
-            id: GO:0050069
-            name: lysine dehydrogenase activity
-            property_value: rdfs:comment "I like this record" xsd:string
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
-        )
-
-    def test_replaced_by(self) -> None:
-        """Test adding a replaced by."""
-        term = Term(LYSINE_DEHYDROGENASE_ACT)
-        term.append_replaced_by(Reference(prefix="GO", identifier="1234569", name="dummy"))
-        self.assert_lines(
-            """\
-            [Term]
-            id: GO:0050069
-            name: lysine dehydrogenase activity
-            property_value: IAO:0100001 GO:1234569 ! term replaced by dummy
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
-        )
-
-    def test_property_default_reference(self) -> None:
-        """Test adding a replaced by."""
-        r = default_reference("go", "hey")
-        term = Term(LYSINE_DEHYDROGENASE_ACT)
-        term.annotate_object(r, Reference(prefix="GO", identifier="1234569", name="dummy"))
-        self.assert_lines(
-            """\
-            [Term]
-            id: GO:0050069
-            name: lysine dehydrogenase activity
-            property_value: hey GO:1234569
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={r.pair: r}),
-        )
-
-    def test_alt(self) -> None:
+    def test_5_alt(self) -> None:
         """Test adding an alternate ID."""
         term = Term(LYSINE_DEHYDROGENASE_ACT)
         term.append_alt(Reference(prefix="GO", identifier="1234569", name="dummy"))
@@ -407,7 +219,68 @@ class TestTerm(unittest.TestCase):
             term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
 
-    def test_append_synonym(self) -> None:
+    def test_6_provenance_no_definition(self) -> None:
+        """Test when there's provenance but not definition."""
+        term = Term(LYSINE_DEHYDROGENASE_ACT)
+        term.append_provenance(CHARLIE)
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            def: "" [orcid:0000-0003-4423-4370]
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
+        )
+
+    def test_6_definition(self):
+        """Test adding a definition."""
+        term = Term(LYSINE_DEHYDROGENASE_ACT, definition="Something")
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            def: "Something" []
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
+        )
+
+        term = Term(LYSINE_DEHYDROGENASE_ACT, definition="Something")
+        term.append_provenance(CHARLIE)
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            def: "Something" [orcid:0000-0003-4423-4370]
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
+        )
+
+    def test_7_comment_macro(self):
+        """"""
+        raise NotImplementedError
+
+    def test_7_comment(self) -> None:
+        """Test appending a comment."""
+        term = Term(LYSINE_DEHYDROGENASE_ACT)
+        term.append_comment("I like this record")
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            property_value: rdfs:comment "I like this record" xsd:string
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+        )
+
+    def test_8(self) -> None:
+        """Test the XXX tag."""
+        raise NotImplementedError
+
+    def test_9_append_synonym(self) -> None:
         """Test appending a synonym."""
         term = Term(LYSINE_DEHYDROGENASE_ACT)
         term.append_synonym(
@@ -473,7 +346,7 @@ class TestTerm(unittest.TestCase):
             ),
         )
 
-    def test_append_synonym_missing_typedef(self) -> None:
+    def test_9_append_synonym_missing_typedef(self) -> None:
         """Test appending a synonym."""
         term = Term(LYSINE_DEHYDROGENASE_ACT)
         term.append_synonym(
@@ -494,137 +367,358 @@ class TestTerm(unittest.TestCase):
             "WARNING:pyobo.struct.struct:[go] synonym typedef not defined: OMO:1234567", log.output
         )
 
-    def test_definition(self):
-        """Test adding a definition."""
-        term = Term(LYSINE_DEHYDROGENASE_ACT, definition="Something")
-        self.assert_lines(
-            """\
-            [Term]
-            id: GO:0050069
-            name: lysine dehydrogenase activity
-            def: "Something" []
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
-        )
-
-        term = Term(LYSINE_DEHYDROGENASE_ACT, definition="Something")
-        term.append_provenance(CHARLIE)
-        self.assert_lines(
-            """\
-            [Term]
-            id: GO:0050069
-            name: lysine dehydrogenase activity
-            def: "Something" [orcid:0000-0003-4423-4370]
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
-        )
-
-    def test_provenance_no_definition(self) -> None:
-        """Test when there's provenance but not definition."""
+    def test_10_xref(self) -> None:
+        """Test emitting a relationship."""
         term = Term(LYSINE_DEHYDROGENASE_ACT)
-        term.append_provenance(CHARLIE)
+        term.append_xref(Reference(prefix="eccode", identifier="1.4.1.15"))
         self.assert_lines(
             """\
             [Term]
             id: GO:0050069
             name: lysine dehydrogenase activity
-            def: "" [orcid:0000-0003-4423-4370]
+            xref: eccode:1.4.1.15
             """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )
 
-    def test_obsolete(self) -> None:
-        """Test obsolete definition."""
-        term = Term(LYSINE_DEHYDROGENASE_ACT, is_obsolete=True)
-        self.assert_lines(
-            """\
-            [Term]
-            id: GO:0050069
-            name: lysine dehydrogenase activity
-            is_obsolete: true
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
-        )
-
-        term = Term(LYSINE_DEHYDROGENASE_ACT, is_obsolete=False)
-        self.assert_lines(
-            """\
-            [Term]
-            id: GO:0050069
-            name: lysine dehydrogenase activity
-            is_obsolete: false
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
-        )
-
-    def test_see_also_single(self) -> None:
-        """Test appending see also."""
-        term = Term(LYSINE_DEHYDROGENASE_ACT)
-        term.append_see_also_url("https://example.org/test")
-        self.assert_lines(
-            """\
-            [Term]
-            id: GO:0050069
-            name: lysine dehydrogenase activity
-            property_value: rdfs:seeAlso "https://example.org/test" xsd:anyURI
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
-        )
-
+        ontology = _ontology_from_term("go", term)
+        mappings_df = ontology.get_mappings_df()
         self.assertEqual(
-            "https://example.org/test",
-            term.get_property(see_also),
+            ["subject_id", "object_id", "predicate_id", "mapping_justification"],
+            list(mappings_df.columns),
         )
-
         self.assertEqual(
-            ["https://example.org/test"],
-            term.get_properties(see_also),
+            ["GO:0050069", "eccode:1.4.1.15", "oboInOwl:hasDbXref", "semapv:UnspecifiedMatching"],
+            list(mappings_df.values[0]),
         )
 
-    def test_see_also_double(self) -> None:
-        """Test appending see also."""
+    def test_10_append_xref_with_axioms(self) -> None:
+        """Test emitting a xref with axioms."""
+        target = Reference(prefix="eccode", identifier="1.4.1.15", name="lysine dehydrogenase")
         term = Term(LYSINE_DEHYDROGENASE_ACT)
-        with self.assertRaises(ValueError):
-            term.append_see_also("something")
-
-        term = Term(LYSINE_DEHYDROGENASE_ACT)
-        term.append_see_also(Reference(prefix="hgnc", identifier="1234", name="dummy 1"))
-        term.append_see_also(Reference(prefix="hgnc", identifier="1235", name="dummy 2"))
-        self.assert_lines(
-            """\
+        term.append_xref(target, confidence=0.99)
+        lines = dedent("""\
             [Term]
             id: GO:0050069
             name: lysine dehydrogenase activity
-            property_value: rdfs:seeAlso hgnc:1234 ! see also dummy 1
-            property_value: rdfs:seeAlso hgnc:1235 ! see also dummy 2
-            """,
-            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
+            xref: eccode:1.4.1.15 {sssom:confidence=0.99} ! lysine dehydrogenase
+        """)
+        self.assert_lines(
+            lines,
+            term.iterate_obo_lines(
+                ontology_prefix="go",
+                typedefs={
+                    RO_DUMMY.pair: RO_DUMMY,
+                    mapping_has_confidence.pair: mapping_has_confidence,
+                    mapping_has_justification.pair: mapping_has_justification,
+                    has_contributor.pair: has_contributor,
+                },
+            ),
         )
 
+        ontology = _ontology_from_term("go", term)
+        mappings_df = ontology.get_mappings_df()
+        self.assertEqual(
+            ["subject_id", "object_id", "predicate_id", "mapping_justification", "confidence"],
+            list(mappings_df.columns),
+        )
         self.assertEqual(
             [
-                Reference(prefix="hgnc", identifier="1234", name="dummy 1").curie,
-                Reference(prefix="hgnc", identifier="1235", name="dummy 2").curie,
+                "GO:0050069",
+                "eccode:1.4.1.15",
+                "oboInOwl:hasDbXref",
+                "semapv:UnspecifiedMatching",
+                0.99,
             ],
-            term.get_properties(see_also),
+            list(mappings_df.values[0]),
         )
 
-        self.assertIsNone(term.get_relationship(exact_match))
-        self.assertIsNone(term.get_species())
-
-    def test_default_term(self) -> None:
-        """Test when a term uses a default reference."""
-        term = Term(reference=default_reference("gard", identifier="genetics", name="Genetics"))
+    def test_11_builtin(self) -> None:
+        """Test the builting tag."""
+        term = Term(
+            reference=LYSINE_DEHYDROGENASE_ACT,
+            builtin=True,
+        )
         self.assert_lines(
             """\
             [Term]
-            id: genetics
-            name: Genetics
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            builtin: true
             """,
-            term.iterate_obo_lines(ontology_prefix="gard", typedefs={}),
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
         )
 
-    def test_append_exact_match_axioms(self) -> None:
+        term2 = Term(
+            reference=LYSINE_DEHYDROGENASE_ACT,
+            builtin=False,
+        )
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            builtin: false
+            """,
+            term2.iterate_obo_lines(ontology_prefix="go", typedefs={}),
+        )
+
+    def test_12_property_default_reference(self) -> None:
+        """Test adding a replaced by."""
+        r = default_reference("go", "hey")
+        term = Term(LYSINE_DEHYDROGENASE_ACT)
+        term.annotate_object(r, Reference(prefix="GO", identifier="1234569", name="dummy"))
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            property_value: hey GO:1234569
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={r.pair: r}),
+        )
+
+    def test_12_property_literal(self) -> None:
+        """Test emitting property literals."""
+        term = Term(reference=LYSINE_DEHYDROGENASE_ACT)
+        term.annotate_literal(RO_DUMMY, "value")
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            property_value: RO:1234567 "value" xsd:string
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+        )
+
+    def test_12_property_integer(self) -> None:
+        """Test emitting property literals that were annotated as a boolean."""
+        term = Term(reference=LYSINE_DEHYDROGENASE_ACT)
+        term.annotate_integer(RO_DUMMY, 1234)
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            property_value: RO:1234567 "1234" xsd:integer
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+        )
+
+    def test_12_property_bool(self) -> None:
+        """Test emitting property literals that were annotated as a boolean."""
+        term = Term(reference=LYSINE_DEHYDROGENASE_ACT)
+        term.annotate_boolean(RO_DUMMY, True)
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            property_value: RO:1234567 "true" xsd:boolean
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+        )
+
+    def test_12_property_year(self) -> None:
+        """Test emitting property literals that were annotated as a year."""
+        term = Term(reference=LYSINE_DEHYDROGENASE_ACT)
+        term.annotate_year(RO_DUMMY, "1993")
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            property_value: RO:1234567 "1993" xsd:gYear
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+        )
+
+    def test_12_property_object(self) -> None:
+        """Test emitting property literals."""
+        term = Term(reference=LYSINE_DEHYDROGENASE_ACT)
+        term.annotate_object(RO_DUMMY, Reference(prefix="hgnc", identifier="123"))
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            property_value: RO:1234567 hgnc:123
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+        )
+
+    def test_13_parent(self) -> None:
+        """Test emitting a relationship."""
+        term = Term(LYSINE_DEHYDROGENASE_ACT)
+        term.append_parent(Reference(prefix="GO", identifier="1234568"))
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            is_a: GO:1234568
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+        )
+
+    def test_14_intersection_of(self) -> None:
+        """Test emitting intersection of."""
+        term = Term(reference=Reference(prefix="ZFA", identifier="0000134"))
+        term.append_intersection_of(Reference(prefix="CL", identifier="0000540", name="neuron"))
+        term.append_intersection_of(
+            part_of.reference,
+            Reference(prefix="NCBITaxon", identifier="7955", name="zebrafish"),
+        )
+        lines = dedent("""\
+            [Term]
+            id: ZFA:0000134
+            intersection_of: CL:0000540 ! neuron
+            intersection_of: BFO:0000050 NCBITaxon:7955 ! part of zebrafish
+        """)
+        self.assert_lines(lines, term.iterate_obo_lines(ontology_prefix="zfa", typedefs={}))
+
+    def test_15_union_of(self) -> None:
+        """Test emitting union of."""
+        term = Term(reference=Reference(prefix="ZFA", identifier="0000134"))
+        term.append_union_of(Reference(prefix="GO", identifier="0"))
+        term.append_union_of(Reference(prefix="GO", identifier="1"))
+        lines = dedent("""\
+            [Term]
+            id: ZFA:0000134
+            union_of: GO:0
+            union_of: GO:1
+        """)
+        self.assert_lines(lines, term.iterate_obo_lines(ontology_prefix="zfa", typedefs={}))
+
+    def test_16_equivalent_classes(self) -> None:
+        """Test emitting equivalent classes."""
+        term = Term(reference=Reference(prefix="ZFA", identifier="0000134"))
+        term.append_equivalent_to(Reference(prefix="GO", identifier="0"))
+        lines = dedent("""\
+            [Term]
+            id: ZFA:0000134
+            equivalent_to: GO:0
+        """)
+        self.assert_lines(lines, term.iterate_obo_lines(ontology_prefix="zfa", typedefs={}))
+
+    def test_17_disjoint_from_namespace(self) -> None:
+        """Test the ``disjoint_from`` tag."""
+        term = Term(reference=LYSINE_DEHYDROGENASE_ACT, disjoint_from=[
+            Reference(prefix="GO", identifier="0000000"),
+            Reference(prefix="GO", identifier="0000001"),
+        ])
+
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            disjoint_from: GO:0000000
+            disjoint_from: GO:0000001
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
+        )
+
+    def test_18_relation(self) -> None:
+        """Test emitting a relationship."""
+        term = Term(LYSINE_DEHYDROGENASE_ACT)
+        term.append_relationship(RO_DUMMY, Reference(prefix="eccode", identifier="1.4.1.15"))
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            relationship: RO:1234567 eccode:1.4.1.15
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+        )
+
+    def test_18_append_exact_match(self) -> None:
+        """Test emitting a relationship."""
+        term = Term(LYSINE_DEHYDROGENASE_ACT)
+        term.append_exact_match(
+            Reference(prefix="eccode", identifier="1.4.1.15", name="lysine dehydrogenase")
+        )
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            property_value: skos:exactMatch eccode:1.4.1.15 ! exact match lysine dehydrogenase
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+        )
+
+        ontology = _ontology_from_term("go", term)
+        mappings_df = ontology.get_mappings_df()
+        self.assertEqual(
+            ["subject_id", "object_id", "predicate_id", "mapping_justification"],
+            list(mappings_df.columns),
+        )
+        self.assertEqual(
+            ["GO:0050069", "eccode:1.4.1.15", "skos:exactMatch", "semapv:UnspecifiedMatching"],
+            list(mappings_df.values[0]),
+        )
+
+        term = Term(LYSINE_DEHYDROGENASE_ACT)
+        term.append_exact_match(
+            Reference(prefix="eccode", identifier="1.4.1.15", name="lysine dehydrogenase")
+        )
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            property_value: skos:exactMatch eccode:1.4.1.15 ! exact match lysine dehydrogenase
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+        )
+
+        term = Term(LYSINE_DEHYDROGENASE_ACT)
+        term.annotate_object(
+            exact_match,
+            Reference(prefix="eccode", identifier="1.4.1.15", name="lysine dehydrogenase"),
+        )
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            property_value: skos:exactMatch eccode:1.4.1.15 ! exact match lysine dehydrogenase
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+        )
+
+    def test_18_set_species(self) -> None:
+        """Test emitting a relationship."""
+        term = Term(LYSINE_DEHYDROGENASE_ACT)
+        term.set_species("9606", "Homo sapiens")
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            relationship: RO:0002162 NCBITaxon:9606 ! in taxon Homo sapiens
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+        )
+
+        species = term.get_species()
+        self.assertIsNotNone(species)
+        self.assertEqual("ncbitaxon", species.prefix)
+        self.assertEqual("9606", species.identifier)
+
+    def test_18_species(self) -> None:
+        """Test setting and getting species."""
+        term = Term(reference=Reference(prefix="hgnc", identifier="1234"))
+        term.set_species("9606", "Homo sapiens")
+        species = term.get_species()
+        self.assertIsNotNone(species)
+        self.assertEqual(NCBITAXON_PREFIX, species.prefix)
+        self.assertEqual("9606", species.identifier)
+
+    def test_18_append_exact_match_axioms(self) -> None:
         """Test emitting a relationship with axioms."""
         target = Reference(prefix="eccode", identifier="1.4.1.15", name="lysine dehydrogenase")
         term = Term(LYSINE_DEHYDROGENASE_ACT)
@@ -679,59 +773,102 @@ sssom:mapping_justification=semapv:UnspecifiedMatching} ! exact match lysine deh
             list(mappings_df.values[0]),
         )
 
-    def test_append_xref_with_axioms(self) -> None:
-        """Test emitting a xref with axioms."""
-        target = Reference(prefix="eccode", identifier="1.4.1.15", name="lysine dehydrogenase")
+    def test_18_see_also_single(self) -> None:
+        """Test appending see also."""
         term = Term(LYSINE_DEHYDROGENASE_ACT)
-        term.append_xref(target, confidence=0.99)
-        lines = dedent("""\
+        term.append_see_also_url("https://example.org/test")
+        self.assert_lines(
+            """\
             [Term]
             id: GO:0050069
             name: lysine dehydrogenase activity
-            xref: eccode:1.4.1.15 {sssom:confidence=0.99} ! lysine dehydrogenase
-        """)
-        self.assert_lines(
-            lines,
-            term.iterate_obo_lines(
-                ontology_prefix="go",
-                typedefs={
-                    RO_DUMMY.pair: RO_DUMMY,
-                    mapping_has_confidence.pair: mapping_has_confidence,
-                    mapping_has_justification.pair: mapping_has_justification,
-                    has_contributor.pair: has_contributor,
-                },
-            ),
+            property_value: rdfs:seeAlso "https://example.org/test" xsd:anyURI
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
         )
 
-        ontology = _ontology_from_term("go", term)
-        mappings_df = ontology.get_mappings_df()
         self.assertEqual(
-            ["subject_id", "object_id", "predicate_id", "mapping_justification", "confidence"],
-            list(mappings_df.columns),
+            "https://example.org/test",
+            term.get_property(see_also),
         )
+
+        self.assertEqual(
+            ["https://example.org/test"],
+            term.get_properties(see_also),
+        )
+
+    def test_18_see_also_double(self) -> None:
+        """Test appending see also."""
+        term = Term(LYSINE_DEHYDROGENASE_ACT)
+        with self.assertRaises(ValueError):
+            term.append_see_also("something")
+
+        term = Term(LYSINE_DEHYDROGENASE_ACT)
+        term.append_see_also(Reference(prefix="hgnc", identifier="1234", name="dummy 1"))
+        term.append_see_also(Reference(prefix="hgnc", identifier="1235", name="dummy 2"))
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            property_value: rdfs:seeAlso hgnc:1234 ! see also dummy 1
+            property_value: rdfs:seeAlso hgnc:1235 ! see also dummy 2
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
+        )
+
         self.assertEqual(
             [
-                "GO:0050069",
-                "eccode:1.4.1.15",
-                "oboInOwl:hasDbXref",
-                "semapv:UnspecifiedMatching",
-                0.99,
+                Reference(prefix="hgnc", identifier="1234", name="dummy 1").curie,
+                Reference(prefix="hgnc", identifier="1235", name="dummy 2").curie,
             ],
-            list(mappings_df.values[0]),
+            term.get_properties(see_also),
         )
 
-    def test_intersection_of(self) -> None:
-        """Test emitting intersection of."""
-        term = Term(reference=Reference(prefix="ZFA", identifier="0000134"))
-        term.append_intersection_of(Reference(prefix="CL", identifier="0000540", name="neuron"))
-        term.append_intersection_of(
-            part_of.reference,
-            Reference(prefix="NCBITaxon", identifier="7955", name="zebrafish"),
-        )
-        lines = dedent("""\
+        self.assertIsNone(term.get_relationship(exact_match))
+        self.assertIsNone(term.get_species())
+
+    def test_19_created_by(self) -> None:
+        """Test the ``created_by`` tag."""
+
+    def test_20_creation_date(self) -> None:
+        """Test the ``creation_date`` tag."""
+
+    def test_21_obsolete(self) -> None:
+        """Test obsolete definition."""
+        term = Term(LYSINE_DEHYDROGENASE_ACT, is_obsolete=True)
+        self.assert_lines(
+            """\
             [Term]
-            id: ZFA:0000134
-            intersection_of: CL:0000540 ! neuron
-            intersection_of: BFO:0000050 NCBITaxon:7955 ! part of zebrafish
-        """)
-        self.assert_lines(lines, term.iterate_obo_lines(ontology_prefix="zfa", typedefs={}))
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            is_obsolete: true
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
+        )
+
+        term = Term(LYSINE_DEHYDROGENASE_ACT, is_obsolete=False)
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            is_obsolete: false
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
+        )
+
+    def test_22_replaced_by(self) -> None:
+        """Test adding a replaced by."""
+        term = Term(LYSINE_DEHYDROGENASE_ACT)
+        term.append_replaced_by(Reference(prefix="GO", identifier="1234569", name="dummy"))
+        self.assert_lines(
+            """\
+            [Term]
+            id: GO:0050069
+            name: lysine dehydrogenase activity
+            property_value: IAO:0100001 GO:1234569 ! term replaced by dummy
+            replaced_by: GO:1234569 ! term replaced by dummy
+            """,
+            term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
+        )

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -258,10 +258,6 @@ class TestTerm(unittest.TestCase):
             term.iterate_obo_lines(ontology_prefix="go", typedefs={}),
         )
 
-    def test_7_comment_macro(self):
-        """"""
-        raise NotImplementedError
-
     def test_7_comment(self) -> None:
         """Test appending a comment."""
         term = Term(LYSINE_DEHYDROGENASE_ACT)
@@ -271,6 +267,7 @@ class TestTerm(unittest.TestCase):
             [Term]
             id: GO:0050069
             name: lysine dehydrogenase activity
+            comment: "I like this record"
             property_value: rdfs:comment "I like this record" xsd:string
             """,
             term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
@@ -604,10 +601,13 @@ class TestTerm(unittest.TestCase):
 
     def test_17_disjoint_from_namespace(self) -> None:
         """Test the ``disjoint_from`` tag."""
-        term = Term(reference=LYSINE_DEHYDROGENASE_ACT, disjoint_from=[
-            Reference(prefix="GO", identifier="0000000"),
-            Reference(prefix="GO", identifier="0000001"),
-        ])
+        term = Term(
+            reference=LYSINE_DEHYDROGENASE_ACT,
+            disjoint_from=[
+                Reference(prefix="GO", identifier="0000000"),
+                Reference(prefix="GO", identifier="0000001"),
+            ],
+        )
 
         self.assert_lines(
             """\
@@ -868,7 +868,7 @@ sssom:mapping_justification=semapv:UnspecifiedMatching} ! exact match lysine deh
             id: GO:0050069
             name: lysine dehydrogenase activity
             property_value: IAO:0100001 GO:1234569 ! term replaced by dummy
-            replaced_by: GO:1234569 ! term replaced by dummy
+            replaced_by: GO:1234569 ! dummy
             """,
             term.iterate_obo_lines(ontology_prefix="go", typedefs={RO_DUMMY.pair: RO_DUMMY}),
         )

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -789,7 +789,7 @@ sssom:mapping_justification=semapv:UnspecifiedMatching} ! exact match lysine deh
 
         self.assertEqual(
             ["https://example.org/test"],
-            term.get_properties_as_str(see_also),
+            term.get_property_literals(see_also),
         )
 
     def test_18_see_also_double(self) -> None:
@@ -817,7 +817,7 @@ sssom:mapping_justification=semapv:UnspecifiedMatching} ! exact match lysine deh
                 Reference(prefix="hgnc", identifier="1234", name="dummy 1").curie,
                 Reference(prefix="hgnc", identifier="1235", name="dummy 2").curie,
             ],
-            term.get_properties_as_str(see_also),
+            term.get_property_literals(see_also),
         )
 
         self.assertIsNone(term.get_relationship(exact_match))

--- a/tests/test_typedef.py
+++ b/tests/test_typedef.py
@@ -521,7 +521,30 @@ class TestTypeDef(unittest.TestCase):
 
         - https://github.com/geneontology/go-ontology/blob/ce41588cbdc05223f9cfd029985df3cadd1e0399/src/ontology/extensions/gorel.obo#L1277-L1285
         - https://github.com/cmungall/bioperl-owl/blob/0b52048975c078d3bc50f6611235e9f8cb9b9475/ont/interval_relations.obo~#L86-L103
+
+        This also works for the combination of gene-transribes-protein, protein-memberof-ec.
         """
+        typedef = TypeDef(
+            reference=Reference(prefix="GO", identifier="1"),
+            equivalent_to_chain=
+            [Reference(prefix="GO", identifier="2"), Reference(prefix="GO", identifier="3")],
+        )
+        self.assert_obo_stanza(
+            """\
+            [Typedef]
+            id: GO:1
+            equivalent_to_chain: GO:2 GO:3
+            """,
+            typedef,
+        )
+        self.assert_funowl_lines(
+            """
+            Declaration( ObjectProperty( GO:1 ) )
+            SubObjectPropertyOf( ObjectPropertyChain( GO:2 GO:3 ) GO:1 )
+            """,
+            typedef,
+        )
+
 
     def test_31_disjoint_over(self) -> None:
         """Test the ``disjoint_over`` tag."""

--- a/tests/test_typedef.py
+++ b/tests/test_typedef.py
@@ -526,8 +526,10 @@ class TestTypeDef(unittest.TestCase):
         """
         typedef = TypeDef(
             reference=Reference(prefix="GO", identifier="1"),
-            equivalent_to_chain=
-            [Reference(prefix="GO", identifier="2"), Reference(prefix="GO", identifier="3")],
+            equivalent_to_chain=[
+                Reference(prefix="GO", identifier="2"),
+                Reference(prefix="GO", identifier="3"),
+            ],
         )
         self.assert_obo_stanza(
             """\
@@ -544,7 +546,6 @@ class TestTypeDef(unittest.TestCase):
             """,
             typedef,
         )
-
 
     def test_31_disjoint_over(self) -> None:
         """Test the ``disjoint_over`` tag."""

--- a/tests/test_typedef.py
+++ b/tests/test_typedef.py
@@ -55,6 +55,37 @@ class TestTypeDef(unittest.TestCase):
             typedef.iterate_obo_lines(ontology_prefix),
         )
 
+    def assert_boolean_tag(self, name: str) -> None:
+        """Assert the boolean tag parses properly."""
+        reference = Reference(prefix="GO", identifier="0000001")
+        typedef = TypeDef(reference=reference, **{name: True})
+        self.assert_obo_stanza(
+            f"""\
+            [Typedef]
+            id: GO:0000001
+            {name}: true
+            """,
+            typedef,
+        )
+        self.assertTrue(hasattr(typedef, name))
+        value = getattr(typedef, name)
+        self.assertIsNotNone(value)
+        self.assertTrue(value)
+
+        typedef = TypeDef(reference=reference, **{name: False})
+        self.assert_obo_stanza(
+            f"""\
+            [Typedef]
+            id: GO:0000001
+            {name}: false
+            """,
+            typedef,
+        )
+        self.assertTrue(hasattr(typedef, name))
+        value = getattr(typedef, name)
+        self.assertIsNotNone(value)
+        self.assertFalse(value)
+
     def test_1_declaration(self) -> None:
         """Test the declaration."""
         object_property = TypeDef(reference=REF)
@@ -81,25 +112,7 @@ class TestTypeDef(unittest.TestCase):
 
     def test_2_is_anonymous(self) -> None:
         """Test the ``is_anonymous`` tag."""
-        typedef = TypeDef(reference=REF, is_anonymous=True)
-        self.assert_obo_stanza(
-            """\
-            [Typedef]
-            id: RO:0000087
-            is_anonymous: true
-            """,
-            typedef,
-        )
-
-        typedef = TypeDef(reference=REF, is_anonymous=False)
-        self.assert_obo_stanza(
-            """\
-            [Typedef]
-            id: RO:0000087
-            is_anonymous: false
-            """,
-            typedef,
-        )
+        self.assert_boolean_tag("is_anonymous")
 
     def test_3_name(self) -> None:
         """Test outputting a name."""
@@ -133,7 +146,7 @@ class TestTypeDef(unittest.TestCase):
         """Test the ``alt_id`` tag."""
         typedef = TypeDef(
             reference=REF,
-            alt_id=[
+            alt_ids=[
                 Reference(prefix="RO", identifier="1234567"),
                 Reference(prefix="RO", identifier="1234568", name="test"),
             ],
@@ -294,18 +307,7 @@ class TestTypeDef(unittest.TestCase):
 
     def test_14_builtin(self) -> None:
         """Test the ``builtin`` tag."""
-        typedef = TypeDef(
-            reference=Reference(prefix="rdfs", identifier="subClassOf"),
-            builtin=True,
-        )
-        self.assert_obo_stanza(
-            """\
-           [Typedef]
-           id: rdfs:subClassOf
-           builtin: true
-           """,
-            typedef,
-        )
+        self.assert_boolean_tag("builtin")
 
     def test_15_holds_over_chain(self) -> None:
         """Test the ``holds_over_chain`` tag.
@@ -326,8 +328,10 @@ class TestTypeDef(unittest.TestCase):
         typedef = TypeDef(
             reference=Reference(prefix="BFO", identifier="0000066"),
             holds_over_chain=[
-                Reference(prefix="BFO", identifier="0000050", name="part of"),
-                Reference(prefix="BFO", identifier="0000066", name="occurs in"),
+                [
+                    Reference(prefix="BFO", identifier="0000050", name="part of"),
+                    Reference(prefix="BFO", identifier="0000066", name="occurs in"),
+                ]
             ],
         )
         self.assert_obo_stanza(
@@ -341,85 +345,45 @@ class TestTypeDef(unittest.TestCase):
 
     def test_16_is_anti_symmetric(self) -> None:
         """Test the ``anti_symmetric`` tag."""
-        typedef = TypeDef(
-            reference=Reference(prefix="rdfs", identifier="subClassOf"), is_anti_symmetric=True
-        )
-        self.assert_obo_stanza(
-            """\
-            [Typedef]
-            id: rdfs:subClassOf
-            is_anti_symmetric: true
-            """,
-            typedef,
-        )
+        self.assert_boolean_tag("is_anti_symmetric")
 
     def test_17_is_cyclic(self) -> None:
         """Test the ``is_cyclic`` tag."""
-        typedef = TypeDef(
-            reference=default_reference(prefix="chebi", identifier="is_conjugate_acid_of"),
-            is_cyclic=True,
-        )
-        self.assert_obo_stanza(
-            """\
-            [Typedef]
-            id: is_conjugate_acid_of
-            is_cyclic: true
-            """,
-            typedef,
-            ontology_prefix="chebi",
-        )
+        self.assert_boolean_tag("is_cyclic")
 
     def test_18_is_reflexive(self) -> None:
         """Test the ``is_reflexive`` tag."""
-        typedef = TypeDef(
-            reference=Reference(prefix="rdfs", identifier="subClassOf"), is_reflexive=True
-        )
-        self.assert_obo_stanza(
-            """\
-            [Typedef]
-            id: rdfs:subClassOf
-            is_reflexive: true
-            """,
-            typedef,
-        )
+        self.assert_boolean_tag("is_reflexive")
 
     def test_19_is_symmetric(self) -> None:
         """Test the ``is_symmetric`` tag."""
-        typedef = TypeDef(
-            reference=default_reference(prefix="ro", identifier="attached_to"), is_symmetric=True
-        )
-        self.assert_obo_stanza(
-            """\
-            [Typedef]
-            id: attached_to
-            is_symmetric: true
-            """,
-            typedef,
-            ontology_prefix="ro",
-        )
+        self.assert_boolean_tag("is_symmetric")
 
     def test_20_is_transitive(self) -> None:
         """Test the ``is_transitive`` tag."""
-        typedef = TypeDef(
-            reference=Reference(prefix="rdfs", identifier="subClassOf"), is_transitive=True
-        )
-        self.assert_obo_stanza(
-            """\
-            [Typedef]
-            id: rdfs:subClassOf
-            is_transitive: true
-            """,
-            typedef,
-        )
+        self.assert_boolean_tag("is_transitive")
 
     def test_21_is_functional(self) -> None:
         """Test the ``is_functional`` tag."""
+        self.assert_boolean_tag("is_functional")
 
     def test_22_is_inverse_functional(self) -> None:
         """Test the ``is_inverse_functional`` tag."""
+        self.assert_boolean_tag("is_inverse_functional")
 
     def test_23_is_a(self) -> None:
         """Test the ``is_a`` tag."""
+        typedef = TypeDef(reference=Reference(prefix="BFO", identifier="0000050", name="part of"))
+        typedef.append_parent(Reference(prefix="RO", identifier="0002131", name="overlaps"))
+        self.assert_obo_stanza(
+            """\
+            [Typedef]
+            id: BFO:0000050
+            name: part of
+            is_a: RO:0002131 ! overlaps
+            """,
+            typedef,
+        )
 
     def test_24_intersection_of(self) -> None:
         """Test the ``intersection_-f`` tag."""
@@ -448,12 +412,44 @@ class TestTypeDef(unittest.TestCase):
 
     def test_25_union_of(self) -> None:
         """Test the ``union_of`` tag."""
+        typedef = TypeDef(reference=Reference(prefix="GO", identifier="0000001"))
+        typedef.append_union_of(Reference(prefix="GO", identifier="0000002"))
+        typedef.append_union_of(Reference(prefix="GO", identifier="0000003"))
+        self.assert_obo_stanza(
+            """\
+            [Typedef]
+            id: GO:0000001
+            union_of: GO:0000002
+            union_of: GO:0000003
+            """,
+            typedef,
+        )
 
     def test_26_equivalent_to(self) -> None:
         """Test the ``equivalent_to`` tag."""
+        typedef = TypeDef(reference=Reference(prefix="GO", identifier="0000001"))
+        typedef.append_equivalent_to(Reference(prefix="GO", identifier="0000002"))
+        self.assert_obo_stanza(
+            """\
+            [Typedef]
+            id: GO:0000001
+            equivalent_to: GO:0000002
+            """,
+            typedef,
+        )
 
     def test_27_disjoint_from(self) -> None:
         """Test the ``disjoint_from`` tag."""
+        typedef = TypeDef(reference=Reference(prefix="GO", identifier="0000001"))
+        typedef.append_disjoint_from(Reference(prefix="GO", identifier="0000002"))
+        self.assert_obo_stanza(
+            """\
+            [Typedef]
+            id: GO:0000001
+            disjoint_from: GO:0000002
+            """,
+            typedef,
+        )
 
     def test_28_inverse_of(self) -> None:
         """Test the ``inverse_of`` tag.
@@ -527,8 +523,10 @@ class TestTypeDef(unittest.TestCase):
         typedef = TypeDef(
             reference=Reference(prefix="GO", identifier="1"),
             equivalent_to_chain=[
-                Reference(prefix="GO", identifier="2"),
-                Reference(prefix="GO", identifier="3"),
+                [
+                    Reference(prefix="GO", identifier="2"),
+                    Reference(prefix="GO", identifier="3"),
+                ]
             ],
         )
         self.assert_obo_stanza(
@@ -539,22 +537,41 @@ class TestTypeDef(unittest.TestCase):
             """,
             typedef,
         )
-        self.assert_funowl_lines(
-            """
-            Declaration( ObjectProperty( GO:1 ) )
-            SubObjectPropertyOf( ObjectPropertyChain( GO:2 GO:3 ) GO:1 )
+
+    def test_31_disjoint_over(self) -> None:
+        """Test the ``disjoint_over`` tag."""
+        typedef = TypeDef(
+            reference=Reference(prefix="GO", identifier="0000001"),
+            disjoint_over=[Reference(prefix="GO", identifier="0000002")],
+        )
+        self.assert_obo_stanza(
+            """\
+            [Typedef]
+            id: GO:0000001
+            disjoint_over: GO:0000002
             """,
             typedef,
         )
 
-    def test_31_disjoint_over(self) -> None:
-        """Test the ``disjoint_over`` tag."""
-
     def test_32_relationship(self) -> None:
         """Test the ``relationship`` tag."""
+        typedef = TypeDef(reference=Reference(prefix="GO", identifier="0000001"))
+        typedef.append_relationship(
+            Reference(prefix="GO", identifier="0000002"),
+            Reference(prefix="GO", identifier="0000003"),
+        )
+        self.assert_obo_stanza(
+            """\
+            [Typedef]
+            id: GO:0000001
+            relationship: GO:0000002 GO:0000003
+            """,
+            typedef,
+        )
 
     def test_33_is_obsolete(self) -> None:
         """Test the ``is_obsolete`` tag."""
+        self.assert_boolean_tag("is_obsolete")
 
     def test_34_created_by(self) -> None:
         """Test the ``created_by`` tag."""
@@ -564,12 +581,34 @@ class TestTypeDef(unittest.TestCase):
 
     def test_36_replaced_by(self) -> None:
         """Test the ``replaced_by`` tag."""
+        typedef = TypeDef(reference=Reference(prefix="GO", identifier="0000001"))
+        typedef.append_replaced_by(Reference(prefix="GO", identifier="0000002"))
+        self.assert_obo_stanza(
+            """\
+            [Typedef]
+            id: GO:0000001
+            replaced_by: GO:0000002
+            """,
+            typedef,
+        )
 
     def test_37_consider(self) -> None:
         """Test the ``consider`` tag."""
+        typedef = TypeDef(reference=Reference(prefix="GO", identifier="0000001"))
+        typedef.append_see_also(Reference(prefix="GO", identifier="0000002"))
+        self.assert_obo_stanza(
+            """\
+            [Typedef]
+            id: GO:0000001
+            consider: GO:0000002
+            """,
+            typedef,
+        )
 
     def test_40_is_metadata_tag(self) -> None:
         """Test the ``is_metadata_tag`` tag."""
+        self.assert_boolean_tag("is_metadata_tag")
 
     def test_41_is_class_level(self) -> None:
         """Test the ``is_class_level`` tag."""
+        self.assert_boolean_tag("is_class_level")


### PR DESCRIPTION
This PR mostly completes the reader and data structures for terms and typedefs with respect to the OBO flat file format.

It's still not quite accurate in the way it represents instances, but this is hard to deal with since ROBOT cowardly refuses to work with instances in OBO format. The functional OWL PR will make it easier to test this