### PR TITLE
Remove xref-types

### DIFF
--- a/src/pyobo/obographs.py
+++ b/src/pyobo/obographs.py
@@ -20,7 +20,7 @@ from bioontologies.obograph import (
 from bioontologies.robot import ParseResults
 from tqdm import tqdm
 
-from pyobo.struct import Obo, Reference, Referenced, Term
+from pyobo.struct import Obo, Referenced, Term
 from pyobo.struct.typedef import definition_source, is_a
 
 __all__ = [

--- a/src/pyobo/obographs.py
+++ b/src/pyobo/obographs.py
@@ -73,21 +73,12 @@ def _get_class_node(term: Term) -> Node:
         )
     else:
         definition = None
-
-    if term.xrefs:
-        if not term.xref_types:
-            term.xref_types = [
-                Reference(prefix="oboInOwl", identifier="hasDbXref") for _ in term.xrefs
-            ]
-        elif len(term.xrefs) != len(term.xref_types):
-            raise ValueError
-
     xrefs = [
         Xref.from_parsed(
-            predicate=_rewire(xref_type),
-            value=_rewire(xref),
+            predicate=_rewire(mapping_predicate),
+            value=_rewire(mapping_objext),
         )
-        for xref, xref_type in zip(term.xrefs, term.xref_types, strict=False)
+        for mapping_predicate, mapping_objext in term.get_mappings(include_xrefs=True)
     ]
     synonyms = [
         Synonym.from_parsed(

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -264,7 +264,8 @@ class Term(Referenced, Stanza):
     #: Synonyms of this term
     synonyms: list[Synonym] = field(default_factory=list)
 
-    #: Equivalent references
+    #: Database cross-references, see :func:`get_mappings` for
+    #: access to all mappings in an SSSOM-like interface
     xrefs: list[Reference] = field(default_factory=list)
 
     #: Alternate Identifiers

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -266,8 +266,6 @@ class Term(Referenced, Stanza):
 
     #: Equivalent references
     xrefs: list[Reference] = field(default_factory=list)
-    # TODO remove xref_types, this can be done with axioms now
-    xref_types: list[Reference] = field(default_factory=list)
 
     #: Alternate Identifiers
     alt_ids: list[Reference] = field(default_factory=list)


### PR DESCRIPTION
This PR removes the `xref_types` variable from the Term class, because there are now alternate ways of adding mappings and getting them back out, see `Term.get_mapping`