### PR TITLE
Make use of preferred CURIEs more consistent

### DIFF
--- a/src/pyobo/api/properties.py
+++ b/src/pyobo/api/properties.py
@@ -61,21 +61,20 @@ def get_filtered_properties_mapping(
     :returns: A mapping from identifier to property value
     """
     prop = _ensure_ref(prop)
+    prop_curie = prop.curie
     version = get_version_from_kwargs(prefix, kwargs)
     all_properties_path = prefix_cache_join(prefix, name="properties.tsv", version=version)
     if all_properties_path.is_file():
         logger.info("[%s] loading pre-cached properties", prefix)
         df = pd.read_csv(all_properties_path, sep="\t")
         logger.info("[%s] filtering pre-cached properties", prefix)
-        df = df.loc[df["property"] == prop.preferred_curie, [f"{prefix}_id", "value"]]
+        df = df.loc[df["property"] == prop_curie, [f"{prefix}_id", "value"]]
         return dict(df.values)
 
-    path = prefix_cache_join(
-        prefix, "properties", name=f"{prop.preferred_curie}.tsv", version=version
-    )
+    path = prefix_cache_join(prefix, "properties", name=f"{prop_curie}.tsv", version=version)
 
     @cached_mapping(
-        path=path, header=[f"{prefix}_id", prop.preferred_curie], force=check_should_force(kwargs)
+        path=path, header=[f"{prefix}_id", prop_curie], force=check_should_force(kwargs)
     )
     def _mapping_getter() -> Mapping[str, str]:
         logger.info("[%s] no cached properties found. getting from OBO loader", prefix)
@@ -98,21 +97,21 @@ def get_filtered_properties_multimapping(
     :returns: A mapping from identifier to property values
     """
     prop = _ensure_ref(prop)
+    prop_curie = prop.curie
     version = get_version_from_kwargs(prefix, kwargs)
     all_properties_path = prefix_cache_join(prefix, name="properties.tsv", version=version)
+
     if all_properties_path.is_file():
         logger.info("[%s] loading pre-cached properties", prefix)
         df = pd.read_csv(all_properties_path, sep="\t")
         logger.info("[%s] filtering pre-cached properties", prefix)
-        df = df.loc[df["property"] == prop.preferred_curie, [f"{prefix}_id", "value"]]
+        df = df.loc[df["property"] == prop_curie, [f"{prefix}_id", "value"]]
         return multidict(df.values)
 
-    path = prefix_cache_join(
-        prefix, "properties", name=f"{prop.preferred_curie}.tsv", version=version
-    )
+    path = prefix_cache_join(prefix, "properties", name=f"{prop_curie}.tsv", version=version)
 
     @cached_multidict(
-        path=path, header=[f"{prefix}_id", prop.preferred_curie], force=check_should_force(kwargs)
+        path=path, header=[f"{prefix}_id", prop_curie], force=check_should_force(kwargs)
     )
     def _mapping_getter() -> Mapping[str, list[str]]:
         logger.info("[%s] no cached properties found. getting from OBO loader", prefix)

--- a/src/pyobo/reader.py
+++ b/src/pyobo/reader.py
@@ -874,7 +874,7 @@ def _iterate_chain(
             logger.warning(
                 "[%s - %s] could not parse line: %s: %s",
                 ontology_prefix,
-                typedef.preferred_curie,
+                typedef.curie,
                 tag,
                 chain,
             )

--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -21,6 +21,7 @@ __all__ = [
     "Reference",
     "Referenced",
     "default_reference",
+    "get_preferred_curie",
     "multi_reference_escape",
     "reference_escape",
     "unspecified_matching",
@@ -173,6 +174,17 @@ class Referenced:
         return self.reference.bioregistry_link
 
 
+def get_preferred_curie(
+    ref: curies.Reference | curies.NamedReference | Reference | Referenced,
+) -> str:
+    """Get the preferred CURIE from a variety of types."""
+    match ref:
+        case Referenced() | Reference():
+            return ref.preferred_curie
+        case curies.Reference() | curies.NamedReference():
+            return ref.curie
+
+
 def default_reference(prefix: str, identifier: str, name: str | None = None) -> Reference:
     """Create a CURIE for an "unqualified" reference.
 
@@ -197,7 +209,7 @@ def reference_escape(
         return reference.identifier.removeprefix(f"{ontology_prefix}#")
     # get sneaky, to allow a variety of the base class from curies.Reference to
     # the extended version in pyobo.Reference
-    rv = getattr(reference, "preferred_curie", reference.curie)
+    rv = get_preferred_curie(reference)
     if add_name_comment and reference.name:
         rv += f" ! {reference.name}"
     return rv
@@ -222,7 +234,7 @@ def multi_reference_escape(
 
 def comma_separate_references(references: list[Reference]) -> str:
     """Map a list to strings and make comma separated."""
-    return ", ".join(r.preferred_curie for r in references)
+    return ", ".join(get_preferred_curie(r) for r in references)
 
 
 def _ground_relation(relation_str: str) -> Reference | None:

--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -207,8 +207,6 @@ def reference_escape(
     """Write a reference with default namespace removed."""
     if reference.prefix == "obo" and reference.identifier.startswith(f"{ontology_prefix}#"):
         return reference.identifier.removeprefix(f"{ontology_prefix}#")
-    # get sneaky, to allow a variety of the base class from curies.Reference to
-    # the extended version in pyobo.Reference
     rv = get_preferred_curie(reference)
     if add_name_comment and reference.name:
         rv += f" ! {reference.name}"

--- a/src/pyobo/struct/struct_utils.py
+++ b/src/pyobo/struct/struct_utils.py
@@ -17,6 +17,7 @@ from .reference import (
     Reference,
     Referenced,
     default_reference,
+    get_preferred_curie,
     multi_reference_escape,
     reference_escape,
 )
@@ -478,7 +479,7 @@ def _iterate_obo_relations(
             match value:
                 case OBOLiteral(dd, datatype):
                     # TODO how to clean/escape value?
-                    end = f'"{dd}" {datatype.preferred_curie}'
+                    end = f'"{dd}" {get_preferred_curie(datatype)}'
                     name = None
                 case curies.Reference():  # it's a reference
                     if predicate in skip_predicate_objects:


### PR DESCRIPTION
This PR adds an intermediate function that enables `curies.Reference`s to be used more widely (though, does not yet carefully update the type annotations)