### PR TITLE
Import ICD11 MMS codes

### DIFF
--- a/src/pyobo/sources/icd11.py
+++ b/src/pyobo/sources/icd11.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from tqdm.auto import tqdm
 
-from ..sources.icd_utils import (
+from ..icd_utils import (
     ICD11_TOP_LEVEL_URL,
     ICDError,
     get_child_identifiers,
@@ -18,7 +18,7 @@ from ..sources.icd_utils import (
     get_icd_11_mms,
     visiter,
 )
-from ..struct import Obo, Reference, Synonym, Term
+from ..struct import Obo, Reference, Synonym, Term, TypeDef, default_reference
 from ..utils.path import prefix_directory_join
 
 __all__ = [

--- a/src/pyobo/sources/icd11.py
+++ b/src/pyobo/sources/icd11.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from tqdm.auto import tqdm
 
-from ..icd_utils import (
+from .icd_utils import (
     ICD11_TOP_LEVEL_URL,
     ICDError,
     get_child_identifiers,
@@ -51,6 +51,7 @@ def iterate_icd11() -> Iterable[Term]:
     version = res_json["releaseId"]
     mms_directory = prefix_directory_join(PREFIX, "mms", version=version)
     terms = list(iterate_icd11_helper(res_json, version))
+    # this takes a bit more than 2 hours
     for term in tqdm(terms, desc="Getting MMS", unit_scale=True):
         path = mms_directory.joinpath(term.identifier).with_suffix(".json")
         if path.exists():

--- a/src/pyobo/sources/icd_utils.py
+++ b/src/pyobo/sources/icd_utils.py
@@ -1,6 +1,6 @@
 """Utilities or interacting with the ICD API.
 
-Want to get your own API cliend ID and client secret?
+Want to get your own API client ID and client secret?
 
 1. Register at https://icdapihome.azurewebsites.net/icdapi/Account/Register
 2. Sell your soul to the American government
@@ -27,12 +27,23 @@ TOKEN_URL = "https://icdaccessmanagement.who.int/connect/token"  # noqa:S105
 ICD_BASE_URL = "https://id.who.int/icd"
 
 ICD11_TOP_LEVEL_URL = f"{ICD_BASE_URL}/entity"
+ICD_11_MMS_URL = f"{ICD_BASE_URL}/release/11/2024-01/mms"
 ICD10_TOP_LEVEL_URL = f"{ICD_BASE_URL}/release/10/2016"
 
 
 def get_icd(url: str) -> requests.Response:
     """Get an ICD API endpoint."""
     return requests.get(url, headers=get_icd_api_headers())
+
+
+def get_icd_11(identifier: str):
+    """Get from ICD11."""
+    return _get_entity(ICD11_TOP_LEVEL_URL, identifier)
+
+
+def get_icd_11_mms(identifier: str):
+    """Get from ICD11 MMS."""
+    return _get_entity(ICD_11_MMS_URL, identifier)
 
 
 def _get_entity(endpoint: str, identifier: str):

--- a/src/pyobo/sources/icd_utils.py
+++ b/src/pyobo/sources/icd_utils.py
@@ -46,11 +46,29 @@ def get_icd_11_mms(identifier: str):
     return _get_entity(ICD_11_MMS_URL, identifier)
 
 
+class ICDError(ValueError):
+    """An error on getting data from ICD."""
+
+    def __init__(self, identifier: str, url: str, text: str) -> None:
+        """Instantiate an ICD error."""
+        self.identifier = identifier
+        self.url = url
+        self.text = text
+
+    def __str__(self) -> str:
+        """Make a string for the ICD error."""
+        return f"[icd11:{self.identifier}] Error getting {self.url} - {self.text}. Try {ICD11_TOP_LEVEL_URL}/{self.identifier}"
+
+
 def _get_entity(endpoint: str, identifier: str):
     url = f"{endpoint}/{identifier}"
     # tqdm.write(f'query {identifier} at {url}')
     res = get_icd(url)
-    return res.json()
+    try:
+        rv = res.json()
+    except OSError:
+        raise ICDError(identifier, url, res.text) from None
+    return rv
 
 
 def get_child_identifiers(endpoint: str, res_json: Mapping[str, Any]) -> list[str]:


### PR DESCRIPTION
This PR adds ICD11 MMS codes as ad-hoc properties. Later, it can create proper mappings once a prefix is decided for the codes.

Note that not all ICD11 identifiers have an MMS code

Here's an example from the top of the written OBO:

```
format-version: 1.4
auto-generated-by: PyOBO v0.12.0-dev-b06b9d0d on 2025-01-09T14:51:39.588002
idspace: dcterms http://purl.org/dc/terms/ "Dublin Core Metadata Initiative Terms"
idspace: skos http://www.w3.org/2004/02/skos/core# "Simple Knowledge Organization System"
ontology: icd11
property_value: dcterms:title "International Classification of Diseases\, 11th Revision" xsd:string
property_value: dcterms:license "CC-BY-ND-3.0-IGO" xsd:string
property_value: dcterms:description "Diagnostic tool for epidemiology\\\, health management and clinical purposes\\\, maintained by the World Health Organization \\\(WHO\\\). It provides a system of diagnostic 
codes for classifying diseases\\\, including nuanced classifications of a wide variety of signs\\\, symptoms\\\, abnormal findings\\\, complaints\\\, social circumstances\\\, and external causes of injury or di
sease." xsd:string

[Typedef]
id: icd_mms_code
is_metadata_tag: true

[Term]
id: icd11:1000004774
name: Congenital coxa valga
def: "A condition caused by failure of the hip joint to correctly develop during the antenatal period. This condition is characterised by an increase in the femoral neck-shaft angle." []
property_value: icd_mms_code "LB74.4" xsd:string
is_a: icd11:1387302440

[Term]
id: icd11:1000034337
name: Mercaptamine
property_value: icd_mms_code "XM85F8" xsd:string
is_a: icd11:1729060495
```
