### PR TITLE
Generate SSSOM for ICD11 to ICD11 codes

### DIFF
--- a/src/pyobo/sources/icd11.py
+++ b/src/pyobo/sources/icd11.py
@@ -77,7 +77,7 @@ def iterate_icd11() -> Iterable[Term]:
                 path.write_text(json.dumps(mms_data))
 
         if code := mms_data.get("code"):
-            term.append_xref(Reference(prefix=CODE_PREFIX, identifier=code))
+            term.append_exact_match(Reference(prefix=CODE_PREFIX, identifier=code))
 
         yield term
 

--- a/src/pyobo/sources/icd11.py
+++ b/src/pyobo/sources/icd11.py
@@ -8,6 +8,7 @@ import logging
 from collections.abc import Iterable, Mapping
 from typing import Any
 
+import bioregistry
 from tqdm.auto import tqdm
 
 from .icd_utils import (
@@ -28,8 +29,17 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 PREFIX = "icd11"
+CODE_PREFIX = "icd11.code"
 
 CODE_PROP = TypeDef(reference=default_reference(PREFIX, "icd_mms_code"), is_metadata_tag=True)
+
+# This hacks a non-sanctioned prefix into the bioregistry
+# for demonstration purposes. Do not merge with this!
+bioregistry.manager.synonyms[CODE_PREFIX] = CODE_PREFIX
+bioregistry.manager.registry[CODE_PREFIX] = bioregistry.Resource(
+    prefix=CODE_PREFIX,
+    name="ICD11 Code",
+)
 
 
 class ICD11Getter(Obo):
@@ -67,8 +77,7 @@ def iterate_icd11() -> Iterable[Term]:
                 path.write_text(json.dumps(mms_data))
 
         if code := mms_data.get("code"):
-            # TODO decide on ICD code prefix, then append this as a mapping
-            term.annotate_literal(CODE_PROP, code)
+            term.append_xref(Reference(prefix=CODE_PREFIX, identifier=code))
 
         yield term
 

--- a/src/pyobo/sources/icd11.py
+++ b/src/pyobo/sources/icd11.py
@@ -13,10 +13,8 @@ from tqdm.auto import tqdm
 
 from .icd_utils import (
     ICD11_TOP_LEVEL_URL,
-    ICDError,
     get_child_identifiers,
     get_icd,
-    get_icd_11_mms,
     visiter,
 )
 from ..struct import Obo, Reference, Synonym, Term, TypeDef, default_reference
@@ -73,8 +71,7 @@ def iterate_icd11() -> Iterable[Term]:
                 # writing this isn't necessary since not all terms have MMS entries
                 # tqdm.write(str(e))
                 mms_data = {}
-            else:
-                path.write_text(json.dumps(mms_data))
+            path.write_text(json.dumps(mms_data))
 
         if code := mms_data.get("code"):
             term.append_exact_match(Reference(prefix=CODE_PREFIX, identifier=code))


### PR DESCRIPTION
cc @matentzn 

now, the ICD11 OBO output looks like:

```
format-version: 1.4
auto-generated-by: PyOBO v0.12.0-dev-86e8399e on 2025-01-09T17:15:55.878453
idspace: dcterms http://purl.org/dc/terms/ "Dublin Core Metadata Initiative Terms"
idspace: skos http://www.w3.org/2004/02/skos/core# "Simple Knowledge Organization System"
ontology: icd11
property_value: dcterms:title "International Classification of Diseases\, 11th Revision" xsd:string
property_value: dcterms:license "CC-BY-ND-3.0-IGO" xsd:string
property_value: dcterms:description "Diagnostic tool for epidemiology\\\, health management and clinical purposes\\\, maintained by the World Health Organization \\\(WHO\\\). It provides a system of diagnostic codes for classifying diseases\\\, including nuanced classifications of a wide variety of signs\\\, symptoms\\\, abnormal findings\\\, complaints\\\, social circumstances\\\, and external causes of injury or disease." xsd:string

[Typedef]
id: icd_mms_code
is_metadata_tag: true

[Term]
id: icd11:1000004774
name: Congenital coxa valga
def: "A condition caused by failure of the hip joint to correctly develop during the antenatal period. This condition is characterised by an increase in the femoral neck-shaft angle." []
xref: icd11.code:LB74.4
is_a: icd11:1387302440

...
```

Here's the [SSSOM file](https://gist.github.com/cthoyt/1c98175990228affee0435820426de9c/raw/896ba86a50296c33bc9e04d34c78e7d98a2aba36/icd11.sssom.tsv) corresponding to this demonstration (with the full list), generated from `pyobo lookup mappings icd11`
