### PR TITLE
Fix obonet caching

### DIFF
--- a/src/pyobo/getters.py
+++ b/src/pyobo/getters.py
@@ -111,10 +111,16 @@ def get_ontology(
         strict = False
 
     if not cache:
+        logger.debug("[%s] caching was turned off, so dont look for an obonet file", prefix)
         obonet_json_gz_path = None
     else:
         obonet_json_gz_path = prefix_directory_join(
             prefix, name=f"{prefix}.obonet.json.gz", ensure_exists=False, version=version
+        )
+        logger.debug(
+            "[%s] caching is turned on, so look for an obonet file at %s",
+            prefix,
+            obonet_json_gz_path,
         )
         if obonet_json_gz_path.exists() and not force:
             from .utils.cache import get_gzipped_graph
@@ -128,7 +134,6 @@ def get_ontology(
             )
         else:
             logger.debug("[%s] no obonet cache found at %s", prefix, obonet_json_gz_path)
-
 
     if has_nomenclature_plugin(prefix):
         obo = run_nomenclature_plugin(prefix, version=version)

--- a/src/pyobo/reader.py
+++ b/src/pyobo/reader.py
@@ -42,6 +42,7 @@ from .struct.reference import OBOLiteral, _parse_identifier
 from .struct.struct_utils import Annotation, Stanza
 from .struct.typedef import comment as has_comment
 from .struct.typedef import default_typedefs, has_ontology_root_term
+from .utils.cache import write_gzipped_graph
 from .utils.misc import STATIC_VERSION_REWRITES, cleanup_version
 
 __all__ = [
@@ -60,6 +61,7 @@ def from_obo_path(
     version: str | None,
     upgrade: bool = True,
     ignore_obsolete: bool = False,
+    _cache_path: Path | None = None,
 ) -> Obo:
     """Get the OBO graph from a path."""
     path = Path(path).expanduser().resolve()
@@ -86,6 +88,9 @@ def from_obo_path(
     if prefix:
         # Make sure the graph is named properly
         _clean_graph_ontology(graph, prefix)
+
+    if _cache_path:
+        write_gzipped_graph(path=_cache_path, graph=graph)
 
     # Convert to an Obo instance and return
     return from_obonet(graph, strict=strict, version=version, upgrade=upgrade)

--- a/src/pyobo/reader.py
+++ b/src/pyobo/reader.py
@@ -90,6 +90,7 @@ def from_obo_path(
         _clean_graph_ontology(graph, prefix)
 
     if _cache_path:
+        logger.info("[%s] writing obonet cache to %s", prefix, _cache_path)
         write_gzipped_graph(path=_cache_path, graph=graph)
 
     # Convert to an Obo instance and return

--- a/tests/test_obo_reader/test_get.py
+++ b/tests/test_obo_reader/test_get.py
@@ -270,7 +270,7 @@ class TestGet(unittest.TestCase):
     def setUp(self) -> None:
         """Set up the test with the mock ChEBI OBO file."""
         with chebi_patch:
-            self.ontology = get_ontology("chebi")
+            self.ontology = get_ontology("chebi", cache=False)
 
     def test_get_id_alts_mapping(self):
         """Make sure the alternative ids are mapped properly.


### PR DESCRIPTION
This PR makes sure that the parsed obonet file is actually cached. It also makes sure the tests don't pollute the active cache directory