### PR TITLE
Update column for species in GTDB source

### DIFF
--- a/src/pyobo/sources/gtdb.py
+++ b/src/pyobo/sources/gtdb.py
@@ -61,7 +61,7 @@ def iter_terms(version: str, force: bool = False) -> Iterable[Term]:
 
     ar_path = ensure_path(PREFIX, url=GTDB_AR_URL, version=version, force=force)
     bac_path = ensure_path(PREFIX, url=GTDB_BAC_URL, version=version, force=force)
-    columns = ["gtdb_taxonomy", "ncbi_taxid"]
+    columns = ["gtdb_taxonomy", "ncbi_species_taxid"]
     for path_name, path in [
         ("ar", ar_path),
         ("bac", bac_path),


### PR DESCRIPTION
## Summary

In the current implementation the species level GTDB terms have mappings to NCBI taxonomy IDs. This is done by retrieving the NCBI taxon IDs from the column ```ncbi_taxid``` in the source files:
```
#: AR stands for archea
GTDB_AR_URL = "https://data.gtdb.ecogenomic.org/releases/latest/ar53_metadata.tsv.gz"
#: BAC stands for bacteria
GTDB_BAC_URL = "https://data.gtdb.ecogenomic.org/releases/latest/bac120_metadata.tsv.gz"
```
I recently realized there is a specific column named ```ncbi_species_taxid``` and that the current ```ncbi_taxid``` doesnt always represent NCBI taxonomy at the species level. The correct column ```ncbi_species_taxid``` should be the one used for this purpose. 

I want to use ```ncbi_taxid``` for a different purpose but that will be part of a different PR/discussion. For now the goal of this PR is to fix the current implemententation to correctly map to ```ncbi_species_taxid``` as originally intended.