### PR TITLE
Improve IDSPACES for sources

### DIFF
--- a/src/pyobo/sources/bigg/bigg_compartment.py
+++ b/src/pyobo/sources/bigg/bigg_compartment.py
@@ -49,9 +49,6 @@ class BiGGCompartmentGetter(Obo):
 
     ontology = PREFIX
     bioversions_key = "bigg"
-    idspaces = {
-        PREFIX: "http://bigg.ucsd.edu/compartments/",
-    }
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""

--- a/src/pyobo/sources/bigg/bigg_metabolite.py
+++ b/src/pyobo/sources/bigg/bigg_metabolite.py
@@ -29,10 +29,6 @@ class BiGGMetaboliteGetter(Obo):
     ontology = PREFIX
     bioversions_key = "bigg"
     typedefs = [participates_in]
-    idspaces = {
-        PREFIX: "http://bigg.ucsd.edu/models/universal/metabolites/",
-        "bigg.model": "http://bigg.ucsd.edu/models/",
-    }
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""

--- a/src/pyobo/sources/bigg/bigg_model.py
+++ b/src/pyobo/sources/bigg/bigg_model.py
@@ -22,9 +22,6 @@ class BiGGModelGetter(Obo):
 
     ontology = PREFIX
     bioversions_key = "bigg"
-    idspaces = {
-        "bigg.model": "http://bigg.ucsd.edu/models/",
-    }
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""

--- a/src/pyobo/sources/bigg/bigg_reaction.py
+++ b/src/pyobo/sources/bigg/bigg_reaction.py
@@ -25,10 +25,6 @@ class BiGGReactionGetter(Obo):
     ontology = PREFIX
     bioversions_key = "bigg"
     typedefs = [participates_in, enabled_by]
-    idspaces = {
-        PREFIX: "http://bigg.ucsd.edu/models/universal/reactions/",
-        "bigg.model": "http://bigg.ucsd.edu/models/",
-    }
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""

--- a/src/pyobo/sources/credit.py
+++ b/src/pyobo/sources/credit.py
@@ -23,9 +23,6 @@ class CreditGetter(Obo):
 
     ontology = PREFIX
     static_version = "2022"
-    idspaces = {
-        PREFIX: "https://credit.niso.org/contributor-roles/",
-    }
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""

--- a/src/pyobo/sources/expasy.py
+++ b/src/pyobo/sources/expasy.py
@@ -53,12 +53,6 @@ class ExpasyGetter(Obo):
         Reference(prefix="eccode", identifier="6"),
         Reference(prefix="eccode", identifier="7"),
     ]
-    idspaces = {
-        "uniprot": "https://bioregistry.io/uniprot:",
-        "eccode": "https://bioregistry.io/eccode:",
-        "GO": "http://purl.obolibrary.org/obo/GO_",
-        "RO": "http://purl.obolibrary.org/obo/RO_",
-    }
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""

--- a/src/pyobo/sources/geonames/features.py
+++ b/src/pyobo/sources/geonames/features.py
@@ -18,12 +18,6 @@ class GeonamesFeatureGetter(Obo):
 
     ontology = PREFIX_FEATURE
     dynamic_version = True
-    idspaces = {
-        PREFIX_FEATURE: "https://www.geonames.org/recent-changes/featurecode/",
-        "dcterms": "http://purl.org/dc/terms/",
-        "orcid": "https://orcid.org/",
-        "NCBITaxon": "http://purl.obolibrary.org/obo/NCBITaxon_",
-    }
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""

--- a/src/pyobo/sources/geonames/geonames.py
+++ b/src/pyobo/sources/geonames/geonames.py
@@ -42,14 +42,6 @@ class GeonamesGetter(Obo):
     ontology = PREFIX
     dynamic_version = True
     typedefs = [part_of, CODE_TYPEDEF, has_part]
-    idspaces = {
-        PREFIX: "https://www.geonames.org/",
-        PREFIX_FEATURE: "https://www.geonames.org/recent-changes/featurecode/",
-        "BFO": "http://purl.obolibrary.org/obo/BFO_",
-        "ENVO": "http://purl.obolibrary.org/obo/ENVO_",
-        "NCBITaxon": "http://purl.obolibrary.org/obo/NCBITaxon_",
-        "orcid": "https://orcid.org/",
-    }
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""

--- a/src/pyobo/sources/gtdb.py
+++ b/src/pyobo/sources/gtdb.py
@@ -40,9 +40,6 @@ class GTDBGetter(Obo):
 
     ontology = bioversions_key = PREFIX
     typedefs = [has_taxonomy_rank]
-    idspaces = {
-        PREFIX: "https://gtdb.ecogenomic.org/tree?r=",
-    }
     root_terms = [
         Reference(prefix=PREFIX, identifier="d__Archea", name="Archea"),
         Reference(prefix=PREFIX, identifier="d__Bacteria", name="Bacteria"),

--- a/src/pyobo/sources/ncbi/ncbi_gc.py
+++ b/src/pyobo/sources/ncbi/ncbi_gc.py
@@ -68,11 +68,6 @@ class NCBIGCGetter(Obo):
     static_version = VERSION
     root_terms = [GC_ROOT]
     typedefs = [has_gc_code, has_contributor, see_also, comment, term_replaced_by]
-    idspaces = {
-        PREFIX: URI_PREFIX,
-        "orcid": "https://orcid.org/",
-        "dcterms": "http://purl.org/dc/terms/",
-    }
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""

--- a/src/pyobo/sources/nlm/nlm_catalog.py
+++ b/src/pyobo/sources/nlm/nlm_catalog.py
@@ -26,23 +26,6 @@ class NLMCatalogGetter(Obo):
     dynamic_version = True
     typedefs = [PUBLISHED_IN, has_end_date, has_start_date, exact_match]
     root_terms = [JOURNAL_TERM.reference, PUBLISHER_TERM.reference]
-    idspaces = {
-        PREFIX_CATALOG: "https://www.ncbi.nlm.nih.gov/nlmcatalog/",
-        PREFIX_PUBLISHER: "https://bioregistry.io/nlm.publisher:",
-        "sio": "http://semanticscience.org/resource/SIO_",
-        "schema": "http://schema.org/",
-        "biolink": "https://w3id.org/biolink/vocab/",
-        "MI": "http://purl.obolibrary.org/obo/MI_",
-        "IAO": "http://purl.obolibrary.org/obo/IAO_",
-        "bibo": "http://purl.org/ontology/bibo/",
-        "FBcv": "http://purl.obolibrary.org/obo/FBcv_",
-        "issn": "https://portal.issn.org/resource/ISSN/",
-        "skos": "http://www.w3.org/2004/02/skos/core#",
-        "uniprot.core": "http://purl.uniprot.org/core/",
-        "dcat": "http://www.w3.org/ns/dcat#",
-        "orcid": "https://orcid.org/",
-        "NCBITaxon": "http://purl.obolibrary.org/obo/NCBITaxon_",
-    }
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over journal terms for NLM Catalog."""

--- a/src/pyobo/sources/nlm/nlm_catalog.py
+++ b/src/pyobo/sources/nlm/nlm_catalog.py
@@ -5,7 +5,6 @@ from collections.abc import Iterable
 from pyobo.sources.nlm.utils import (
     JOURNAL_TERM,
     PREFIX_CATALOG,
-    PREFIX_PUBLISHER,
     PUBLISHED_IN,
     PUBLISHER_TERM,
     get_journals,

--- a/src/pyobo/sources/nlm/nlm_publisher.py
+++ b/src/pyobo/sources/nlm/nlm_publisher.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Iterable
 
-from pyobo.sources.nlm.utils import PREFIX_CATALOG, PREFIX_PUBLISHER, PUBLISHER_TERM, get_publishers
+from pyobo.sources.nlm.utils import PREFIX_PUBLISHER, PUBLISHER_TERM, get_publishers
 from pyobo.struct import CHARLIE_TERM, HUMAN_TERM, Obo, Term
 
 __all__ = [

--- a/src/pyobo/sources/nlm/nlm_publisher.py
+++ b/src/pyobo/sources/nlm/nlm_publisher.py
@@ -16,22 +16,6 @@ class NLMPublisherGetter(Obo):
     bioversions_key = ontology = PREFIX_PUBLISHER
     dynamic_version = True
     root_terms = [PUBLISHER_TERM.reference]
-    idspaces = {
-        PREFIX_CATALOG: "https://www.ncbi.nlm.nih.gov/nlmcatalog/",
-        PREFIX_PUBLISHER: "https://bioregistry.io/nlm.publisher:",
-        "sio": "http://semanticscience.org/resource/SIO_",
-        "schema": "http://schema.org/",
-        "biolink": "https://w3id.org/biolink/vocab/",
-        "MI": "http://purl.obolibrary.org/obo/MI_",
-        "IAO": "http://purl.obolibrary.org/obo/IAO_",
-        "bibo": "http://purl.org/ontology/bibo/",
-        "FBcv": "http://purl.obolibrary.org/obo/FBcv_",
-        "issn": "https://portal.issn.org/resource/ISSN/",
-        "skos": "http://www.w3.org/2004/02/skos/core#",
-        "uniprot.core": "http://purl.uniprot.org/core/",
-        "orcid": "https://orcid.org/",
-        "NCBITaxon": "http://purl.obolibrary.org/obo/NCBITaxon_",
-    }
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over gene terms for NLM Catalog."""

--- a/src/pyobo/sources/ror.py
+++ b/src/pyobo/sources/ror.py
@@ -56,26 +56,6 @@ class RORGetter(Obo):
     typedefs = [has_homepage, *RMAP.values()]
     synonym_typedefs = [acronym]
     root_terms = [CITY_CLASS, ORG_CLASS]
-    idspaces = {
-        "ror": "https://ror.org/",
-        "geonames": "https://www.geonames.org/",
-        "ENVO": "http://purl.obolibrary.org/obo/ENVO_",
-        "BFO": "http://purl.obolibrary.org/obo/BFO_",
-        "RO": "http://purl.obolibrary.org/obo/RO_",
-        "IAO": "http://purl.obolibrary.org/obo/IAO_",
-        "OBI": "http://purl.obolibrary.org/obo/OBI_",
-        "OMO": "http://purl.obolibrary.org/obo/OMO_",
-        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-        "foaf": "http://xmlns.com/foaf/0.1/",
-        "isni": "http://www.isni.org/isni/",
-        "funderregistry": "http://data.crossref.org/fundingdata/funder/",
-        "wikidata": "http://www.wikidata.org/entity/",
-        "grid": "https://www.grid.ac/institutes/",
-        "hesa": "https://bioregistry.io/hesa:",
-        "ucas": "https://bioregistry.io/ucas:",
-        "ukprn": "https://bioregistry.io/ukprn:",
-        "cnrs": "https://bioregistry.io/cnrs:",
-    }
 
     def __post_init__(self):
         self.data_version, _url, _path = _get_info()

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -652,7 +652,12 @@ class Obo:
         """Get a prefix map including all prefixes used in the ontology."""
         rv = {}
         for prefix in sorted(self._get_prefixes(), key=str.casefold):
-            uri_prefix = bioregistry.get_uri_prefix(prefix)
+            resource = bioregistry.get_resource(prefix)
+            if resource is None:
+                raise ValueError
+            uri_prefix = resource.get_rdf_uri_prefix()
+            if uri_prefix is None:
+                uri_prefix = resource.get_uri_prefix()
             if uri_prefix is None:
                 # This allows us an escape hatch, since some
                 # prefixes don't have an associated URI prefix


### PR DESCRIPTION
Closes #333 by doing the following:

1. Remove all manual IDSPACE definitions from PyOBO sources. This means that the Bioregistry will be used to look up all URI prefixes. This functionality was added in #291
2. Update the way URI prefixes are looked up from the Bioregistry to use the RDF URI prefix as a higher priority before anything else




This means we can upstream all discussions about the expansions into the Bioregistry repo