### PR TITLE
Handle annotation objects with superfluous datatypes

### DIFF
--- a/src/pyobo/reader.py
+++ b/src/pyobo/reader.py
@@ -1198,7 +1198,7 @@ def _handle_prop(
                 return Annotation(prop_reference, OBOLiteral.string(value))
     else:
         if datatype:
-            logger.warning(
+            logger.debug(
                 "[%s] throwing away datatype since no quotes were used: %s", node.curie, value_type
             )
 

--- a/src/pyobo/reader.py
+++ b/src/pyobo/reader.py
@@ -1161,6 +1161,9 @@ def _handle_prop(
     # if the value doesn't start with a quote, we're going to
     # assume that it's a reference
     if not value_type.startswith('"'):
+        # TODO check if there's a space in here. if so, assume that it splits between
+        #  a datatype definition. if so, check that it's xsd:string or xsd:anyURI,
+        #  otherwise error
         obj_reference = _parse_identifier(
             value_type, strict=strict, ontology_prefix=ontology_prefix, node=node
         )

--- a/tests/test_obo_reader/test_reader.py
+++ b/tests/test_obo_reader/test_reader.py
@@ -17,6 +17,7 @@ from pyobo.struct.typedef import (
     has_dbxref,
     is_conjugate_base_of,
     see_also,
+    definition_source,
     term_replaced_by,
 )
 from pyobo.struct.vocabulary import CHARLIE
@@ -1000,6 +1001,22 @@ class TestReaderTerm(unittest.TestCase):
         self.assertEqual(1, len(list(term.properties)))
         self.assertIn(see_also.reference, term.properties)
         self.assertEqual("hgnc:1234", term.get_property(see_also))
+
+    def test_12_property_object_with_string_dtype(self) -> None:
+        """Test parsing a property with a literal object that has a string dtype."""
+        # the dtype really shouldn't be here, so we have to special case it
+        ontology = from_str("""\
+            ontology: ro
+
+            [Term]
+            id: RO:0002160
+            property_value: IAO:0000119 PMID:17921072 xsd:string
+        """)
+        term = self.get_only_term(ontology)
+        self.assertEqual(1, len(list(term.properties)))
+        xx = term.get_property_objects(definition_source)
+        self.assertEqual(1, len(xx))
+        self.assertEqual(Reference(prefix="pubmed", identifier="17921072"), xx[0])
 
     def test_13_parent(self) -> None:
         """Test parsing out a parent."""

--- a/tests/test_obo_reader/test_reader.py
+++ b/tests/test_obo_reader/test_reader.py
@@ -12,12 +12,12 @@ from pyobo.struct.struct import abbreviation
 from pyobo.struct.struct_utils import Annotation
 from pyobo.struct.typedef import (
     comment,
+    definition_source,
     derives_from,
     exact_match,
     has_dbxref,
     is_conjugate_base_of,
     see_also,
-    definition_source,
     term_replaced_by,
 )
 from pyobo.struct.vocabulary import CHARLIE


### PR DESCRIPTION
This enables sitauations like the following, where quotes are omitted, but a trailing (superfluous) datatype is set.

```
ontology: ro

[Term]
id: RO:0002160
property_value: IAO:0000119 PMID:17921072 xsd:string
```

This is relevant for `ceph` (and many others)

```
ceph - Cephalopod Ontology
2025-02-05 23:29:27 WARNING  [obo:ceph - dc:source] could not parse object: http://www.sil.si.edu/smithsoniancontributions/zoology/pdf_hi/sctz-0513.pdf xsd:anyURI                                                        
2025-02-05 23:29:27 WARNING  [ro:0002160 - iao:0000119] could not parse object: PMID:17921072 xsd:string                                                                                                                  
2025-02-05 23:29:27 WARNING  [ro:0002160 - iao:0000119] could not parse object: PMID:20973947 xsd:string                                                                                                                  
2025-02-05 23:29:27 WARNING  [ro:0002160] failed to parse definition quotes: no closing quote found in `x only in taxon y if and only if x is in taxon y, and there is no other organism z such that y`                   
2025-02-05 23:29:27 WARNING  [ro:0002215 - iao:0000119] could not parse object: PMID:20123131 xsd:string                                                                                                                  
2025-02-05 23:29:27 WARNING  [ro:0002215 - iao:0000119] could not parse object: PMID:21208450 xsd:string                                                                                                                  
2025-02-05 23:29:27 WARNING  [bfo:0000050 - dc:source] could not parse object: http://www.obofoundry.org/ro/#OBO_REL:part_of xsd:string                                                                                   
2025-02-05 23:29:27 WARNING  [ceph:0000023 - rdfs:seeAlso] could not parse object: http://en.wikipedia.org/wiki/Cephalopod_beak xsd:anyURI                                                                                
2025-02-05 23:29:27 WARNING  [ceph:0000032 - rdfs:seeAlso] could not parse object: http://en.wikipedia.org/wiki/Branchial_heart xsd:string                                                                                
2025-02-05 23:29:27 WARNING  [ceph:0000116 - rdfs:seeAlso] could not parse object: http://en.wikipedia.org/wiki/Siphon_%28mollusc%29 xsd:anyURI                                                                           
2025-02-05 23:29:27 WARNING  [ceph:0000118 - rdfs:seeAlso] could not parse object: http://en.wikipedia.org/wiki/Funnel%E2%80%93mantle_locking_apparatus xsd:string                                                        
2025-02-05 23:29:27 WARNING  [ceph:0000175 - rdfs:seeAlso] could not parse object: Nidamental:gland                                                                                                                       
2025-02-05 23:29:27 WARNING  [ceph:0000232 - rdfs:seeAlso] could not parse object: http://en.wikipedia.org/wiki/Siphuncle xsd:anyURI                                                                                      
2025-02-05 23:29:27 WARNING  [ceph:0000309 - rdfs:seeAlso] could not parse object: http://en.wikipedia.org/wiki/Cephalopod_size xsd:anyURI                                                                                
2025-02-05 23:29:27 WARNING  [ceph:0001054 - debio:0000023] could not parse object: http://purl.obolibrary.org/obo/NCBITaxon_subclass xsd:string                                                                          
2025-02-05 23:29:27 WARNING  [ceph:0001055 - debio:0000023] could not parse object: http://purl.obolibrary.org/obo/NCBITaxon_order xsd:string 
```