### PR TITLE
Refactor `pyobo.Reference`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
     "class_resolver",
     "psycopg2-binary",
     "pydantic>=2.0",
-    "curies>=0.10.2",
+    "curies>=0.10.3",
     "python-dateutil",
     # Resource Downloaders
     "drugbank_downloader",

--- a/src/pyobo/api/edges.py
+++ b/src/pyobo/api/edges.py
@@ -2,6 +2,7 @@
 
 import networkx as nx
 import pandas as pd
+from curies import Reference
 from tqdm import tqdm
 from typing_extensions import Unpack
 
@@ -14,7 +15,6 @@ from pyobo.constants import (
     check_should_use_tqdm,
 )
 from pyobo.getters import get_ontology
-from pyobo.struct import Reference
 from pyobo.utils.path import prefix_cache_join
 
 from ..utils.cache import cached_df

--- a/src/pyobo/api/properties.py
+++ b/src/pyobo/api/properties.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import Mapping
 
 import pandas as pd
+from curies import Reference
 from tqdm import tqdm
 from typing_extensions import Unpack
 
@@ -16,7 +17,6 @@ from ..constants import (
 )
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
-from ..struct.reference import Reference
 from ..struct.struct_utils import OBOLiteral, ReferenceHint, _ensure_ref
 from ..utils.cache import cached_df
 from ..utils.io import multidict

--- a/src/pyobo/sources/pharmgkb/utils.py
+++ b/src/pyobo/sources/pharmgkb/utils.py
@@ -4,10 +4,10 @@ from collections.abc import Iterable
 from pathlib import Path
 
 import pandas as pd
+from curies import Reference
 from pystow.utils import read_zipfile_csv
 from tqdm import tqdm
 
-from pyobo import Reference
 from pyobo.utils.path import ensure_path
 
 __all__ = [

--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -217,8 +217,14 @@ def default_reference(prefix: str, identifier: str, name: str | None = None) -> 
     return Reference(prefix="obo", identifier=f"{prefix}#{identifier}", name=name)
 
 
+def _get_ref_name(reference: curies.Reference | Referenced) -> str | None:
+    if isinstance(reference, curies.NamableReference | Referenced):
+        return reference.name
+    return None
+
+
 def reference_escape(
-    reference: curies.Reference | Reference | Referenced,
+    reference: curies.Reference | Referenced,
     *,
     ontology_prefix: str,
     add_name_comment: bool = False,
@@ -227,8 +233,8 @@ def reference_escape(
     if reference.prefix == "obo" and reference.identifier.startswith(f"{ontology_prefix}#"):
         return reference.identifier.removeprefix(f"{ontology_prefix}#")
     rv = get_preferred_curie(reference)
-    if add_name_comment and isinstance(reference, curies.NamableReference) and reference.name:
-        rv += f" ! {reference.name}"
+    if add_name_comment and (name := _get_ref_name(reference)):
+        rv += f" ! {name}"
     return rv
 
 

--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -15,7 +15,7 @@ import dateutil.parser
 import pytz
 from curies import ReferenceTuple
 from curies.api import ExpansionError
-from pydantic import field_validator, model_validator
+from pydantic import model_validator
 
 from .utils import obo_escape
 from ..constants import GLOBAL_CHECK_IDS
@@ -36,14 +36,6 @@ logger = logging.getLogger(__name__)
 
 class Reference(curies.NamableReference):
     """A namespace, identifier, and label."""
-
-    @field_validator("prefix")
-    def validate_prefix(cls, v):  # noqa
-        """Validate the prefix for this reference."""
-        norm_prefix = bioregistry.normalize_prefix(v)
-        if norm_prefix is None:
-            raise ExpansionError(f"Unknown prefix: {v}")
-        return norm_prefix
 
     @property
     def preferred_prefix(self) -> str:

--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -15,7 +15,7 @@ import dateutil.parser
 import pytz
 from curies import ReferenceTuple
 from curies.api import ExpansionError
-from pydantic import model_validator
+from pydantic import ValidationError, model_validator
 
 from .utils import obo_escape
 from ..constants import GLOBAL_CHECK_IDS
@@ -118,7 +118,7 @@ class Reference(curies.NamableReference):
             name = get_name(prefix, identifier)
         try:
             rv = cls.model_validate({"prefix": prefix, "identifier": identifier, "name": name})
-        except ValueError:
+        except ValidationError:
             if strict:
                 raise
             return None

--- a/tests/test_struct/test_reference.py
+++ b/tests/test_struct/test_reference.py
@@ -1,0 +1,19 @@
+"""Test references."""
+
+import unittest
+
+from pyobo import Reference
+
+
+class TestReference(unittest.TestCase):
+    """Test references."""
+
+    def test_reference_with_spaces(self) -> None:
+        """Test reference with spaces can't be validated as a CURIE."""
+        with self.assertRaises(ValueError):
+            Reference.from_curie("go:0123455677  asga")
+
+    def test_superclass_validate(self) -> None:
+        """Test that the from_curie function that's inherited returns the child class."""
+        x = Reference.from_curie("go:1234567")
+        self.assertIsInstance(x, Reference)

--- a/tests/test_struct/test_reference.py
+++ b/tests/test_struct/test_reference.py
@@ -2,6 +2,8 @@
 
 import unittest
 
+from pydantic import ValidationError
+
 from pyobo import Reference
 
 
@@ -12,6 +14,11 @@ class TestReference(unittest.TestCase):
         """Test reference with spaces can't be validated as a CURIE."""
         with self.assertRaises(ValueError):
             Reference.from_curie("go:0123455677  asga")
+
+    def test_validate_prefix(self) -> None:
+        """Test reference with spaces can't be validated as a CURIE."""
+        with self.assertRaises(ValidationError):
+            Reference.from_curie("nope:nope")
 
     def test_superclass_validate(self) -> None:
         """Test that the from_curie function that's inherited returns the child class."""

--- a/tox.ini
+++ b/tox.ini
@@ -131,7 +131,9 @@ deps =
     types-python-dateutil
     types-redis
     types-pytz
-commands = mypy --install-types --non-interactive --ignore-missing-imports src/
+commands =
+    mypy --ignore-missing-imports src/
+    mypy --ignore-missing-imports --strict tests/test_struct/test_reference.py
 # TODO make strict
 
 [testenv:doc8]


### PR DESCRIPTION
- Reuse new base class from `curies.NamableReference`
- Remove redundant prefix validation