### PR TITLE
Improve error handling in reader

### DIFF
--- a/src/pyobo/reader.py
+++ b/src/pyobo/reader.py
@@ -556,7 +556,9 @@ class MacroConfig:
             try:
                 gd_prefix, gd_predicate, gd_target = line.split()
             except ValueError:
-                tqdm.write(f"[{ontology_prefix}] failed to parse treat-xrefs-as-genus-differentia: {line}")
+                tqdm.write(
+                    f"[{ontology_prefix}] failed to parse treat-xrefs-as-genus-differentia: {line}"
+                )
                 continue
 
             gd_prefix_norm = bioregistry.normalize_prefix(gd_prefix)
@@ -1181,7 +1183,9 @@ def _handle_prop(
         try:
             obo_literal = OBOLiteral.datetime(value)
         except ValueError:
-            logger.warning('[%s - %s] could not parse date: %s', node.curie, prop_reference.curie, value)
+            logger.warning(
+                "[%s - %s] could not parse date: %s", node.curie, prop_reference.curie, value
+            )
             return None
         else:
             return Annotation(prop_reference, obo_literal)

--- a/src/pyobo/reader.py
+++ b/src/pyobo/reader.py
@@ -553,7 +553,12 @@ class MacroConfig:
 
         self.treat_xrefs_as_genus_differentia: dict[str, tuple[Reference, Reference]] = {}
         for line in data.get("treat-xrefs-as-genus-differentia", []):
-            gd_prefix, gd_predicate, gd_target = line.split()
+            try:
+                gd_prefix, gd_predicate, gd_target = line.split()
+            except ValueError:
+                tqdm.write(f"[{ontology_prefix}] failed to parse treat-xrefs-as-genus-differentia: {line}")
+                continue
+
             gd_prefix_norm = bioregistry.normalize_prefix(gd_prefix)
             if gd_prefix_norm is None:
                 continue
@@ -1173,7 +1178,13 @@ def _handle_prop(
     # first, special case datetimes. Whether it's quoted or not,
     # we always deal with this first
     if datatype and datatype.curie == "xsd:dateTime":
-        return Annotation(prop_reference, OBOLiteral.datetime(value))
+        try:
+            obo_literal = OBOLiteral.datetime(value)
+        except ValueError:
+            logger.warning('[%s - %s] could not parse date: %s', node.curie, prop_reference.curie, value)
+            return None
+        else:
+            return Annotation(prop_reference, obo_literal)
 
     if datatype and datatype.curie == "xsd:anyURI":
         obj_reference = Reference.from_curie_or_uri(value)

--- a/src/pyobo/reader.py
+++ b/src/pyobo/reader.py
@@ -556,6 +556,8 @@ class MacroConfig:
             try:
                 gd_prefix, gd_predicate, gd_target = line.split()
             except ValueError:
+                # this happens in `plana`, where there's an incorrectly written
+                # line `CARO part_of NCBITaxon:79327; CL part_of NCBITaxon:79327`
                 tqdm.write(
                     f"[{ontology_prefix}] failed to parse treat-xrefs-as-genus-differentia: {line}"
                 )
@@ -578,7 +580,14 @@ class MacroConfig:
 
         self.treat_xrefs_as_relationship: dict[str, Reference] = {}
         for line in data.get("treat-xrefs-as-relationship", []):
-            gd_prefix, gd_predicate = line.split()
+            try:
+                gd_prefix, gd_predicate = line.split()
+            except ValueError:
+                tqdm.write(
+                    f"[{ontology_prefix}] failed to parse treat-xrefs-as-relationship: {line}"
+                )
+                continue
+
             gd_prefix_norm = bioregistry.normalize_prefix(gd_prefix)
             if gd_prefix_norm is None:
                 continue

--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -281,12 +281,15 @@ def _parse_identifier(
         return Reference.from_curie_or_uri(
             s, ontology_prefix=ontology_prefix, name=name, strict=strict, node=node
         )
+    if upgrade:
+        if xx := bioontologies.upgrade.upgrade(s):
+            return Reference(prefix=xx.prefix, identifier=xx.identifier, name=name)
+        if yy := _ground_relation(s):
+            return Reference(prefix=yy.prefix, identifier=yy.identifier, name=name)
+
+    # in `geno`, there are some string properties that are written
+    # without quotes where this check is important
     try:
-        if upgrade:
-            if xx := bioontologies.upgrade.upgrade(s):
-                return Reference(prefix=xx.prefix, identifier=xx.identifier, name=name)
-            if yy := _ground_relation(s):
-                return Reference(prefix=yy.prefix, identifier=yy.identifier, name=name)
         return default_reference(ontology_prefix, s, name=name)
     except ValidationError:
         return None


### PR DESCRIPTION
Improve error handling in 3 cases:

1. Handle incorrect `treat-xrefs-as-genus-differentia` lines, which happens in `plana`
2. Handle unparsable dates, which happens in `nomen`
3. Handle validation of ill-defined default values, which happens in `geno`
4. Additional typing cleanup for OBO Literal construction