### PR TITLE
Switch to SSSLM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
     "bioversions>=0.7.0",
     "bioregistry>=0.11.33",
     "bioontologies>=0.5.2",
-    "ssslm",
+    "ssslm>=0.0.9",
     "zenodo-client>=0.3.6",
     "class_resolver",
     "psycopg2-binary",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
     "bioversions>=0.7.0",
     "bioregistry>=0.11.33",
     "bioontologies>=0.5.2",
-    "biosynonyms>=0.3.3",
+    "ssslm",
     "zenodo-client>=0.3.6",
     "class_resolver",
     "psycopg2-binary",
@@ -103,14 +103,12 @@ docs = [
     "sphinx-click", 
     "sphinx_automodapi",
 ]
-grounding = [
-    "gilda",
+gilda = [
+    "ssslm[gilda]",
 ]
-
-[tool.uv.sources]
-# this fork of gilda doesn't install any of
-# the unneeded requirements for grounding
-gilda = { git = "https://github.com/cthoyt/gilda", branch = "slim" }
+gilda-slim = [
+    "ssslm[gilda-slim]",
+]
 
 # See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls
 # and also https://packaging.python.org/en/latest/specifications/well-known-project-urls/

--- a/src/pyobo/__init__.py
+++ b/src/pyobo/__init__.py
@@ -145,7 +145,6 @@ __all__ = [
     "is_descendent",
     "iter_nomenclature_plugins",
     "iter_xref_plugins",
-    "literal_mappings_to_gilda",
     "parse_results_from_obo",
     "run_nomenclature_plugin",
     "run_xref_plugin",

--- a/src/pyobo/__init__.py
+++ b/src/pyobo/__init__.py
@@ -55,7 +55,7 @@ from .api import (
     is_descendent,
 )
 from .getters import get_ontology
-from .ner import get_grounder, literal_mappings_to_gilda
+from .ner import get_grounder
 from .ner.normalizer import OboNormalizer, ground
 from .obographs import parse_results_from_obo
 from .plugins import (

--- a/src/pyobo/api/combine.py
+++ b/src/pyobo/api/combine.py
@@ -2,8 +2,8 @@
 
 from collections.abc import Sequence
 
-import biosynonyms
 import curies
+import ssslm
 from typing_extensions import Unpack
 
 from pyobo.api.hierarchy import get_descendants
@@ -22,7 +22,7 @@ def get_literal_mappings_subset(
     *,
     skip_obsolete: bool = False,
     **kwargs: Unpack[GetOntologyKwargs],
-) -> list[biosynonyms.LiteralMapping]:
+) -> list[ssslm.LiteralMapping]:
     """Get a subset of literal mappings under the given ancestors."""
     if isinstance(ancestors, curies.Reference):
         ancestors = [ancestors]

--- a/src/pyobo/api/names.py
+++ b/src/pyobo/api/names.py
@@ -8,9 +8,10 @@ from collections.abc import Callable, Mapping
 from functools import lru_cache
 from typing import Any, TypeVar
 
-import biosynonyms
 import pandas as pd
+import ssslm
 from curies import Reference, ReferenceTuple
+from ssslm import LiteralMapping
 from typing_extensions import Unpack
 
 from .alts import get_primary_identifier
@@ -257,10 +258,10 @@ def get_id_synonyms_mapping(
 
 def get_literal_mappings(
     prefix: str, *, skip_obsolete: bool = False, **kwargs: Unpack[GetOntologyKwargs]
-) -> list[biosynonyms.LiteralMapping]:
+) -> list[LiteralMapping]:
     """Get literal mappings."""
     df = get_literal_mappings_df(prefix=prefix, **kwargs)
-    rv = biosynonyms.df_to_literal_mappings(df)
+    rv = ssslm.df_to_literal_mappings(df)
     if skip_obsolete:
         obsoletes = get_obsolete(prefix, **kwargs)
         rv = [lm for lm in rv if lm.reference.identifier not in obsoletes]

--- a/src/pyobo/gilda_utils.py
+++ b/src/pyobo/gilda_utils.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import bioregistry
 import ssslm
-from ssslm import GildaGrounder
+from ssslm import GildaGrounder, literal_mappings_to_gilda
 from tqdm.auto import tqdm
 from typing_extensions import Unpack
 
@@ -20,7 +20,6 @@ from pyobo.api import (
     get_literal_mappings_subset,
 )
 from pyobo.constants import GetOntologyKwargs
-from pyobo.ner.api import literal_mappings_to_gilda
 from pyobo.struct.reference import Reference
 
 if TYPE_CHECKING:

--- a/src/pyobo/gilda_utils.py
+++ b/src/pyobo/gilda_utils.py
@@ -9,9 +9,10 @@ from typing import TYPE_CHECKING, Any, cast
 
 import bioregistry
 import ssslm
+from ssslm import GildaGrounder
 from tqdm.auto import tqdm
 from typing_extensions import Unpack
-from ssslm import GildaGrounder
+
 from pyobo.api import (
     get_id_name_mapping,
     get_ids,

--- a/src/pyobo/ner/__init__.py
+++ b/src/pyobo/ner/__init__.py
@@ -1,10 +1,8 @@
 """Wrapper around NER functionalities."""
 
-from .api import get_grounder, ground, ground_best, literal_mappings_to_gilda
+from .api import get_grounder, literal_mappings_to_gilda
 
 __all__ = [
     "get_grounder",
-    "ground",
-    "ground_best",
     "literal_mappings_to_gilda",
 ]

--- a/src/pyobo/ner/__init__.py
+++ b/src/pyobo/ner/__init__.py
@@ -1,8 +1,7 @@
 """Wrapper around NER functionalities."""
 
-from .api import get_grounder, literal_mappings_to_gilda
+from .api import get_grounder
 
 __all__ = [
     "get_grounder",
-    "literal_mappings_to_gilda",
 ]

--- a/src/pyobo/ner/api.py
+++ b/src/pyobo/ner/api.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from subprocess import CalledProcessError
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import ssslm
-from ssslm import LiteralMapping, Match
-from ssslm.ner import GildaGrounder
+from ssslm import LiteralMapping
 from tqdm import tqdm
 from typing_extensions import Unpack
 

--- a/src/pyobo/ner/api.py
+++ b/src/pyobo/ner/api.py
@@ -54,7 +54,6 @@ def get_grounder(
     return ssslm.make_grounder(literal_mappings, implementation="gilda", grounder_cls=grounder_cls)
 
 
-
 def _clean_prefix_versions(
     prefixes: str | Iterable[str],
     versions: None | str | Iterable[str | None] | dict[str, str] = None,

--- a/src/pyobo/ner/api.py
+++ b/src/pyobo/ner/api.py
@@ -6,76 +6,23 @@ from collections.abc import Iterable
 from subprocess import CalledProcessError
 from typing import TYPE_CHECKING, Any
 
-import biosynonyms
-from biosynonyms import LiteralMapping
-from pydantic import BaseModel
+import ssslm
+from ssslm import LiteralMapping, Match
+from ssslm.ner import GildaGrounder
 from tqdm import tqdm
 from typing_extensions import Unpack
 
-from pyobo.api import get_literal_mappings, get_species
+from pyobo.api import get_literal_mappings
 from pyobo.constants import GetOntologyKwargs, check_should_use_tqdm
 from pyobo.getters import NoBuildError
 from pyobo.struct.reference import Reference
-from pyobo.utils.io import multidict
 
 if TYPE_CHECKING:
     import gilda
 
 __all__ = [
-    "Match",
     "get_grounder",
-    "ground",
-    "ground_best",
 ]
-
-
-class Match(BaseModel):
-    """A wrapped match."""
-
-    reference: Reference
-    score: float
-
-    @classmethod
-    def from_scored_match(cls, scored_match: gilda.ScoredMatch) -> Match:
-        """Wrap a Gilda scored match."""
-        return cls(
-            reference=Reference(
-                prefix=scored_match.term.db,
-                identifier=scored_match.term.id,
-                name=scored_match.term.entry_name,
-            ),
-            score=scored_match.score,
-        )
-
-    @property
-    def prefix(self) -> str:
-        """Get the scored match's term's prefix."""
-        return self.reference.prefix
-
-    @property
-    def identifier(self) -> str:
-        """Get the scored match's term's identifier."""
-        return self.reference.identifier
-
-    @property
-    def name(self) -> str:
-        """Get the scored match's term's name."""
-        if not self.reference.name:
-            raise ValueError
-        return self.reference.name
-
-
-def ground(grounder: gilda.Grounder, text: str, **kwargs: Any) -> list[Match]:
-    """Repack scored matches to be easier to use."""
-    return [
-        Match.from_scored_match(scored_match) for scored_match in grounder.ground(text, **kwargs)
-    ]
-
-
-def ground_best(grounder: gilda.Grounder, text: str, **kwargs: Any) -> Match | None:
-    """Repack scored matches to be easier to use."""
-    sm = grounder.ground_best(text, **kwargs)
-    return Match.from_scored_match(sm) if sm else None
 
 
 def get_grounder(
@@ -85,9 +32,9 @@ def get_grounder(
     versions: None | str | Iterable[str | None] | dict[str, str] = None,
     skip_obsolete: bool = False,
     **kwargs: Unpack[GetOntologyKwargs],
-) -> gilda.Grounder:
+) -> ssslm.Grounder:
     """Get a grounder for the given prefix(es)."""
-    literal_mappings: list[biosynonyms.LiteralMapping] = []
+    literal_mappings: list[LiteralMapping] = []
     disable = not check_should_use_tqdm(kwargs)
     for prefix, kwargs["version"] in tqdm(
         _clean_prefix_versions(prefixes, versions=versions),
@@ -105,35 +52,19 @@ def get_grounder(
         except (NoBuildError, CalledProcessError):
             continue
 
-    return _build_grounder(literal_mappings, grounder_cls=grounder_cls)
+    return ssslm.make_grounder(literal_mappings, implementation="gilda", grounder_cls=grounder_cls)
 
 
 def literal_mappings_to_gilda(
-    literal_mappings: Iterable[biosynonyms.LiteralMapping],
+    literal_mappings: Iterable[LiteralMapping],
 ) -> Iterable[gilda.Term]:
     """Yield literal mappings as gilda terms.
 
-    This is different from the upstream biosynonyms impl
+    This is different from the upstream ssslm impl
     because it injects species.
     """
-    for lm in literal_mappings:
-        yield _lm_to_gilda(lm)
-
-
-def _build_grounder(
-    literal_mappings: list[LiteralMapping], grounder_cls: type[gilda.Grounder] | None = None
-):
-    from gilda.term import filter_out_duplicates
-
-    gilda_terms = filter_out_duplicates(literal_mappings_to_gilda(literal_mappings))
-    terms_dict = multidict((term.norm_text, term) for term in gilda_terms)
-
-    if grounder_cls is None:
-        from gilda import Grounder
-
-        return Grounder(terms_dict)
-    else:
-        return grounder_cls(terms_dict)
+    for _lm in literal_mappings:
+        yield _lm.to_gilda()
 
 
 def _clean_prefix_versions(
@@ -156,10 +87,6 @@ def _clean_prefix_versions(
         raise ValueError
 
     return list(zip(prefixes, versions, strict=True))
-
-
-def _lm_to_gilda(mapping: LiteralMapping) -> gilda.Term:
-    return mapping.to_gilda(organism=get_species(mapping.reference))
 
 
 def _ensure_list(reference: Reference | list[Reference]) -> list[Reference]:

--- a/src/pyobo/ner/api.py
+++ b/src/pyobo/ner/api.py
@@ -54,17 +54,6 @@ def get_grounder(
     return ssslm.make_grounder(literal_mappings, implementation="gilda", grounder_cls=grounder_cls)
 
 
-def literal_mappings_to_gilda(
-    literal_mappings: Iterable[LiteralMapping],
-) -> Iterable[gilda.Term]:
-    """Yield literal mappings as gilda terms.
-
-    This is different from the upstream ssslm impl
-    because it injects species.
-    """
-    for _lm in literal_mappings:
-        yield _lm.to_gilda()
-
 
 def _clean_prefix_versions(
     prefixes: str | Iterable[str],

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -17,11 +17,11 @@ from textwrap import dedent
 from typing import Annotated, Any, ClassVar, TextIO
 
 import bioregistry
-import biosynonyms
 import click
 import curies
 import networkx as nx
 import pandas as pd
+import ssslm
 from curies import ReferenceTuple
 from curies import vocabulary as _cv
 from more_click import force_option, verbose_option
@@ -1168,7 +1168,7 @@ class Obo:
             (
                 "literal_mappings",
                 self._literal_mappings_path,
-                biosynonyms.LiteralMappingTuple._fields,
+                ssslm.LiteralMappingTuple._fields,
                 self.iterate_literal_mapping_rows,
             ),
         ]
@@ -1855,7 +1855,7 @@ class Obo:
         """Get a mapping from identifiers to a list of sorted synonym strings."""
         return multidict(self.iterate_synonym_rows(use_tqdm=use_tqdm))
 
-    def get_literal_mappings(self) -> Iterable[biosynonyms.LiteralMapping]:
+    def get_literal_mappings(self) -> Iterable[ssslm.LiteralMapping]:
         """Get literal mappings in a standard data model."""
         stanzas: Iterable[Stanza] = itt.chain(self, self.typedefs or [])
         yield from itt.chain.from_iterable(
@@ -1892,14 +1892,14 @@ class Obo:
         for term, xref in self.iterate_xrefs(use_tqdm=use_tqdm):
             yield term.identifier, xref.prefix, xref.identifier
 
-    def iterate_literal_mapping_rows(self) -> Iterable[biosynonyms.LiteralMappingTuple]:
+    def iterate_literal_mapping_rows(self) -> Iterable[ssslm.LiteralMappingTuple]:
         """Iterate over literal mapping rows."""
         for synonym in self.get_literal_mappings():
             yield synonym._as_row()
 
     def get_literal_mappings_df(self) -> pd.DataFrame:
         """Get a literal mappings dataframe."""
-        return biosynonyms.literal_mappings_to_df(self.get_literal_mappings())
+        return ssslm.literal_mappings_to_df(self.get_literal_mappings())
 
     def iterate_mapping_rows(
         self, *, use_tqdm: bool = False

--- a/src/pyobo/struct/struct_utils.py
+++ b/src/pyobo/struct/struct_utils.py
@@ -10,12 +10,12 @@ from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 from typing import TYPE_CHECKING, Literal, NamedTuple, TypeAlias, overload
 
-import biosynonyms
 import curies
 from curies import ReferenceTuple
 from curies import vocabulary as _v
 from curies.vocabulary import SynonymScope
 from pydantic import BaseModel, ConfigDict
+from ssslm import LiteralMapping
 from typing_extensions import Self
 
 from . import vocabulary as v
@@ -183,7 +183,7 @@ class Stanza(HasReferencesMixin):
                 rv[prefix].update(references)
         return rv
 
-    def get_literal_mappings(self) -> list[biosynonyms.LiteralMapping]:
+    def get_literal_mappings(self) -> list[LiteralMapping]:
         """Get synonym objects for this term, including one for its label."""
         rv = [_convert_synoynym(self, synonym) for synonym in self.synonyms]
         if self.reference.name:
@@ -1012,8 +1012,8 @@ def _get_references_from_annotations(
     return dict(rv)
 
 
-def _get_stanza_name_synonym(stanza: Stanza) -> biosynonyms.LiteralMapping:
-    return biosynonyms.LiteralMapping(
+def _get_stanza_name_synonym(stanza: Stanza) -> LiteralMapping:
+    return LiteralMapping(
         text=stanza.reference.name,
         reference=stanza.reference.as_named_reference(),
         predicate=_v.has_label,
@@ -1026,7 +1026,7 @@ def _get_stanza_name_synonym(stanza: Stanza) -> biosynonyms.LiteralMapping:
     )
 
 
-def _convert_synoynym(stanza: Stanza, synonym: Synonym) -> biosynonyms.LiteralMapping:
+def _convert_synoynym(stanza: Stanza, synonym: Synonym) -> LiteralMapping:
     o = OBOLiteral.string(synonym.name, language=synonym.language)
     # TODO make this indexing reusable? similar code used for SSSOM export
     idx: dict[Reference, Reference | OBOLiteral] = {
@@ -1038,7 +1038,7 @@ def _convert_synoynym(stanza: Stanza, synonym: Synonym) -> biosynonyms.LiteralMa
     contributor = _safe_str(idx.get(v.has_contributor))
     date = _safe_str(idx.get(v.has_date))
 
-    return biosynonyms.LiteralMapping(
+    return LiteralMapping(
         text=synonym.name,
         language=synonym.language,
         reference=stanza.reference.as_named_reference(synonym.name),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,9 +6,9 @@ from contextlib import ExitStack
 from unittest import mock
 
 import bioregistry
-from biosynonyms import LiteralMapping
 from curies import Reference, ReferenceTuple
 from curies import vocabulary as _v
+from ssslm import LiteralMapping
 
 import pyobo
 from pyobo import Reference as PyOBOReference
@@ -20,7 +20,7 @@ from pyobo import (
     get_primary_identifier,
 )
 from pyobo.mocks import get_mock_id_alts_mapping, get_mock_id_name_mapping
-from pyobo.ner import get_grounder, ground_best
+from pyobo.ner import get_grounder
 from pyobo.struct import vocabulary as v
 from pyobo.struct.struct import Obo, Term, TypeDef, make_ad_hoc_ontology
 
@@ -217,10 +217,10 @@ class TestAltIds(unittest.TestCase):
 
             if importlib.util.find_spec("gilda"):
                 grounder = get_grounder(TEST_P1)
-                scored_match = ground_best(grounder, syn1)
-                self.assertIsNotNone(scored_match)
-                self.assertEqual(TEST_P1, scored_match.prefix)
-                self.assertEqual("1", scored_match.identifier)
+                match = grounder.get_best_match(syn1)
+                self.assertIsNotNone(match)
+                self.assertEqual(TEST_P1, match.prefix)
+                self.assertEqual("1", match.identifier)
 
             # Properties
 


### PR DESCRIPTION
As a follow-up to #345, this upstreams even more functionality for wrapping NER and storing literal mappings in a generic way to the SSSLM package