### PR TITLE
Add source annotation to EC

### DIFF
--- a/src/pyobo/sources/expasy.py
+++ b/src/pyobo/sources/expasy.py
@@ -7,15 +7,15 @@ from collections.abc import Iterable, Mapping
 from typing import Any
 
 from .utils import get_go_mapping
-from ..struct import Obo, Reference, Synonym, Term
-from ..struct.typedef import enables, has_member, term_replaced_by
+from ..struct import Annotation, Obo, OBOLiteral, Reference, Synonym, Term
+from ..struct.typedef import enables, has_member, has_source, term_replaced_by
 from ..utils.path import ensure_path
 
 __all__ = [
     "ExpasyGetter",
 ]
 
-PREFIX = "eccode"
+PREFIX = "ec"
 EXPASY_DATABASE_URL = "ftp://ftp.expasy.org/databases/enzyme/enzyme.dat"
 EXPASY_TREE_URL = "ftp://ftp.expasy.org/databases/enzyme/enzclass.txt"
 
@@ -43,7 +43,7 @@ class ExpasyGetter(Obo):
     """A getter for ExPASy Enzyme Classes."""
 
     bioversions_key = ontology = PREFIX
-    typedefs = [has_member, enables, term_replaced_by]
+    typedefs = [has_member, enables, term_replaced_by, has_source]
     root_terms = [
         Reference(prefix="eccode", identifier="1"),
         Reference(prefix="eccode", identifier="2"),
@@ -53,6 +53,7 @@ class ExpasyGetter(Obo):
         Reference(prefix="eccode", identifier="6"),
         Reference(prefix="eccode", identifier="7"),
     ]
+    property_values = [Annotation(has_source.reference, OBOLiteral.uri(EXPASY_DATABASE_URL))]
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""

--- a/src/pyobo/struct/__init__.py
+++ b/src/pyobo/struct/__init__.py
@@ -18,7 +18,7 @@ from .struct import (
     TypeDef,
     make_ad_hoc_ontology,
 )
-from .struct_utils import Stanza
+from .struct_utils import Annotation, Stanza
 from .typedef import (
     derives_from,
     enables,
@@ -45,6 +45,7 @@ __all__ = [
     "CHARLIE_TERM",
     "HUMAN_TERM",
     "PYOBO_INJECTED",
+    "Annotation",
     "OBOLiteral",
     "Obo",
     "Reference",

--- a/src/pyobo/struct/typedef.py
+++ b/src/pyobo/struct/typedef.py
@@ -280,6 +280,7 @@ mapping_has_confidence = TypeDef(
     reference=v.mapping_has_confidence, is_metadata_tag=True, range=v.xsd_float
 )
 has_contributor = TypeDef(reference=v.has_contributor, is_metadata_tag=True)
+has_source = TypeDef(reference=v.has_source, is_metadata_tag=True)
 
 has_start_date = TypeDef(
     reference=Reference(prefix="dcat", identifier="startDate", name="has start date"),


### PR DESCRIPTION
References #186

This PR adds a `dcterms:source` property to the EC export to make it clear that it comes from ExPASy and not enzyme-database.org. This is just historical - we can rewrite it to ingest the other one in a future update.

cc @cmungall 

```
format-version: 1.4
data-version: 2025-02-05
auto-generated-by: PyOBO v0.12.0-dev-1f6792ff on 2025-03-06T09:13:20.732577
idspace: EC https://www.ebi.ac.uk/intenz/query?cmd=SearchEC&ec= "Enzyme Nomenclature"
idspace: dcterms http://purl.org/dc/terms/ "Dublin Core Metadata Initiative Terms"
idspace: uniprot http://purl.uniprot.org/uniprot/ "UniProt Protein"
ontology: ec
property_value: dcterms:title "Enzyme Nomenclature" xsd:string
property_value: dcterms:license "CC-BY-4.0" xsd:string
property_value: dcterms:description "The Enzyme Nomenclature ..." xsd:string
property_value: IAO:0000700 EC:1
property_value: IAO:0000700 EC:2
property_value: IAO:0000700 EC:3
property_value: IAO:0000700 EC:4
property_value: IAO:0000700 EC:5
property_value: IAO:0000700 EC:6
property_value: IAO:0000700 EC:7
property_value: dcterms:source "ftp\://ftp.expasy.org/databases/enzyme/enzyme.dat" xsd:anyURI
```