### PR TITLE
Streamline cache path generation

### DIFF
--- a/src/pyobo/api/alts.py
+++ b/src/pyobo/api/alts.py
@@ -12,7 +12,7 @@ from ..constants import GetOntologyKwargs, check_should_cache, check_should_forc
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..utils.cache import cached_multidict
-from ..utils.path import prefix_cache_join
+from ..utils.path import CacheArtifact, get_cache_path
 
 __all__ = [
     "get_alts_to_id",
@@ -36,7 +36,7 @@ def get_id_to_alts(prefix: str, **kwargs: Unpack[GetOntologyKwargs]) -> Mapping[
         return {}
 
     version = get_version_from_kwargs(prefix, kwargs)
-    path = prefix_cache_join(prefix, name="alt_ids.tsv", version=version)
+    path = get_cache_path(prefix, CacheArtifact.alts, version=version)
 
     @cached_multidict(
         path=path,

--- a/src/pyobo/api/edges.py
+++ b/src/pyobo/api/edges.py
@@ -15,9 +15,9 @@ from pyobo.constants import (
     check_should_use_tqdm,
 )
 from pyobo.getters import get_ontology
-from pyobo.utils.path import prefix_cache_join
 
 from ..utils.cache import cached_df
+from ..utils.path import CacheArtifact, get_cache_path
 
 __all__ = [
     "get_edges",
@@ -40,7 +40,7 @@ def get_graph(prefix: str, **kwargs: Unpack[GetOntologyKwargs]) -> nx.DiGraph:
 def get_edges_df(prefix, **kwargs: Unpack[GetOntologyKwargs]) -> pd.DataFrame:
     """Get a dataframe of edges triples."""
     version = get_version_from_kwargs(prefix, kwargs)
-    path = prefix_cache_join(prefix, name="object_properties.tsv", version=version)
+    path = get_cache_path(prefix, CacheArtifact.edges, version=version)
 
     @cached_df(
         path=path, dtype=str, force=check_should_force(kwargs), cache=check_should_cache(kwargs)

--- a/src/pyobo/api/metadata.py
+++ b/src/pyobo/api/metadata.py
@@ -11,7 +11,7 @@ from ..constants import GetOntologyKwargs, check_should_force
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..utils.cache import cached_json
-from ..utils.path import prefix_cache_join
+from ..utils.path import CacheArtifact, get_cache_path
 
 __all__ = [
     "get_metadata",
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 def get_metadata(prefix: str, **kwargs: Unpack[GetOntologyKwargs]) -> dict[str, Any]:
     """Get metadata for the ontology."""
     version = get_version_from_kwargs(prefix, kwargs)
-    path = prefix_cache_join(prefix, name="metadata.json", version=version)
+    path = get_cache_path(prefix, CacheArtifact.metadata, version=version)
 
     @cached_json(path=path, force=check_should_force(kwargs))
     def _get_json() -> dict[str, Any]:

--- a/src/pyobo/api/properties.py
+++ b/src/pyobo/api/properties.py
@@ -20,7 +20,7 @@ from ..identifier_utils import wrap_norm_prefix
 from ..struct.struct_utils import OBOLiteral, ReferenceHint, _ensure_ref
 from ..utils.cache import cached_df
 from ..utils.io import multidict
-from ..utils.path import prefix_cache_join
+from ..utils.path import CacheArtifact, get_cache_path
 
 __all__ = [
     "get_filtered_properties_df",
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 def get_object_properties_df(prefix, **kwargs: Unpack[GetOntologyKwargs]) -> pd.DataFrame:
     """Get a dataframe of object property triples."""
     version = get_version_from_kwargs(prefix, kwargs)
-    path = prefix_cache_join(prefix, name="object_properties.tsv", version=version)
+    path = get_cache_path(prefix, CacheArtifact.object_properties, version=version)
 
     @cached_df(
         path=path, dtype=str, force=check_should_force(kwargs), cache=check_should_cache(kwargs)
@@ -93,7 +93,7 @@ def get_literal_properties(
 def get_literal_properties_df(prefix: str, **kwargs: Unpack[GetOntologyKwargs]) -> pd.DataFrame:
     """Get a dataframe of literal property quads."""
     version = get_version_from_kwargs(prefix, kwargs)
-    path = prefix_cache_join(prefix, name="literal_properties.tsv", version=version)
+    path = get_cache_path(prefix, CacheArtifact.literal_properties, version=version)
 
     @cached_df(
         path=path, dtype=str, force=check_should_force(kwargs), cache=check_should_cache(kwargs)
@@ -114,7 +114,7 @@ def get_properties_df(prefix: str, **kwargs: Unpack[GetOntologyKwargs]) -> pd.Da
     :returns: A dataframe with the properties
     """
     version = get_version_from_kwargs(prefix, kwargs)
-    path = prefix_cache_join(prefix, name="properties.tsv", version=version)
+    path = get_cache_path(prefix, CacheArtifact.properties, version=version)
 
     @cached_df(
         path=path, dtype=str, force=check_should_force(kwargs), cache=check_should_cache(kwargs)

--- a/src/pyobo/api/relations.py
+++ b/src/pyobo/api/relations.py
@@ -26,7 +26,7 @@ from ..identifier_utils import wrap_norm_prefix
 from ..struct.reference import Reference
 from ..struct.struct_utils import ReferenceHint, _ensure_ref
 from ..utils.cache import cached_df
-from ..utils.path import prefix_cache_join
+from ..utils.path import CacheArtifact, get_cache_path, get_relation_cache_path
 
 __all__ = [
     "get_filtered_relations_df",
@@ -62,7 +62,7 @@ def get_relations_df(
 ) -> pd.DataFrame:
     """Get all relations from the OBO."""
     version = get_version_from_kwargs(prefix, kwargs)
-    path = prefix_cache_join(prefix, name="relations.tsv", version=version)
+    path = get_cache_path(prefix, CacheArtifact.relations, version=version)
 
     @cached_df(
         path=path, dtype=str, force=check_should_force(kwargs), cache=check_should_cache(kwargs)
@@ -90,7 +90,7 @@ def get_filtered_relations_df(
     """Get all the given relation."""
     relation = _ensure_ref(relation, ontology_prefix=prefix)
     version = get_version_from_kwargs(prefix, kwargs)
-    all_relations_path = prefix_cache_join(prefix, name="relations.tsv", version=version)
+    all_relations_path = get_cache_path(prefix, CacheArtifact.relations, version=version)
     if all_relations_path.is_file():
         logger.debug("[%] loading all relations from %s", prefix, all_relations_path)
         df = pd.read_csv(all_relations_path, sep="\t", dtype=str)
@@ -98,12 +98,7 @@ def get_filtered_relations_df(
         columns = [f"{prefix}_id", TARGET_PREFIX, TARGET_ID]
         return df.loc[idx, columns]
 
-    path = prefix_cache_join(
-        prefix,
-        "relations",
-        name=f"{relation.curie}.tsv",
-        version=version,
-    )
+    path = get_relation_cache_path(prefix, relation, version=version)
 
     @cached_df(
         path=path, dtype=str, force=check_should_force(kwargs), cache=check_should_cache(kwargs)

--- a/src/pyobo/api/species.py
+++ b/src/pyobo/api/species.py
@@ -13,7 +13,7 @@ from ..constants import GetOntologyKwargs, check_should_force
 from ..getters import NoBuildError, get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..utils.cache import cached_mapping
-from ..utils.path import prefix_cache_join
+from ..utils.path import CacheArtifact, get_cache_path
 
 __all__ = [
     "get_id_species_mapping",
@@ -62,7 +62,7 @@ def get_id_species_mapping(prefix: str, **kwargs: Unpack[GetOntologyKwargs]) -> 
         return rv
 
     version = get_version_from_kwargs(prefix, kwargs)
-    path = prefix_cache_join(prefix, name="species.tsv", version=version)
+    path = get_cache_path(prefix, CacheArtifact.species, version=version)
 
     @cached_mapping(path=path, header=[f"{prefix}_id", "species"], force=check_should_force(kwargs))
     def _get_id_species_mapping() -> Mapping[str, str]:

--- a/src/pyobo/api/typedefs.py
+++ b/src/pyobo/api/typedefs.py
@@ -11,7 +11,7 @@ from ..constants import GetOntologyKwargs, check_should_cache, check_should_forc
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
 from ..utils.cache import cached_df
-from ..utils.path import prefix_cache_join
+from ..utils.path import CacheArtifact, get_cache_path
 
 __all__ = [
     "get_typedef_df",
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 def get_typedef_df(prefix: str, **kwargs: Unpack[GetOntologyKwargs]) -> pd.DataFrame:
     """Get an identifier to name mapping for the typedefs in an OBO file."""
     version = get_version_from_kwargs(prefix, kwargs)
-    path = prefix_cache_join(prefix, name="typedefs.tsv", version=version)
+    path = get_cache_path(prefix, CacheArtifact.typedefs, version=version)
 
     @cached_df(
         path=path, dtype=str, force=check_should_force(kwargs), cache=check_should_cache(kwargs)

--- a/src/pyobo/aws.py
+++ b/src/pyobo/aws.py
@@ -20,7 +20,7 @@ from pyobo import (
 from pyobo.api.utils import get_version
 from pyobo.constants import RAW_DIRECTORY
 from pyobo.registries import iter_cached_obo
-from pyobo.utils.path import prefix_cache_join
+from pyobo.utils.path import CacheArtifact, get_cache_path
 
 __all__ = [
     "download_artifacts",
@@ -88,55 +88,55 @@ def upload_artifacts_for_prefix(
 
     logger.info("[%s] getting id->name mapping", prefix)
     get_id_name_mapping(prefix)
-    id_name_path = prefix_cache_join(prefix, name="names.tsv", version=version)
+    id_name_path = get_cache_path(prefix, CacheArtifact.names, version=version)
     if not id_name_path.exists():
         raise FileNotFoundError
-    id_name_key = os.path.join(prefix, "cache", "names.tsv")
+    id_name_key = os.path.join(prefix, "cache", id_name_path.name)
     logger.info("[%s] uploading id->name mapping", prefix)
     upload_file(path=id_name_path, bucket=bucket, key=id_name_key, s3_client=s3_client)
 
     logger.info("[%s] getting id->synonyms mapping", prefix)
     get_id_synonyms_mapping(prefix)
-    id_synonyms_path = prefix_cache_join(prefix, name="synonyms.tsv", version=version)
+    id_synonyms_path = get_cache_path(prefix, CacheArtifact.synonyms, version=version)
     if not id_synonyms_path.exists():
         raise FileNotFoundError
-    id_synonyms_key = os.path.join(prefix, "cache", "synonyms.tsv")
+    id_synonyms_key = os.path.join(prefix, "cache", id_synonyms_path.name)
     logger.info("[%s] uploading id->synonyms mapping", prefix)
     upload_file(path=id_synonyms_path, bucket=bucket, key=id_synonyms_key, s3_client=s3_client)
 
     logger.info("[%s] getting xrefs", prefix)
     get_xrefs_df(prefix)
-    xrefs_path = prefix_cache_join(prefix, name="xrefs.tsv", version=version)
+    xrefs_path = get_cache_path(prefix, CacheArtifact.xrefs, version=version)
     if not xrefs_path.exists():
         raise FileNotFoundError
-    xrefs_key = os.path.join(prefix, "cache", "xrefs.tsv")
+    xrefs_key = os.path.join(prefix, "cache", xrefs_path.name)
     logger.info("[%s] uploading xrefs", prefix)
     upload_file(path=xrefs_path, bucket=bucket, key=xrefs_key, s3_client=s3_client)
 
     logger.info("[%s] getting relations", prefix)
     get_relations_df(prefix)
-    relations_path = prefix_cache_join(prefix, name="relations.tsv", version=version)
+    relations_path = get_cache_path(prefix, CacheArtifact.relations, version=version)
     if not relations_path.exists():
         raise FileNotFoundError
-    relations_key = os.path.join(prefix, "cache", "relations.tsv")
+    relations_key = os.path.join(prefix, "cache", relations_path.name)
     logger.info("[%s] uploading relations", prefix)
     upload_file(path=relations_path, bucket=bucket, key=relations_key, s3_client=s3_client)
 
     logger.info("[%s] getting properties", prefix)
     get_properties_df(prefix)
-    properties_path = prefix_cache_join(prefix, name="properties.tsv", version=version)
+    properties_path = get_cache_path(prefix, CacheArtifact.properties, version=version)
     if not properties_path.exists():
         raise FileNotFoundError
-    properties_key = os.path.join(prefix, "cache", "properties.tsv")
+    properties_key = os.path.join(prefix, properties_path.name)
     logger.info("[%s] uploading properties", prefix)
     upload_file(path=properties_path, bucket=bucket, key=properties_key, s3_client=s3_client)
 
     logger.info("[%s] getting alternative identifiers", prefix)
     get_id_to_alts(prefix)
-    alts_path = prefix_cache_join(prefix, name="alt_ids.tsv", version=version)
+    alts_path = get_cache_path(prefix, CacheArtifact.alts, version=version)
     if not alts_path.exists():
         raise FileNotFoundError
-    alts_key = os.path.join(prefix, "cache", "alt_ids.tsv")
+    alts_key = os.path.join(prefix, "cache", alts_path.name)
     logger.info("[%s] uploading alternative identifiers", prefix)
     upload_file(path=alts_path, bucket=bucket, key=alts_key)
 

--- a/src/pyobo/constants.py
+++ b/src/pyobo/constants.py
@@ -28,6 +28,8 @@ BUILD_SUBDIRECTORY_NAME = "build"
 #: The directory inside an ontology cache where
 #: small caches for alts, xrefs, names, etc. go
 CACHE_SUBDIRECTORY_NAME = "cache"
+#: the directory for caching relations
+RELATION_SUBDIRECTORY_NAME = "relations"
 
 SPECIES_REMAPPING = {
     "Canis familiaris": "Canis lupus familiaris",

--- a/src/pyobo/utils/path.py
+++ b/src/pyobo/utils/path.py
@@ -1,18 +1,22 @@
 """Utilities for building paths."""
 
+import enum
 import logging
 from pathlib import Path
 from typing import Any, Literal
 
 import pandas as pd
+from curies import Reference
 from pystow import VersionHint
 
-from ..constants import CACHE_SUBDIRECTORY_NAME, RAW_MODULE
+from ..constants import CACHE_SUBDIRECTORY_NAME, RAW_MODULE, RELATION_SUBDIRECTORY_NAME
 
 __all__ = [
+    "CacheArtifact",
     "ensure_df",
     "ensure_path",
-    "prefix_cache_join",
+    "get_cache_path",
+    "get_relation_cache_path",
     "prefix_directory_join",
 ]
 
@@ -92,8 +96,52 @@ def ensure_df(
     return pd.read_csv(_path, sep=sep, dtype=dtype, **kwargs)
 
 
-def prefix_cache_join(prefix: str, *parts, name: str | None, version: VersionHint) -> Path:
-    """Ensure the prefix cache is available."""
+class CacheArtifact(enum.StrEnum):
+    """An enumeration for."""
+
+    names = "names.tsv"
+    definitions = "definitions.tsv"
+    species = "species.tsv"
+    synonyms = "synonyms.tsv"  # deprecated
+    xrefs = "xrefs.tsv"  # deprecated
+    mappings = "mappings.tsv"
+    relations = "relations.tsv"
+    alts = "alt_ids.tsv"
+    typedefs = "typedefs.tsv"
+    literal_mappings = "literal_mappings.tsv"
+    references = "references.tsv"
+    obsoletes = "obsolete.tsv"
+
+    properties = "properties.tsv"  # deprecated
+    literal_properties = "literal_properties.tsv"
+    object_properties = "object_properties.tsv"
+
+    nodes = "nodes.tsv"
+    edges = "edges.tsv"
+
+    prefixes = "prefixes.json"
+    metadata = "metadata.json"
+
+
+def get_cache_path(
+    ontology: str,
+    name: CacheArtifact,
+    *,
+    version: str | None = None,
+) -> Path:
+    """Get a cache path."""
     return prefix_directory_join(
-        prefix, CACHE_SUBDIRECTORY_NAME, *parts, name=name, version=version
+        ontology, CACHE_SUBDIRECTORY_NAME, name=name.value, version=version
+    )
+
+
+def get_relation_cache_path(
+    ontology: str,
+    reference: Reference,
+    *,
+    version: str | None = None,
+) -> Path:
+    """Get a relation cache path."""
+    return prefix_directory_join(
+        ontology, RELATION_SUBDIRECTORY_NAME, name=f"{reference.curie}.tsv", version=version
     )

--- a/src/pyobo/utils/path.py
+++ b/src/pyobo/utils/path.py
@@ -96,7 +96,7 @@ def ensure_df(
     return pd.read_csv(_path, sep=sep, dtype=dtype, **kwargs)
 
 
-class CacheArtifact(enum.StrEnum):
+class CacheArtifact(enum.Enum):
     """An enumeration for."""
 
     names = "names.tsv"

--- a/src/pyobo/xrefdb/sources/intact.py
+++ b/src/pyobo/xrefdb/sources/intact.py
@@ -6,8 +6,7 @@ import pandas as pd
 
 from pyobo.api.utils import get_version
 from pyobo.constants import PROVENANCE, SOURCE_PREFIX, TARGET_PREFIX, XREF_COLUMNS
-from pyobo.utils.cache import cached_mapping
-from pyobo.utils.path import prefix_cache_join
+from pyobo.utils.path import ensure_df
 
 __all__ = [
     "COMPLEXPORTAL_MAPPINGS",
@@ -23,9 +22,16 @@ COMPLEXPORTAL_MAPPINGS = (
 REACTOME_MAPPINGS = "ftp://ftp.ebi.ac.uk/pub/databases/intact/current/various/reactome.dat"
 
 
-def _get_complexportal_df():
-    return pd.read_csv(
-        COMPLEXPORTAL_MAPPINGS, sep="\t", header=None, names=["source_id", "target_id"]
+def _get_complexportal_df(version: str | None = None):
+    if version is None:
+        version = get_version("intact")
+    return ensure_df(
+        "intact",
+        url=COMPLEXPORTAL_MAPPINGS,
+        version=version,
+        sep="\t",
+        header=None,
+        names=["source_id", "target_id"],
     )
 
 
@@ -50,22 +56,21 @@ def get_complexportal_mapping() -> Mapping[str, str]:
 
         intact_complexportal_mapping = get_filtered_xrefs("intact", "complexportal")
     """
+    df = _get_complexportal_df()
+    return dict(df.values)
 
-    @cached_mapping(
-        path=prefix_cache_join(
-            "intact", "xrefs", name="complexportal.tsv", version=get_version("intact")
-        ),
-        header=["intact_id", "complexportal_id"],
+
+def _get_reactome_df(version: str | None = None):
+    if version is None:
+        version = get_version("intact")
+    return ensure_df(
+        "intact",
+        url=REACTOME_MAPPINGS,
+        version=version,
+        sep="\t",
+        header=None,
+        names=["source_id", "target_id"],
     )
-    def _cache():
-        df = _get_complexportal_df()
-        return dict(df.values)
-
-    return _cache()
-
-
-def _get_reactome_df():
-    return pd.read_csv(REACTOME_MAPPINGS, sep="\t", header=None, names=["source_id", "target_id"])
 
 
 def get_intact_reactome_xrefs_df() -> pd.DataFrame:
@@ -89,18 +94,8 @@ def get_reactome_mapping() -> Mapping[str, str]:
 
         intact_complexportal_mapping = get_filtered_xrefs("intact", "reactome")
     """
-
-    @cached_mapping(
-        path=prefix_cache_join(
-            "intact", "xrefs", name="reactome.tsv", version=get_version("intact")
-        ),
-        header=["intact_id", "reactome_id"],
-    )
-    def _cache():
-        df = _get_complexportal_df()
-        return dict(df.values)
-
-    return _cache()
+    df = _get_reactome_df()
+    return dict(df.values)
 
 
 def get_xrefs_df() -> pd.DataFrame:


### PR DESCRIPTION
1. Use an enum for names of caches / files associated with them
2. Simplify synonym cache lookup to rely on literal mappings
3. Simplify filtered xref cache lookup to rely on full xref df and just make a filter