### PR TITLE
Update antibodyregistry to use API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ dependencies = [
     "curies>=0.10.6",
     "python-dateutil",
     "networkx>=3.4",
-    "httpx",
+    "httpx[http2]",
     # Resource Downloaders
     "drugbank_downloader",
     "chembl_downloader",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ dependencies = [
     "curies>=0.10.6",
     "python-dateutil",
     "networkx>=3.4",
+    "httpx",
     # Resource Downloaders
     "drugbank_downloader",
     "chembl_downloader",

--- a/src/pyobo/sources/antibodyregistry.py
+++ b/src/pyobo/sources/antibodyregistry.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 PREFIX = "antibodyregistry"
 BASE_URL = "https://www.antibodyregistry.org/api/antibodies"
-PAGE_SIZE = 10000
+PAGE_SIZE = 10_000
 TIMEOUT = 180.0
 RAW_DATA_MODULE = RAW_MODULE.module(PREFIX)
 RAW_DATA_PARTS = RAW_DATA_MODULE.module("parts")
@@ -84,9 +84,7 @@ SKIP = {
 }
 
 
-def _get_term(
-    json_data: dict[str, None | str | list[str]], needs_curating: set
-) -> Term:
+def _get_term(json_data: dict[str, None | str | list[str]], needs_curating: set) -> Term:
     # todo: makes use of more fields in the JSON? All fields:
     #  catalogNum, vendorName, clonality, epitope, comments, url, abName,
     #  abTarget, cloneId, commercialType, definingCitation, productConjugate,
@@ -121,8 +119,6 @@ def _get_term(
 
 
 def get_data(
-    max_pages: int | None = None,
-    page_size: int = PAGE_SIZE,
     force: bool = False,
     timeout: float = TIMEOUT,
 ) -> list[dict[str, str | None | list[str]]]:
@@ -174,7 +170,7 @@ def get_data(
         # Now, iterate over the remaining pages
         for page in tqdm(
             range(1, total_pages),
-            desc=f"{PREFIX}, page size={PAGE_SIZE}",
+            desc=PREFIX,
             total=total_pages,
         ):
             # Skip if the page already exists, unless we are forcing
@@ -204,16 +200,10 @@ def antibodyregistry_login(timeout: float = TIMEOUT) -> Cookies:
     """Login to Antibody Registry."""
     logger.info("Logging in to Antibody Registry")
     try:
-        username = pystow.get_config(
-            "pyobo", "antibodyregistry_username", raise_on_missing=True
-        )
-        password = pystow.get_config(
-            "pyobo", "antibodyregistry_password", raise_on_missing=True
-        )
+        username = pystow.get_config("pyobo", "antibodyregistry_username", raise_on_missing=True)
+        password = pystow.get_config("pyobo", "antibodyregistry_password", raise_on_missing=True)
     except ConfigError:
-        logger.error(
-            "You must register at https://www.antibodyregistry.org to use this source."
-        )
+        logger.error("You must register at https://www.antibodyregistry.org to use this source.")
         raise
 
     with Client(

--- a/src/pyobo/sources/antibodyregistry.py
+++ b/src/pyobo/sources/antibodyregistry.py
@@ -44,10 +44,8 @@ class AntibodyRegistryGetter(Obo):
         return iter_terms()
 
 
-def iter_terms(force: bool = False, retries: int = 4) -> Iterable[Term]:
+def iter_terms(force: bool = False, retries: int = 10) -> Iterable[Term]:
     """Get Antibody Registry terms."""
-    # From experience, errors typically happen about one hour after the first request,
-    # so with < 400 pages 4 retries should be enough.
     raw_data = []
     for i in range(max(1, retries)):
         try:

--- a/src/pyobo/sources/antibodyregistry.py
+++ b/src/pyobo/sources/antibodyregistry.py
@@ -140,7 +140,21 @@ def get_data(
     else:
         # Find the first missing page
         logger.info(f"Found {len(existing_pages)} existing pages.")
-        first_page = min(set(range(1, max(existing_pages) + 2)) - existing_pages)
+        first_page = min(
+            set(range(1, max(existing_pages) + 1)) - existing_pages or
+            # if all pages exist, return -1
+            {-1}
+        )
+
+    if first_page == -1:
+        logger.info("All pages exist, returning cached data.")
+        cache = []
+        for page in RAW_DATA_PARTS.base.glob("page*json"):
+            with page.open("r") as file:
+                cache.extend(json.load(file))
+        with RAW_CACHE.open("w") as file:
+            json.dump(cache, file)
+        return cache
 
     # Get first missing page
     cookies = antibodyregistry_login(timeout=timeout)

--- a/src/pyobo/sources/antibodyregistry.py
+++ b/src/pyobo/sources/antibodyregistry.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable, Mapping
 
 import lxml.html
 import pystow
-from httpx import Client, Timeout, Cookies, URL as httpx_URL
+from httpx import Client, Timeout, Cookies, URL as HTTPX_URL
 from pystow import ConfigError
 
 from bioregistry.utils import removeprefix
@@ -124,7 +124,7 @@ def get_data(
     cookies = antibodyregistry_login(timeout=timeout)
     with Client(http2=True, timeout=Timeout(timeout)) as client:
         r = client.get(
-            httpx_URL(BASE_URL),
+            HTTPX_URL(BASE_URL),
             cookies=cookies,
             params={"page": 1, "size": page_size},
         )
@@ -154,7 +154,7 @@ def get_data(
             total=total_pages - 1,
         ):
             r = client.get(
-                httpx_URL(BASE_URL),
+                HTTPX_URL(BASE_URL),
                 cookies=cookies,
                 params={"page": page, "size": page_size},
             )
@@ -189,12 +189,12 @@ def antibodyregistry_login(timeout: float = TIMEOUT) -> Cookies:
         http2=True,
         timeout=Timeout(timeout),
     ) as client:
-        r = client.get(httpx_URL("https://www.antibodyregistry.org/login"))
+        r = client.get(HTTPX_URL("https://www.antibodyregistry.org/login"))
         r.raise_for_status()
 
         cookies = r.cookies
         tree = lxml.html.fromstring(r.content)
-        login_post_url = httpx_URL(tree.xpath('//form[@id="kc-form-login"]/@action')[0])
+        login_post_url = HTTPX_URL(tree.xpath('//form[@id="kc-form-login"]/@action')[0])
 
         r = client.post(
             login_post_url,

--- a/src/pyobo/sources/antibodyregistry.py
+++ b/src/pyobo/sources/antibodyregistry.py
@@ -4,7 +4,6 @@ import logging
 from collections.abc import Iterable, Mapping
 
 import lxml.html
-import pandas as pd
 import pystow
 from httpx import Client, Timeout, Cookies, URL as httpx_URL
 
@@ -15,7 +14,6 @@ from curies import Prefix
 from pyobo import Obo, Reference, Term
 from pyobo.constants import RAW_MODULE
 from pyobo.struct.typedef import has_citation
-from pyobo.utils.path import ensure_df
 
 __all__ = [
     "AntibodyRegistryGetter",

--- a/src/pyobo/sources/antibodyregistry.py
+++ b/src/pyobo/sources/antibodyregistry.py
@@ -36,6 +36,7 @@ class AntibodyRegistryGetter(Obo):
 
     ontology = bioversions_key = PREFIX
     typedefs = [has_citation]
+    dynamic_version = True
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""
@@ -97,7 +98,7 @@ def _get_term(json_data: dict[str, None | str | list[str]], needs_curating: set)
         term.append_xref((MAPPING[vendor], catalog_number))
     if defining_citation:
         for pubmed_id in defining_citation.split(","):
-            pubmed_id = pubmed_id.strip().removeprefix("PMID: ")
+            pubmed_id = removeprefix(pubmed_id.strip(), prefix="PMID:").strip()
             if not pubmed_id:
                 continue
             term.append_provenance(

--- a/src/pyobo/sources/antibodyregistry.py
+++ b/src/pyobo/sources/antibodyregistry.py
@@ -188,11 +188,13 @@ def get_data(
             with part_file.open("w") as file:
                 json.dump(res_json["items"], file)
 
-    # Now merge all the pages
+    # Now merge all the pages and write to the cache
     cache = []
     for page in RAW_DATA_PARTS.base.glob("page*json"):
         with page.open("r") as file:
             cache.extend(json.load(file))
+    with RAW_CACHE.open("w") as file:
+        json.dump(cache, file)
     return cache
 
 

--- a/src/pyobo/sources/antibodyregistry.py
+++ b/src/pyobo/sources/antibodyregistry.py
@@ -108,7 +108,7 @@ def _get_term(
 
 
 def get_data(
-    max_pages: int = None,
+    max_pages: int | None = None,
     page_size: int = PAGE_SIZE,
     force: bool = False,
     timeout: float = TIMEOUT,

--- a/src/pyobo/sources/antibodyregistry.py
+++ b/src/pyobo/sources/antibodyregistry.py
@@ -160,7 +160,8 @@ def get_data(
         # Get max page and calculate total pages left after first page
         total_count = res_json["totalElements"]
         total_pages = total_count // PAGE_SIZE + (1 if total_count % PAGE_SIZE else 0)
-        if len(res_json["items"]) != PAGE_SIZE:
+        # Check if the first page has the expected number of items (unless it's the last page)
+        if len(res_json["items"]) != PAGE_SIZE and first_page != total_pages:
             logger.error("The first page does not have the expected number of items.")
             raise ValueError(
                 f"Number of items on the first page is not {PAGE_SIZE}. "

--- a/src/pyobo/sources/antibodyregistry.py
+++ b/src/pyobo/sources/antibodyregistry.py
@@ -1,4 +1,5 @@
 """Converter for the Antibody Registry."""
+
 import json
 import logging
 from collections.abc import Iterable, Mapping
@@ -48,7 +49,6 @@ def iter_terms(force: bool = False) -> Iterable[Term]:
     for item in raw_data:
         term = _get_term(item, needs_curating=needs_curating)
         yield term
-    
 
 
 # TODO there are tonnnnsss of mappings to be curated
@@ -70,8 +70,9 @@ SKIP = {
 }
 
 
-
-def _get_term(json_data: dict[str, None | str | list[str]], needs_curating: set) -> Term:
+def _get_term(
+    json_data: dict[str, None | str | list[str]], needs_curating: set
+) -> Term:
     # todo: makes use of more fields in the JSON? All fields:
     #  catalogNum, vendorName, clonality, epitope, comments, url, abName,
     #  abTarget, cloneId, commercialType, definingCitation, productConjugate,
@@ -164,6 +165,7 @@ def get_data(
         with RAW_CACHE.open("w") as file:
             json.dump(cache, file)
     return cache
+
 
 def antibodyregistry_login(timeout: float = TIMEOUT) -> Cookies:
     """Login to Antibody Registry."""

--- a/src/pyobo/sources/antibodyregistry.py
+++ b/src/pyobo/sources/antibodyregistry.py
@@ -169,7 +169,7 @@ def get_data(
 
         # Now, iterate over the remaining pages
         for page in tqdm(
-            range(1, total_pages),
+            range(1, total_pages+1),
             desc=PREFIX,
             total=total_pages,
         ):

--- a/src/pyobo/sources/antibodyregistry.py
+++ b/src/pyobo/sources/antibodyregistry.py
@@ -153,10 +153,6 @@ def get_data(
         r.raise_for_status()
         res_json = r.json()
 
-        # Write the first page to the cache
-        with RAW_DATA_PARTS.base.joinpath(f"page{first_page}.json").open("w") as file:
-            json.dump(res_json["items"], file)
-
         # Get max page and calculate total pages left after first page
         total_count = res_json["totalElements"]
         total_pages = total_count // PAGE_SIZE + (1 if total_count % PAGE_SIZE else 0)
@@ -167,6 +163,10 @@ def get_data(
                 f"Number of items on the first page is not {PAGE_SIZE}. "
                 f"Recommending reduce page_size."
             )
+
+        # Write the first page to the cache
+        with RAW_DATA_PARTS.base.joinpath(f"page{first_page}.json").open("w") as file:
+            json.dump(res_json["items"], file)
 
         # Now, iterate over the remaining pages
         for page in tqdm(

--- a/src/pyobo/sources/antibodyregistry.py
+++ b/src/pyobo/sources/antibodyregistry.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable, Mapping
 import lxml.html
 import pystow
 from httpx import Client, Timeout, Cookies, URL as httpx_URL
+from pystow import ConfigError
 
 from bioregistry.utils import removeprefix
 from tqdm.auto import tqdm
@@ -170,12 +171,19 @@ def get_data(
 def antibodyregistry_login(timeout: float = TIMEOUT) -> Cookies:
     """Login to Antibody Registry."""
     logger.info("Logging in to Antibody Registry")
-    username = pystow.get_config(
-        "pyobo", "antibodyregistry_username", raise_on_missing=True
-    )
-    password = pystow.get_config(
-        "pyobo", "antibodyregistry_password", raise_on_missing=True
-    )
+    try:
+        username = pystow.get_config(
+            "pyobo", "antibodyregistry_username", raise_on_missing=True
+        )
+        password = pystow.get_config(
+            "pyobo", "antibodyregistry_password", raise_on_missing=True
+        )
+    except ConfigError:
+        logger.error(
+            "You must register at https://www.antibodyregistry.org to use this source."
+        )
+        raise
+
     with Client(
         follow_redirects=True,
         http2=True,


### PR DESCRIPTION
## Summary

Resolves #369.

This PR updates antibodyregistry to use their API. The API requires login, which is now handled by `httpx`. After a login sequence that uses personal login information, the API can be used to download all the data.

The previous implementation of this API was broken by updates from the maintainers of the data.

## Issue: Slow Download

The current implementation takes ~3 hours. We should consider running concurrent requests to speed this up if 3 hours is unacceptable.