### PR TITLE
Reimplement getting xrefs

### DIFF
--- a/src/pyobo/api/hierarchy.py
+++ b/src/pyobo/api/hierarchy.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 
 import networkx as nx
 from curies import ReferenceTuple
-from typing_extensions import Unpack
+from typing_extensions import NotRequired, Unpack
 
 from .edges import get_edges
 from .names import get_name, get_references
@@ -33,8 +33,8 @@ logger = logging.getLogger(__name__)
 class HierarchyKwargs(GetOntologyKwargs):
     """Keyword argument hints for hierarchy getter functions."""
 
-    include_part_of: bool
-    include_has_member: bool
+    include_part_of: NotRequired[bool]
+    include_has_member: NotRequired[bool]
 
 
 def get_hierarchy(

--- a/src/pyobo/api/xrefs.py
+++ b/src/pyobo/api/xrefs.py
@@ -161,7 +161,7 @@ def get_mappings_df(
             path=path, dtype=str, force=check_should_force(kwargs), cache=check_should_cache(kwargs)
         )
         def _df_getter() -> pd.DataFrame:
-            logger.info(f"[%s] rebuilding SSSOM", prefix)
+            logger.info("[%s] rebuilding SSSOM", prefix)
             ontology = get_ontology(prefix, **kwargs)
             return ontology.get_mappings_df(
                 use_tqdm=check_should_use_tqdm(kwargs),

--- a/src/pyobo/api/xrefs.py
+++ b/src/pyobo/api/xrefs.py
@@ -7,7 +7,6 @@ from functools import lru_cache
 
 import pandas as pd
 from curies import ReferenceTuple
-from tqdm import tqdm
 from typing_extensions import Unpack
 
 from .utils import get_version_from_kwargs

--- a/src/pyobo/api/xrefs.py
+++ b/src/pyobo/api/xrefs.py
@@ -157,13 +157,12 @@ def get_mappings_df(
     else:
         version = get_version_from_kwargs(prefix, kwargs)
         path = get_cache_path(prefix, CacheArtifact.mappings, version=version)
-        tqdm.write(f"[{prefix}] checking SSSOM cache path {path}")
 
         @cached_df(
             path=path, dtype=str, force=check_should_force(kwargs), cache=check_should_cache(kwargs)
         )
         def _df_getter() -> pd.DataFrame:
-            tqdm.write(f"[{prefix}] rebuilding SSSOM")
+            logger.info(f"[{prefix}] rebuilding SSSOM")
             ontology = get_ontology(prefix, **kwargs)
             return ontology.get_mappings_df(
                 use_tqdm=check_should_use_tqdm(kwargs),

--- a/src/pyobo/api/xrefs.py
+++ b/src/pyobo/api/xrefs.py
@@ -161,7 +161,7 @@ def get_mappings_df(
             path=path, dtype=str, force=check_should_force(kwargs), cache=check_should_cache(kwargs)
         )
         def _df_getter() -> pd.DataFrame:
-            logger.info(f"[{prefix}] rebuilding SSSOM")
+            logger.info(f"[%s] rebuilding SSSOM", prefix)
             ontology = get_ontology(prefix, **kwargs)
             return ontology.get_mappings_df(
                 use_tqdm=check_should_use_tqdm(kwargs),

--- a/src/pyobo/api/xrefs.py
+++ b/src/pyobo/api/xrefs.py
@@ -61,9 +61,15 @@ def get_filtered_xrefs(
     **kwargs: Unpack[GetOntologyKwargs],
 ) -> Mapping[str, str]:
     """Get xrefs to a given target."""
-    df = get_xrefs_df(prefix, **kwargs)
-    df = df.loc[df[TARGET_PREFIX] == xref_prefix, [f"{prefix}_id", TARGET_ID]]
-    rv = dict(df.values)
+    mappings_df = get_mappings_df(prefix, **kwargs)
+
+    rv = {}
+    for subject_curie, object_curie in mappings_df[["subject_id", "object_id"]].values:
+        subject_pair = ReferenceTuple.from_curie(subject_curie)
+        object_pair = ReferenceTuple.from_curie(object_curie)
+        if object_pair.prefix == xref_prefix:
+            rv[subject_pair.identifier] = object_pair.identifier
+
     if flip:
         return {v: k for k, v in rv.items()}
     return rv

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -1846,11 +1846,6 @@ class Obo:
             if xref.prefix == prefix:
                 yield term, xref
 
-    def iterate_xref_rows(self, *, use_tqdm: bool = False) -> Iterable[tuple[str, str, str]]:
-        """Iterate over terms' identifiers, xref prefixes, and xref identifiers."""
-        for term, xref in self.iterate_xrefs(use_tqdm=use_tqdm):
-            yield term.identifier, xref.prefix, xref.identifier
-
     def iterate_literal_mapping_rows(self) -> Iterable[ssslm.LiteralMappingTuple]:
         """Iterate over literal mapping rows."""
         for synonym in self.get_literal_mappings():
@@ -1901,21 +1896,6 @@ class Obo:
             df["mapping_source"] = self.ontology
 
         return df
-
-    @property
-    def xrefs_header(self):
-        """The header for the xref dataframe."""
-        warnings.warn("use SSSOM_DF_COLUMNS instead", DeprecationWarning, stacklevel=2)
-        return [f"{self.ontology}_id", TARGET_PREFIX, TARGET_ID]
-
-    def get_xrefs_df(self, *, use_tqdm: bool = False) -> pd.DataFrame:
-        """Get a dataframe of all xrefs extracted from the OBO document."""
-        warnings.warn("use ontology.get_mappings_df instead", DeprecationWarning, stacklevel=2)
-
-        return pd.DataFrame(
-            list(self.iterate_xref_rows(use_tqdm=use_tqdm)),
-            columns=[f"{self.ontology}_id", TARGET_PREFIX, TARGET_ID],
-        ).drop_duplicates()
 
     def get_filtered_xrefs_mapping(
         self, prefix: str, *, use_tqdm: bool = False

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -1834,7 +1834,7 @@ class Obo:
         for stanza in self._iter_stanzas(
             use_tqdm=use_tqdm, desc=f"[{self.ontology}] getting xrefs"
         ):
-            xrefs = {xref for _, xref in stanza.get_mappings()}
+            xrefs = {xref for _, xref in stanza.get_mappings(add_context=False)}
             for xref in sorted(xrefs):
                 yield stanza, xref
 

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -1834,7 +1834,8 @@ class Obo:
         for stanza in self._iter_stanzas(
             use_tqdm=use_tqdm, desc=f"[{self.ontology}] getting xrefs"
         ):
-            for xref in stanza.xrefs:
+            xrefs = {xref for _, xref in stanza.get_mappings()}
+            for xref in sorted(xrefs):
                 yield stanza, xref
 
     def iterate_filtered_xrefs(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -44,12 +44,18 @@ mock_id_names_mapping = get_mock_id_name_mapping(
 )
 
 TEST_P1 = "test"
+TEST_P2 = "test2"
 
 bioregistry.manager.synonyms[TEST_P1] = TEST_P1
 bioregistry.manager.registry[TEST_P1] = bioregistry.Resource(
     prefix=TEST_P1,
     name="Test Semantic Space",
     pattern="^\\d+$",
+)
+bioregistry.manager.synonyms[TEST_P2] = TEST_P2
+bioregistry.manager.registry[TEST_P2] = bioregistry.Resource(
+    prefix=TEST_P2,
+    name="Test Semantic Space 2",
 )
 
 
@@ -152,11 +158,13 @@ class TestAltIds(unittest.TestCase):
         r1 = PyOBOReference(prefix=TEST_P1, identifier="1", name="test name")
         r2 = PyOBOReference(prefix=TEST_P1, identifier="2")
         r3 = PyOBOReference(prefix=TEST_P1, identifier="3")
+        r2_1 = PyOBOReference(prefix=TEST_P2, identifier="X")
+        r2_2 = PyOBOReference(prefix=TEST_P2, identifier="Y")
         syn1 = "ttt1"
-        t1 = Term(reference=r1).append_alt(r2).append_synonym(syn1)
+        t1 = Term(reference=r1).append_alt(r2).append_synonym(syn1).append_xref(r2_1)
         t1.append_comment("test comment")
         t2 = Term(reference=r2)
-        t3 = Term(reference=r3).append_parent(r1)
+        t3 = Term(reference=r3).append_parent(r1).append_exact_match(r2_2)
         terms = [t1, t2, t3]
         ontology = make_ad_hoc_ontology(TEST_P1, terms=terms, _typedefs=[td1])
 
@@ -166,6 +174,7 @@ class TestAltIds(unittest.TestCase):
             "pyobo.api.properties.get_ontology",
             "pyobo.api.relations.get_ontology",
             "pyobo.api.edges.get_ontology",
+            "pyobo.api.xrefs.get_ontology",
         ]
         with patch_ontologies(ontology, targets):
             # Alts
@@ -198,6 +207,10 @@ class TestAltIds(unittest.TestCase):
 
             self.assertEqual(t1.name, pyobo.get_name(r1, cache=False))
             self.assertEqual(t1.name, pyobo.get_name(r2, cache=False))
+
+            # Xrefs
+            d = pyobo.get_filtered_xrefs(TEST_P1, TEST_P2, cache=False, use_tqdm=False)
+            self.assertEqual({"1": "X", "3": "Y"}, d)
 
             # Synonyms
 
@@ -233,7 +246,15 @@ class TestAltIds(unittest.TestCase):
             self.assertEqual("test comment", value)
 
             edges = pyobo.get_edges(TEST_P1, cache=False, use_tqdm=False)
-            self.assertEqual({(r3, v.is_a, r1), (r1, v.alternative_term, r2)}, set(edges))
+            self.assertEqual(
+                {
+                    (r3, v.is_a, r1),
+                    (r1, v.alternative_term, r2),
+                    (r1, v.has_dbxref, r2_1),
+                    (r3, v.exact_match, r2_2),
+                },
+                set(edges),
+            )
 
             graph = pyobo.get_hierarchy(TEST_P1, cache=False, use_tqdm=False)
             self.assertEqual(4, graph.number_of_nodes())


### PR DESCRIPTION
The `get_xrefs()` function has been deprecated - this is a step towards replacing the implementation with the SSSOM-based one