### PR TITLE
Fix ground relation usage

### DIFF
--- a/src/pyobo/identifier_utils.py
+++ b/src/pyobo/identifier_utils.py
@@ -184,8 +184,10 @@ def _parse_str_or_curie_or_uri_helper(
 
     if upgrade and (reference_t := bioontologies.upgrade.upgrade(str_or_curie_or_uri)):
         return Reference(prefix=reference_t.prefix, identifier=reference_t.identifier)
-    if upgrade and (yy := bioontologies.relations.ground_relation(str_or_curie_or_uri)):
-        return Reference(prefix=yy.prefix, identifier=yy.identifier, name=name)
+    if upgrade:
+        rel_prefix, rel_identifier = bioontologies.relations.ground_relation(str_or_curie_or_uri)
+        if rel_prefix and rel_identifier:
+            return Reference(prefix=rel_prefix, identifier=rel_identifier, name=name)
 
     if _is_uri(str_or_curie_or_uri):
         prefix, identifier = bioregistry.parse_iri(str_or_curie_or_uri)


### PR DESCRIPTION
This PR fixes a usage of `bioontologies.relations.ground_relation` which returns a simple tuple of two strings (or Nones) and the None case has to be handled. The preexisting code assumed that None or an object with attributes is returned, which errored when this part of the code was invoked.