### PR TITLE
Remove trailing slash from URLs

### DIFF
--- a/src/pyobo/identifier_utils/api.py
+++ b/src/pyobo/identifier_utils/api.py
@@ -134,6 +134,7 @@ def _preclean_uri(s: str) -> str:
     s = s.removeprefix("WWW:").removeprefix("www:").lstrip()
     s = s.replace("http\\:", "http:")
     s = s.replace("https\\:", "https:")
+    s = s.rstrip("/")
     return s
 
 


### PR DESCRIPTION
This helps deal with issues with URLs in DOID (and potentially other places)