### PR TITLE
Support custom grounding workflows

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ PyOBO |release| Documentation
     cli
     usage
     functional
+    ner
     scispacy
 
 Indices and Tables

--- a/docs/source/ner.rst
+++ b/docs/source/ner.rst
@@ -1,0 +1,59 @@
+Named Entity Recognition
+========================
+
+PyOBO has high-level wrappers to construct literal mapping objects defined by
+:mod:`ssslm.LiteralMapping`, which can be used to construct generic named entity
+recognition (NER) and named entity normalization (NEN) tooling (e.g., using ScispaCy or
+Gilda as a backend)
+
+You can use :func:`pyobo.ground` as an integrated workflow:
+
+.. code-block:: python
+
+    import pyobo
+    import ssslm
+
+    matches: list[ssslm.Match] = pyobo.ground("chebi", "ethanol")
+
+You can get the grounder directly first using :func:`pyobo.get_grounder`:
+
+.. code-block:: python
+
+    import pyobo
+    import ssslm
+
+    grounder: ssslm.Grounder = pyobo.get_grounder("chebi")
+    matches: list[ssslm.Match] = grounder.get_matches("ethanol")
+
+You can get the ontology directly using :func:`pyobo.get_ontology` then the grounder
+with :meth:`pyobo.Obo.get_grounder`:
+
+.. code-block:: python
+
+    import pyobo
+    import ssslm
+
+    ontology: pyobo.Obo = pyobo.get_ontology("chebi")
+    grounder: ssslm.Grounder = ontology.get_grounder()
+    matches: list[ssslm.Match] = grounder.get_matches("ethanol")
+
+You can load a custom ontology with :func:`pyobo.from_obo_path`:
+
+.. code-block:: python
+
+    import pyobo
+    from urllib.request import urlretrieve
+
+    url = "http://purl.obolibrary.org/obo/chebi.obo"
+    path = "chebi.obo"
+    urlretrieve(url, path)
+
+    ontology: pyobo.Obo = pyobo.from_obo_path(path, prefix="chebi")
+    grounder: ssslm.Grounder = ontology.get_grounder()
+    matches: list[ssslm.Match] = grounder.get_matches("ethanol")
+
+.. warning::
+
+    When loading a custom ontology, it's required that the prefix is registered in the
+    :mod:`bioregistry`, since PyOBO does additional standardization and normalization of
+    prefixes, CURIEs, and URIs that are not part of the OBO specification.

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -1906,7 +1906,8 @@ class Obo:
     def get_grounder(self) -> ssslm.Grounder:
         """Get a grounder from this ontology.
 
-        :returns: An object that can be used for named entity recognition and named entity normalization
+        :returns: An object that can be used for named entity recognition and named
+            entity normalization
 
         Here's example usage for a built-in ontology:
 
@@ -1920,6 +1921,8 @@ class Obo:
 
         Here's example usage for a custom ontology:
 
+        .. code-block:: python
+
             import pyobo
             from urllib.request import urlretrieve
 
@@ -1931,8 +1934,7 @@ class Obo:
             # and it must be registered in the Bioregistry
             ontology = pyobo.from_obo_path(path, prefix="taxrank")
             grounder = ontology.get_grounder()
-            matches = grounder.ground("species") # contains a match to taxrank:0000006
-
+            matches = grounder.ground("species")  # contains a match to taxrank:0000006
         """
         return ssslm.make_grounder(self.get_literal_mappings())
 

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -1903,6 +1903,39 @@ class Obo:
         """Get a mapping from identifiers to a list of sorted synonym strings."""
         return multidict(self.iterate_synonym_rows(use_tqdm=use_tqdm))
 
+    def get_grounder(self) -> ssslm.Grounder:
+        """Get a grounder from this ontology.
+
+        :returns: An object that can be used for named entity recognition and named entity normalization
+
+        Here's example usage for a built-in ontology:
+
+        .. code-block:: python
+
+            import pyobo
+
+            ontology = pyobo.get_ontology("taxrank")
+            grounder = ontology.get_grounder()
+            matches = grounder.ground("species") # contains a match to taxrank:0000006
+
+        Here's example usage for a custom ontology:
+
+            import pyobo
+            from urllib.request import urlretrieve
+
+            url = "http://purl.obolibrary.org/obo/taxrank.obo"
+            path = "taxrank.obo"
+            urlretrieve(url, path)
+
+            # it's required to tell PyOBO the prefix for a custom ontology,
+            # and it must be registered in the Bioregistry
+            ontology = pyobo.from_obo_path(path, prefix="taxrank")
+            grounder = ontology.get_grounder()
+            matches = grounder.ground("species") # contains a match to taxrank:0000006
+
+        """
+        return ssslm.make_grounder(self.get_literal_mappings())
+
     def get_literal_mappings(self) -> Iterable[ssslm.LiteralMapping]:
         """Get literal mappings in a standard data model."""
         stanzas: Iterable[Stanza] = itt.chain(self, self.typedefs or [])

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -1916,7 +1916,7 @@ class Obo:
 
             ontology = pyobo.get_ontology("taxrank")
             grounder = ontology.get_grounder()
-            matches = grounder.ground("species") # contains a match to taxrank:0000006
+            matches = grounder.ground("species")  # contains a match to taxrank:0000006
 
         Here's example usage for a custom ontology:
 

--- a/tests/test_obo_reader/test_reader.py
+++ b/tests/test_obo_reader/test_reader.py
@@ -1362,3 +1362,21 @@ class TestReaderTerm(unittest.TestCase):
             "orcid": {ADNAN_MALIK},
         }
         self.assertEqual(expected_references, ontology._get_references())
+
+    def test_get_grounder(self) -> None:
+        """Test getting a grounder from an ontology."""
+        ontology = from_str("""\
+            ontology: chebi
+            date: 20:11:2024 18:44
+
+            [Term]
+            id: CHEBI:16236
+            name: ethanol
+        """)
+        r1 = Reference(prefix="CHEBI", identifier="16236", name="ethanol")
+        grounder = ontology.get_grounder()
+        match = grounder.get_best_match("Ethanol")
+        self.assertIsNotNone(match)
+        if match is None:
+            raise ValueError
+        self.assertEqual(r1, match.reference)


### PR DESCRIPTION
This PR adds a convenience function for creating a grounder from a pre-constructed ontology. It also adds documentation to support @gouttegd's use cases described in https://incenp.org/notes/2025/comparing-python-ontology-libraries.html.

Ultimately, though, his blog post is correct in that PyOBO's goal is to provide downstream user access to the most up-to-date versions of the ontologies more than support local/custom ontology usage.