### PR TITLE
Consolidate synonym type usage in HGNC and RGD

### DIFF
--- a/src/pyobo/sources/hgnc/hgnc.py
+++ b/src/pyobo/sources/hgnc/hgnc.py
@@ -16,7 +16,6 @@ from pyobo.resources.so import get_so_name
 from pyobo.struct import (
     Obo,
     Reference,
-    SynonymTypeDef,
     Term,
     TypeDef,
     default_reference,
@@ -28,7 +27,7 @@ from pyobo.struct import (
     orthologous,
     transcribes_to,
 )
-from pyobo.struct.struct import previous_name as previous_name_type
+from pyobo.struct.struct import gene_symbol_synonym, previous_gene_symbol, previous_name
 from pyobo.struct.typedef import exact_match
 from pyobo.utils.path import ensure_path, prefix_directory_join
 
@@ -44,15 +43,6 @@ DEFINITIONS_URL_FMT = (
     "hgnc_complete_set_{version}.json"
 )
 
-previous_symbol_type = SynonymTypeDef(
-    reference=default_reference(PREFIX, "previous_symbol", name="previous symbol")
-)
-alias_symbol_type = SynonymTypeDef(
-    reference=default_reference(PREFIX, "alias_symbol", name="alias symbol")
-)
-alias_name_type = SynonymTypeDef(
-    reference=default_reference(PREFIX, "alias_name", name="alias name")
-)
 HAS_LOCUS_TYPE = TypeDef(
     reference=default_reference(PREFIX, "locus_type", name="has locus type"), is_metadata_tag=True
 )
@@ -207,10 +197,9 @@ class HGNCGetter(Obo):
         HAS_LOCATION,
     ]
     synonym_typedefs = [
-        previous_name_type,
-        previous_symbol_type,
-        alias_name_type,
-        alias_symbol_type,
+        previous_name,
+        previous_gene_symbol,
+        gene_symbol_synonym,
     ]
     root_terms = [
         Reference(prefix="SO", identifier=so_id, name=get_so_name(so_id))
@@ -388,15 +377,16 @@ def get_terms(version: str | None = None, force: bool = False) -> Iterable[Term]
             )
 
         for alias_symbol in entry.pop("alias_symbol", []):
-            term.append_synonym(alias_symbol, type=alias_symbol_type)
+            term.append_synonym(alias_symbol, type=gene_symbol_synonym)
         for alias_name in entry.pop("alias_name", []):
-            term.append_synonym(alias_name, type=alias_name_type)
+            # regular synonym, no type needed.
+            term.append_synonym(alias_name)
         for previous_symbol in itt.chain(
             entry.pop("previous_symbol", []), entry.pop("prev_symbol", [])
         ):
-            term.append_synonym(previous_symbol, type=previous_symbol_type)
-        for previous_name in entry.pop("prev_name", []):
-            term.append_synonym(previous_name, type=previous_name_type)
+            term.append_synonym(previous_symbol, type=previous_gene_symbol)
+        for previous_name_ in entry.pop("prev_name", []):
+            term.append_synonym(previous_name_, type=previous_name)
 
         for prop, td in [("location", HAS_LOCATION)]:
             value = entry.pop(prop, None)

--- a/src/pyobo/sources/rgd.py
+++ b/src/pyobo/sources/rgd.py
@@ -9,21 +9,17 @@ from tqdm.auto import tqdm
 from pyobo.struct import (
     Obo,
     Reference,
-    SynonymTypeDef,
     Term,
-    default_reference,
     from_species,
     has_gene_product,
     is_mentioned_by,
     transcribes_to,
 )
-from pyobo.struct.struct import previous_name
+from pyobo.struct.struct import previous_gene_symbol, previous_name
 from pyobo.utils.path import ensure_df
 
 logger = logging.getLogger(__name__)
 PREFIX = "rgd"
-
-old_symbol_type = SynonymTypeDef(reference=default_reference(PREFIX, "old_symbol"))
 
 # NOTE unigene id was discontinue in January 18th, 2021 dump
 
@@ -74,7 +70,7 @@ class RGDGetter(Obo):
 
     bioversions_key = ontology = PREFIX
     typedefs = [from_species, transcribes_to, has_gene_product, is_mentioned_by]
-    synonym_typedefs = [previous_name, old_symbol_type]
+    synonym_typedefs = [previous_name, previous_gene_symbol]
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""
@@ -123,7 +119,7 @@ def get_terms(force: bool = False, version: str | None = None) -> Iterable[Term]
         old_symbols = row["OLD_SYMBOL"]
         if old_symbols and pd.notna(old_symbols):
             for old_symbol in old_symbols.split(";"):
-                term.append_synonym(old_symbol, type=old_symbol_type)
+                term.append_synonym(old_symbol, type=previous_gene_symbol)
         for prefix, key in namespace_to_column:
             xref_ids = str(row[key])
             if xref_ids and pd.notna(xref_ids):

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -255,6 +255,13 @@ uk_spelling = SynonymTypeDef(
 previous_name = SynonymTypeDef(
     reference=Reference(prefix="omo", identifier="0003008", name="previous name")
 )
+previous_gene_symbol = SynonymTypeDef(
+    reference=Reference(prefix="omo", identifier="0003015", name="previous gene symbol")
+)
+gene_symbol_synonym = SynonymTypeDef(
+    reference=Reference(prefix="omo", identifier="0003016", name="gene symbol synonym")
+)
+
 default_synonym_typedefs: dict[ReferenceTuple, SynonymTypeDef] = {
     abbreviation.pair: abbreviation,
     acronym.pair: acronym,


### PR DESCRIPTION
This PR consolidates the synoynm types used in gene resources HGNC and RGD.

Upstream PR to OMO that standardizes these types: https://github.com/information-artifact-ontology/ontology-metadata/pull/197.