### PR TITLE
Link to script that produced ontology

### DIFF
--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import inspect
 import itertools as itt
 import json
 import logging
@@ -106,6 +107,7 @@ SSSOM_DF_COLUMNS = [
     "contributor",
 ]
 FORMAT_VERSION = "1.4"
+_SOURCES = Path(__file__).parent.parent.joinpath("sources").resolve()
 
 
 @dataclass
@@ -631,8 +633,15 @@ class Obo:
                 raise ValueError(f"{self.ontology} is missing data_version")
             elif "/" in self.data_version:
                 raise ValueError(f"{self.ontology} has a slash in version: {self.data_version}")
+
+        file_path = Path(inspect.getfile(self.__class__)).resolve()
+        script_url = f"https://github.com/biopragmatics/pyobo/blob/main/src/pyobo/sources/{file_path.relative_to(_SOURCES)}"
+
         if self.auto_generated_by is None:
-            self.auto_generated_by = f"PyOBO v{get_pyobo_version(with_git_hash=True)} on {datetime.datetime.now().isoformat()}"  # type:ignore
+            self.auto_generated_by = (
+                f"PyOBO v{get_pyobo_version(with_git_hash=True)} on "
+                f"{datetime.datetime.now().isoformat()} by {script_url}."
+            )  # type:ignore
 
     def _get_clean_idspaces(self) -> dict[str, str]:
         """Get normalized idspace dictionary."""


### PR DESCRIPTION
This PR updates the way `auto_generated_by` is formatted to also include a link to the scrip on the main branch of the PyOBO github repository. This makes it easier for someone who looks at an ontology to figure out where it came from.

Here's how this looks in an abridged HGNC OBO file:

```
format-version: 1.4
data-version: 2025-10-07
auto-generated-by: PyOBO v0.12.11-dev-ea1f0438 on 2025-10-10T16:56:04.644071 by https://github.com/biopragmatics/pyobo/blob/main/src/pyobo/sources/hgnc/hgnc.py.
synonymtypedef: OMO:0003008 "previous name"
synonymtypedef: OMO:0003015 "previous gene symbol"
synonymtypedef: OMO:0003016 "gene symbol synonym"
ontology: hgnc
```