### PR TITLE
Complete locus types in HGNC

### DIFF
--- a/src/pyobo/sources/hgnc/hgnc.py
+++ b/src/pyobo/sources/hgnc/hgnc.py
@@ -391,7 +391,6 @@ def get_terms(version: str | None = None, force: bool = False) -> Iterable[Term]
         # and since we already have an exhaustive mapping from locus type
         # to SO, then we can throw this annotation away
         _locus_group = entry.pop("locus_group")
-
         so_id = LOCUS_TYPE_TO_SO.get(locus_type)
         if not so_id:
             raise ValueError("""\


### PR DESCRIPTION
Closes #118

This PR completes the annotations from HGNC gene locus types to SO terms. SO is currently unresponsive, so I made two pull requests and just started using the terms directly.

Note that HGNC also has a more broad category "locus group" which is subsumed by "locus type". We don't need either of them now, so this PR removes the annotations there.

## Depends on

- https://github.com/The-Sequence-Ontology/SO-Ontologies/pull/668
- https://github.com/The-Sequence-Ontology/SO-Ontologies/pull/667