### PR TITLE
Improve MeSH xref processing

### DIFF
--- a/src/pyobo/sources/mesh.py
+++ b/src/pyobo/sources/mesh.py
@@ -131,7 +131,14 @@ def get_terms(version: str, *, force: bool = False) -> Iterable[Term]:
             for term in concept["terms"]:
                 synonyms.add(term["name"])
             for xref_prefix, xref_identifier in concept.get("xrefs", []):
-                xrefs.append(Reference(prefix=xref_prefix, identifier=xref_identifier))
+                try:
+                    xref = Reference(prefix=xref_prefix, identifier=xref_identifier)
+                except ValueError:
+                    tqdm.write(
+                        f"[mesh:{identifier}] has invalid xref {xref_prefix}:{xref_identifier}"
+                    )
+                else:
+                    xrefs.append(xref)
 
         mesh_id_to_term[identifier] = Term(
             definition=definition,


### PR DESCRIPTION
Motivated by #463 

This adds a try/except for invalid identifiers to support older versions of MeSH (e.g., from 2018) that result in a few issues like:

```
[C437863] invalid identifier for ec: 3.4.-21
[C056074] invalid identifier for ec: 3.4.23.20-30
```