### PR TITLE
Enable skipping maintainer annotations

### DIFF
--- a/src/pyobo/sources/hgnc/hgnc.py
+++ b/src/pyobo/sources/hgnc/hgnc.py
@@ -210,6 +210,7 @@ class HGNCGetter(Obo):
         for so_id in sorted(set(LOCUS_TYPE_TO_SO.values()))
         if so_id
     ]
+    skip_maintainers = True
 
     def iter_terms(self, force: bool = False) -> Iterable[Term]:
         """Iterate over terms in the ontology."""
@@ -342,6 +343,8 @@ def get_terms(version: str | None = None, force: bool = False) -> Iterable[Term]
                 term.append_exact_match(
                     Reference(prefix="iuphar.ligand", identifier=iuphar[len("ligandId:") :])
                 )
+            elif iuphar.startswith("HGNC:"):
+                pass
             else:
                 tqdm.write(f"[hgnc:{identifier}] unhandled IUPHAR: {iuphar}")
 


### PR DESCRIPTION
This PR enables adding `skip_maintainers = True` to an OBO converter class to turn off outputting ontology-level maintainer annotations. 

This supports the HGNC use case, where the maintainers asked that they are not explicitly listed on the PyOBO third-party ontology conversion because they don't want it to be confused for them endorsing the product.

Related discussion on how to best show this attribution on EBI OLS: https://github.com/EBISPOT/ols4/issues/1025