### PR TITLE
Update relations in ROR source

### DIFF
--- a/src/pyobo/sources/ror.py
+++ b/src/pyobo/sources/ror.py
@@ -16,11 +16,11 @@ from pyobo.struct import Obo, Reference, Term
 from pyobo.struct.struct import CHARLIE_TERM, HUMAN_TERM, PYOBO_INJECTED, acronym
 from pyobo.struct.typedef import (
     has_homepage,
-    has_part,
     has_predecessor,
+    has_suborganization,
     has_successor,
+    is_suborganization_of,
     located_in,
-    part_of,
     see_also,
 )
 
@@ -34,12 +34,13 @@ PREFIX = "ror"
 
 # Constants
 ORG_CLASS = Reference(prefix="OBI", identifier="0000245", name="organization")
+ORG_ORG_CLASS = Reference(prefix="org", identifier="Organization", name="Organization")
 CITY_CLASS = Reference(prefix="ENVO", identifier="00000856", name="city")
 
 RMAP = {
     "related": see_also,
-    "child": has_part,
-    "parent": part_of,
+    "child": has_suborganization,
+    "parent": is_suborganization_of,
     "predecessor": has_predecessor,
     "successor": has_successor,
     "located in": located_in,
@@ -60,6 +61,7 @@ class RORGetter(Obo):
     typedefs = [has_homepage, *RMAP.values()]
     synonym_typedefs = [acronym]
     root_terms = [CITY_CLASS, ORG_CLASS]
+    hierarchy_typedefs = [is_suborganization_of.reference]
 
     def __post_init__(self) -> None:
         self.data_version = ror_downloader.get_version_info(download=False).version
@@ -69,7 +71,7 @@ class RORGetter(Obo):
         """Iterate over terms in the ontology."""
         yield CHARLIE_TERM
         yield HUMAN_TERM
-        yield Term(reference=ORG_CLASS)
+        yield Term(reference=ORG_CLASS).append_exact_match(ORG_ORG_CLASS)
         yield Term(reference=CITY_CLASS)
         yield from ROR_ORGANIZATION_TYPE_TO_OBI.values()
         yield from iterate_ror_terms(force=force)
@@ -101,7 +103,9 @@ def iterate_ror_terms(*, force: bool = False) -> Iterable[Term]:
     unhandled_xref_prefixes: set[str] = set()
 
     seen_geonames_references = set()
-    for record in tqdm(records, unit_scale=True, unit="record", desc=f"{PREFIX} v{status.version}"):
+    for record in tqdm(
+        records, unit_scale=True, unit="record", desc=f"parsing {PREFIX} v{status.version}"
+    ):
         identifier = record.id.removeprefix("https://ror.org/")
 
         primary_name = record.get_preferred_label()

--- a/src/pyobo/sources/ror.py
+++ b/src/pyobo/sources/ror.py
@@ -12,10 +12,12 @@ from pydantic import ValidationError
 from ror_downloader import OrganizationType
 from tqdm.auto import tqdm
 
+from pyobo import Annotation
 from pyobo.struct import Obo, Reference, Term
 from pyobo.struct.struct import CHARLIE_TERM, HUMAN_TERM, PYOBO_INJECTED, acronym
 from pyobo.struct.typedef import (
     has_homepage,
+    has_ontology_hierarchy_predicate,
     has_predecessor,
     has_suborganization,
     has_successor,
@@ -61,7 +63,9 @@ class RORGetter(Obo):
     typedefs = [has_homepage, *RMAP.values()]
     synonym_typedefs = [acronym]
     root_terms = [CITY_CLASS, ORG_CLASS]
-    hierarchy_typedefs = [is_suborganization_of.reference]
+    property_values = [
+        Annotation(has_ontology_hierarchy_predicate.reference, is_suborganization_of.reference)
+    ]
 
     def __post_init__(self) -> None:
         self.data_version = ror_downloader.get_version_info(download=False).version

--- a/src/pyobo/struct/typedef.py
+++ b/src/pyobo/struct/typedef.py
@@ -52,6 +52,7 @@ __all__ = [
     "has_smiles",
     "has_source",
     "has_start_date",
+    "has_suborganization",
     "has_successor",
     "has_taxonomy_rank",
     "is_a",
@@ -60,6 +61,7 @@ __all__ = [
     "is_defined_by",
     "is_inverse_agonist_of",
     "is_mentioned_by",
+    "is_suborganization_of",
     "located_in",
     "mapping_has_confidence",
     "mapping_has_justification",
@@ -286,6 +288,9 @@ has_output = TypeDef.from_triple(prefix=RO_PREFIX, identifier="0002234", name="h
 
 has_successor = TypeDef.from_triple(prefix="BFO", identifier="0000063", name="has successor")
 has_predecessor = TypeDef.from_triple(prefix="BFO", identifier="0000062", name="has predecessor")
+
+has_suborganization = TypeDef(reference=v.has_suborganization)
+is_suborganization_of = TypeDef(reference=v.is_suborganization_of)
 
 gene_product_enables = TypeDef(
     reference=Reference(prefix="RO", identifier="0018042", name="has gene product that enables"),

--- a/src/pyobo/struct/vocabulary.py
+++ b/src/pyobo/struct/vocabulary.py
@@ -104,6 +104,9 @@ has_repository = Reference(prefix="doap", identifier="repository", name="has rep
 has_mailing_list = Reference(prefix="doap", identifier="mailing-list", name="has mailing list")
 has_maintainer = Reference(prefix="doap", identifier="maintainer", name="has maintainer")
 
+has_suborganization = _c(_v.has_suborganization)
+is_suborganization_of = _c(_v.is_suborganization_of)
+
 has_part = Reference(prefix=BFO_PREFIX, identifier="0000051", name="has part")
 part_of = Reference(prefix=BFO_PREFIX, identifier="0000050", name="part of")
 orthologous = Reference(


### PR DESCRIPTION
This PR updates the relations used to link organizations inspired by @tgroth-bsci in https://github.com/tgroth-bsci/rorio-org

It also explicitly annotates `org:subOrganizationOf` as the hierarchical property, which is possible as of https://github.com/information-artifact-ontology/ontology-metadata/pull/193. This would need to get propagated to the EBI's OLS configuration to incorporate. I don't think Protege makes use of this (yet)