### PR TITLE
Refactor annotating literals

### DIFF
--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -6,6 +6,8 @@ import datetime
 import logging
 from collections import Counter
 from collections.abc import Iterable, Sequence
+from datetime import date as date_cls
+from datetime import datetime as datetime_cls
 from typing import Any, NamedTuple
 
 import bioregistry
@@ -14,6 +16,7 @@ import dateutil.parser
 import pytz
 from bioregistry import NormalizedNamableReference as Reference
 from curies import ReferenceTuple
+from curies import vocabulary as v
 from curies.preprocessing import BlocklistError
 
 from ..identifier_utils import (
@@ -304,9 +307,7 @@ def _parse_reference_or_uri_literal(
             return None
 
 
-unspecified_matching = Reference(
-    prefix="semapv", identifier="UnspecifiedMatching", name="unspecified matching process"
-)
+unspecified_matching = Reference.from_reference(v.unspecified_matching_process)
 
 
 class OBOLiteral(NamedTuple):
@@ -319,44 +320,53 @@ class OBOLiteral(NamedTuple):
     @classmethod
     def string(cls, value: str, *, language: str | None = None) -> OBOLiteral:
         """Get a string literal."""
-        return cls(value, curies.Reference(prefix="xsd", identifier="string"), language)
+        return cls(value, v.xsd_string, language)
 
     @classmethod
     def boolean(cls, value: bool) -> OBOLiteral:
         """Get a boolean literal."""
-        return cls(str(value).lower(), curies.Reference(prefix="xsd", identifier="boolean"), None)
+        return cls(str(value).lower(), v.xsd_boolean, None)
 
     @classmethod
     def decimal(cls, value: float) -> OBOLiteral:
         """Get a decimal literal."""
-        return cls(str(value), curies.Reference(prefix="xsd", identifier="decimal"), None)
+        return cls(str(value), v.xsd_decimal, None)
 
     @classmethod
     def float(cls, value: float) -> OBOLiteral:
         """Get a float literal."""
-        return cls(str(value), curies.Reference(prefix="xsd", identifier="float"), None)
+        return cls(str(value), v.xsd_float, None)
 
     @classmethod
     def integer(cls, value: int | str) -> OBOLiteral:
         """Get a integer literal."""
-        return cls(str(int(value)), curies.Reference(prefix="xsd", identifier="integer"), None)
+        return cls(str(int(value)), v.xsd_integer, None)
 
     @classmethod
     def year(cls, value: int | str) -> OBOLiteral:
         """Get a year (gYear) literal."""
-        return cls(str(int(value)), curies.Reference(prefix="xsd", identifier="gYear"), None)
+        return cls(str(int(value)), v.xsd_year, None)
 
     @classmethod
     def uri(cls, uri: str) -> OBOLiteral:
         """Get a string literal for a URI."""
-        return cls(uri, curies.Reference(prefix="xsd", identifier="anyURI"), None)
+        return cls(uri, v.xsd_uri, None)
 
     @classmethod
-    def datetime(cls, dt: datetime.datetime | str) -> OBOLiteral:
+    def datetime(cls, dt: datetime_cls | str) -> OBOLiteral:
         """Get a datetime literal."""
         if isinstance(dt, str):
             dt = _parse_datetime(dt)
-        return cls(dt.isoformat(), curies.Reference(prefix="xsd", identifier="dateTime"), None)
+        return cls(dt.isoformat(), v.xsd_datetime, None)
+
+    @classmethod
+    def date(cls, dt: datetime_cls | date_cls | str) -> OBOLiteral:
+        """Get a datetime literal."""
+        if isinstance(dt, str):
+            dt = _parse_datetime(dt)
+        if isinstance(dt, datetime.datetime):
+            dt = dt.date()
+        return cls(dt.isoformat(), v.xsd_date, None)
 
 
 def _parse_datetime(dd: str) -> datetime.datetime:

--- a/src/pyobo/struct/reference.py
+++ b/src/pyobo/struct/reference.py
@@ -363,8 +363,8 @@ class OBOLiteral(NamedTuple):
     def date(cls, dt: datetime_cls | date_cls | str) -> OBOLiteral:
         """Get a datetime literal."""
         if isinstance(dt, str):
-            dt = _parse_datetime(dt)
-        if isinstance(dt, datetime.datetime):
+            dt = datetime.date.fromisoformat(dt)
+        elif isinstance(dt, datetime.datetime):
             dt = dt.date()
         return cls(dt.isoformat(), v.xsd_date, None)
 

--- a/src/pyobo/struct/struct_utils.py
+++ b/src/pyobo/struct/struct_utils.py
@@ -501,6 +501,16 @@ class Stanza(Referenced, HasReferencesMixin):
         """Append a datetime annotation."""
         return self.annotate_literal(prop, OBOLiteral.datetime(value), annotations=annotations)
 
+    def annotate_date(
+        self,
+        prop: ReferenceHint,
+        value: datetime.datetime | datetime.date | str,
+        *,
+        annotations: Iterable[Annotation] | None = None,
+    ) -> Self:
+        """Append a date annotation."""
+        return self.annotate_literal(prop, OBOLiteral.date(value), annotations=annotations)
+
     def _iterate_obo_properties(
         self,
         *,
@@ -976,7 +986,7 @@ def _iterate_obo_relations(
                     end = reference_escape(value, ontology_prefix=ontology_prefix)
                     name = value.name
                 case _:
-                    raise TypeError(f"got unexpected value: {values}")
+                    raise TypeError(f"got unexpected type {type(values)} with value: {values}")
             end += _get_obo_trailing_modifiers(
                 predicate, value, annotations, ontology_prefix=ontology_prefix
             )

--- a/tests/test_struct/test_obo/test_struct_term.py
+++ b/tests/test_struct/test_obo/test_struct_term.py
@@ -771,6 +771,26 @@ class TestTerm(unittest.TestCase):
             typedefs={RO_DUMMY.pair: RO_DUMMY},
         )
 
+    def test_12_property_date(self) -> None:
+        """Test emitting property literals that were annotated as a date."""
+        term = Term(reference=LYSINE_DEHYDROGENASE_ACT)
+        term.annotate_date(RO_DUMMY, "1993-01-01")
+        self.assert_obo_stanza(
+            term,
+            obo="""\
+                [Term]
+                id: GO:0050069
+                name: lysine dehydrogenase activity
+                property_value: RO:1234567 "1993-01-01" xsd:date
+            """,
+            ofn="""\
+                Declaration(Class(GO:0050069))
+                AnnotationAssertion(rdfs:label GO:0050069 "lysine dehydrogenase activity")
+                AnnotationAssertion(RO:1234567 GO:0050069 "1993-01-01"^^xsd:date)
+            """,
+            typedefs={RO_DUMMY.pair: RO_DUMMY},
+        )
+
     def test_12_property_object(self) -> None:
         """Test emitting property literals."""
         term = Term(reference=LYSINE_DEHYDROGENASE_ACT)


### PR DESCRIPTION
this PR reuses XSD terms from `curies.vocabulary` and adds support for XSD date (as opposed to datetimes)