### PR TITLE
Remove explicit depedency group for embiggen

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,8 +169,8 @@ pykeen = [
     "scipy>=1.17.1",
 ]
 grape = [
-    "embiggen<0.11.97",
-    "ensmallen<0.8.101",
+    # "embiggen<0.11.97",
+    # "ensmallen<0.8.101",
 ]
 
 # see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#dependencies-optional-dependencies


### PR DESCRIPTION
uv doesn't appear to be properly handling the now quarantined releases of embiggen and ensmallen.

I'm going to remove them as explicit dependencies now, since I can't lock other projects at the moment.

tracking on https://github.com/monarch-initiative/embiggen/issues/305