### PR TITLE
Update caching of version metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "humanize",
     "tabulate",
     "cachier",
-    "pystow>=0.8.16",
+    "pystow>=0.8.17",
     "bioversions>=0.10.45",
     "bioregistry>=0.13.59",
     "ssslm>=0.2.0",

--- a/src/pyobo/api/metadata.py
+++ b/src/pyobo/api/metadata.py
@@ -2,15 +2,15 @@
 
 import logging
 from functools import lru_cache
-from typing import Any, cast
 
+from pystow.cache import CachedPydantic
 from typing_extensions import Unpack
 
 from .utils import get_version_from_kwargs
 from ..constants import GetOntologyKwargs, check_should_force
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
-from ..utils.cache import cached_json
+from ..struct.struct import VersionMetadata
 from ..utils.path import CacheArtifact, get_cache_path
 
 __all__ = [
@@ -22,14 +22,14 @@ logger = logging.getLogger(__name__)
 
 @lru_cache
 @wrap_norm_prefix
-def get_metadata(prefix: str, **kwargs: Unpack[GetOntologyKwargs]) -> dict[str, Any]:
+def get_metadata(prefix: str, **kwargs: Unpack[GetOntologyKwargs]) -> VersionMetadata:
     """Get metadata for the ontology."""
     version = get_version_from_kwargs(prefix, kwargs)
     path = get_cache_path(prefix, CacheArtifact.metadata, version=version)
 
-    @cached_json(path=path, force=check_should_force(kwargs))
-    def _get_json() -> dict[str, Any]:
+    @CachedPydantic(path=path, force=check_should_force(kwargs), model_cls=VersionMetadata)
+    def _inner() -> VersionMetadata:
         ontology = get_ontology(prefix, **kwargs)
         return ontology.get_metadata()
 
-    return cast(dict[str, Any], _get_json())
+    return _inner()

--- a/src/pyobo/api/metadata.py
+++ b/src/pyobo/api/metadata.py
@@ -6,12 +6,11 @@ from functools import lru_cache
 from pystow.cache import CachedPydantic
 from typing_extensions import Unpack
 
-from .utils import get_version_from_kwargs
 from ..constants import GetOntologyKwargs, check_should_force
 from ..getters import get_ontology
 from ..identifier_utils import wrap_norm_prefix
-from ..struct.struct import VersionMetadata
 from ..utils.path import CacheArtifact, get_cache_path
+from ..utils.ver import VersionMetadata, get_version_from_kwargs
 
 __all__ = [
     "get_metadata",

--- a/src/pyobo/api/utils.py
+++ b/src/pyobo/api/utils.py
@@ -1,21 +1,18 @@
 """Utilities for high-level API."""
 
-import json
-import logging
-import os
 import warnings
-from functools import lru_cache
-from typing import Literal, cast, overload
 
-import bioversions
 import curies
 from bioregistry import NormalizedNamableReference as Reference
 from curies import ReferenceTuple
-from pystow.utils import read_pydantic_json
 
-from ..constants import GetOntologyKwargs
-from ..struct.struct import VersionMetadata
-from ..utils.path import CacheArtifact, prefix_directory_join
+from ..utils.ver import (
+    VersionError,
+    get_version,
+    get_version_from_kwargs,
+    get_version_pins,
+    pin_version,
+)
 
 __all__ = [
     "VersionError",
@@ -24,121 +21,6 @@ __all__ = [
     "get_version_pins",
     "pin_version",
 ]
-
-logger = logging.getLogger(__name__)
-
-
-class VersionError(ValueError):
-    """A catch-all for version getting failure."""
-
-
-# docstr-coverage:excused `overload`
-@overload
-def get_version(prefix: str, *, strict: Literal[True] = ...) -> str: ...
-
-
-# docstr-coverage:excused `overload`
-@overload
-def get_version(prefix: str, *, strict: Literal[False] = ...) -> str | None: ...
-
-
-@lru_cache(None)
-def get_version(prefix: str, *, strict: bool = False) -> str | None:
-    """Get the version for the resource, if available.
-
-    :param prefix: the resource name
-    :param strict: Should an error be raised if no version is available?
-
-    :returns: The version if available else None
-
-    :raises VersionError: if the version is not available and strict mode is enabled
-    """
-    # Prioritize loaded environment variable PYOBO_VERSION_PINS dictionary
-    if version := get_version_pins().get(prefix):
-        return version
-
-    try:
-        version = bioversions.get_version(prefix)
-    except KeyError:
-        pass  # this prefix isn't available from bioversions
-    except Exception as e:
-        msg = f"[{prefix}] could not get version from bioversions"
-        if strict:
-            raise ValueError(msg) from e
-        logger.warning(msg)
-        raise
-    else:
-        if version:
-            return version
-
-    metadata_path = prefix_directory_join(
-        prefix, name=CacheArtifact.metadata.value, ensure_exists=False
-    )
-    if metadata_path.exists():
-        metadata = read_pydantic_json(metadata_path, VersionMetadata)
-        if metadata.version:
-            return metadata.version
-
-    if strict:
-        raise ValueError
-
-    return None
-
-
-def get_version_from_kwargs(prefix: str, kwargs: GetOntologyKwargs) -> str | None:
-    """Get the version for the resource based on generic keyword arguments."""
-    if version := kwargs.get("version"):
-        return version
-    # it's okay if none gets returned after getting this far, we at least tried
-    return get_version(prefix, strict=False)
-
-
-def pin_version(prefix: str, version: str) -> None:
-    """Pin the version."""
-    get_version_pins()[prefix] = version
-
-
-@lru_cache(1)
-def get_version_pins() -> dict[str, str]:
-    """Retrieve user-defined resource version pins.
-
-    To set your own resource pins, set your machine's environmental variable
-    "PYOBO_VERSION_PINS" to a JSON string containing string resource prefixes as keys
-    and string versions of their respective resource as values. Constraining version
-    pins will make PyOBO rely on cached versions of a resource. A user might want to pin
-    resource versions that are used by PyOBO due to the fact that PyOBO will download
-    the latest version of a resource if it is not pinned. This downloading process can
-    lead to a slow-down in downstream applications that rely on PyOBO.
-    """
-    version_pins_str = os.getenv("PYOBO_VERSION_PINS")
-    if not version_pins_str:
-        return {}
-
-    try:
-        version_pins = cast(dict[str, str], json.loads(version_pins_str))
-    except ValueError as e:
-        logger.error(
-            "The value for the environment variable PYOBO_VERSION_PINS "
-            "must be a valid JSON string: %s",
-            e,
-        )
-        return {}
-
-    for prefix, version in list(version_pins.items()):
-        if not isinstance(prefix, str) or not isinstance(version, str):
-            logger.error(f"The prefix:{prefix} and version:{version} name must both be strings")
-            del version_pins[prefix]
-
-    logger.debug(
-        f"These are the resource versions that are pinned.\n"
-        f"{version_pins}. "
-        f"\nPyobo will download the latest version of a resource if it's "
-        f"not pinned.\nIf you want to use a specific version of a "
-        f"resource, edit your PYOBO_VERSION_PINS environmental "
-        f"variable which is a JSON string to include a prefix and version "
-        f"name."
-    )
-    return version_pins
 
 
 def _get_pi(

--- a/src/pyobo/api/utils.py
+++ b/src/pyobo/api/utils.py
@@ -11,9 +11,11 @@ import bioversions
 import curies
 from bioregistry import NormalizedNamableReference as Reference
 from curies import ReferenceTuple
+from pystow.utils import read_pydantic_json
 
 from ..constants import GetOntologyKwargs
-from ..utils.path import prefix_directory_join
+from ..struct.struct import VersionMetadata
+from ..utils.path import CacheArtifact, prefix_directory_join
 
 __all__ = [
     "VersionError",
@@ -69,12 +71,13 @@ def get_version(prefix: str, *, strict: bool = False) -> str | None:
         if version:
             return version
 
-    metadata_json_path = prefix_directory_join(prefix, name="metadata.json", ensure_exists=False)
-    if metadata_json_path.exists():
-        data = json.loads(metadata_json_path.read_text())
-        version = cast(str | None, data["version"])
-        if version:
-            return version
+    metadata_path = prefix_directory_join(
+        prefix, name=CacheArtifact.metadata.value, ensure_exists=False
+    )
+    if metadata_path.exists():
+        metadata = read_pydantic_json(metadata_path, VersionMetadata)
+        if metadata.version:
+            return metadata.version
 
     if strict:
         raise ValueError

--- a/src/pyobo/cli/database.py
+++ b/src/pyobo/cli/database.py
@@ -152,10 +152,14 @@ def metadata(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs]) ->
     def _iter_metadata_internal(
         **kwargs: Unpack[IterHelperHelperDict],
     ) -> Iterable[tuple[str, str, str, bool]]:
-        for prefix, data in iter_helper_helper(get_metadata, **kwargs):
-            version = data["version"]
-            logger.debug(f"[{prefix}] using version {version}")
-            yield prefix, version, data["date"], bioregistry.is_deprecated(prefix)
+        for prefix, metadata in iter_helper_helper(get_metadata, **kwargs):
+            logger.debug(f"[{prefix}] using version {metadata.version}")
+            yield (
+                prefix,
+                metadata.version,
+                metadata.date.isoformat() if metadata.date else "",
+                bioregistry.is_deprecated(prefix),
+            )
 
     it = _iter_metadata_internal(**kwargs)
     db_output_helper(

--- a/src/pyobo/cli/database.py
+++ b/src/pyobo/cli/database.py
@@ -153,10 +153,12 @@ def metadata(zenodo: bool, directory: Path, **kwargs: Unpack[DatabaseKwargs]) ->
         **kwargs: Unpack[IterHelperHelperDict],
     ) -> Iterable[tuple[str, str, str, bool]]:
         for prefix, metadata in iter_helper_helper(get_metadata, **kwargs):
+            if metadata.version is None and metadata.date is None:
+                continue
             logger.debug(f"[{prefix}] using version {metadata.version}")
             yield (
                 prefix,
-                metadata.version,
+                metadata.version or "",
                 metadata.date.isoformat() if metadata.date else "",
                 bioregistry.is_deprecated(prefix),
             )

--- a/src/pyobo/cli/lookup.py
+++ b/src/pyobo/cli/lookup.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import inspect
-import json
 from collections.abc import Callable, Iterable, Mapping
 from typing import TYPE_CHECKING, ParamSpec, TypeVar
 
@@ -113,7 +112,7 @@ def metadata(prefix: str, **kwargs: Unpack[GetOntologyKwargs]) -> None:
     from ..api import get_metadata
 
     metadata = get_metadata(prefix, **kwargs)
-    click.echo(json.dumps(metadata, indent=2))
+    click.echo(metadata.model_dump_json(indent=2))
 
 
 @lookup_annotate

--- a/src/pyobo/getters.py
+++ b/src/pyobo/getters.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import datetime
-import json
 import logging
 import pathlib
 import subprocess
@@ -22,6 +21,8 @@ import click
 import pystow.utils
 import requests.exceptions
 from bioregistry.schema import AnnotatedURL, RDFFormat
+from pydantic import BaseModel
+from pystow.utils import write_pydantic_json
 from tabulate import tabulate
 from tqdm.auto import tqdm
 from typing_extensions import Unpack
@@ -551,17 +552,13 @@ def db_output_helper(
             detailed_summary_writer.writerows((*keys, v) for keys, v in c_detailed.most_common())
         rv.append(("Summary (Detailed)", db_summary_detailed_path))
 
-    with open(db_metadata_path, "w") as file:
-        json.dump(
-            {
-                "version": get_version(),
-                "git_hash": get_git_hash(),
-                "date": datetime.datetime.now().strftime("%Y-%m-%d-%H-%M"),
-                "count": sum(c.values()),
-            },
-            file,
-            indent=2,
-        )
+    database_metadata = DatabaseMetadata(
+        version=get_version(),
+        git_hash=get_git_hash(),
+        date=datetime.datetime.now(),
+        count=sum(c.values()),
+    )
+    write_pydantic_json(database_metadata, db_metadata_path, indent=2)
 
     elapsed = time.time() - start
     click.secho(f"\nWrote the following files in {elapsed:.1f} seconds\n", fg="green")
@@ -572,3 +569,12 @@ def db_output_helper(
     click.echo()
 
     return [path for _, path in rv]
+
+
+class DatabaseMetadata(BaseModel):
+    """A model for database metadata."""
+
+    version: str  # PyOBO version
+    git_hash: str  # PyOBO git hash
+    date: datetime.datetime
+    count: int

--- a/src/pyobo/sources/hgnc/hgncgenefamily.py
+++ b/src/pyobo/sources/hgnc/hgncgenefamily.py
@@ -71,7 +71,7 @@ def get_gene_family_terms(*, version: str | None = None, force: bool = False) ->
     yield from terms
 
 
-def _get_terms_helper(version: str, force: bool = False) -> Iterable[Term]:
+def _get_terms_helper(version: str, *, force: bool = False) -> Iterable[Term]:
     alias_df = ensure_df(
         GENE_GROUP_PREFIX, url=FAMILIES_ALIAS_URL, force=force, sep=",", version=version
     )

--- a/src/pyobo/sources/mesh.py
+++ b/src/pyobo/sources/mesh.py
@@ -12,11 +12,12 @@ from typing import Any
 import bioversions
 from lxml import etree
 from lxml.etree import Element
+from pystow.cache import CachedJSON
 from tqdm.auto import tqdm
 
 from pyobo.identifier_utils import standardize_ec
 from pyobo.struct import Obo, Reference, Synonym, Term, default_reference
-from pyobo.utils.cache import cached_json, cached_mapping
+from pyobo.utils.cache import cached_mapping
 from pyobo.utils.path import ensure_path, prefix_directory_join
 
 __all__ = [
@@ -173,7 +174,7 @@ def ensure_mesh_descriptors(
 ) -> list[Mapping[str, Any]]:
     """Get the parsed MeSH dictionary, and cache it if it wasn't already."""
 
-    @cached_json(path=prefix_directory_join(PREFIX, name="desc.json", version=version), force=force)
+    @CachedJSON(path=prefix_directory_join(PREFIX, name="desc.json", version=version), force=force)
     def _inner() -> list[dict[str, Any]]:
         path = ensure_path(PREFIX, url=get_descriptors_url(version), version=version)
         root = _get_xml_root(path)
@@ -199,7 +200,7 @@ def get_supplemental_url(version: str) -> str:
 def ensure_mesh_supplemental_records(version: str, force: bool = False) -> list[Mapping[str, Any]]:
     """Get the parsed MeSH dictionary, and cache it if it wasn't already."""
 
-    @cached_json(path=prefix_directory_join(PREFIX, name="supp.json", version=version), force=force)
+    @CachedJSON(path=prefix_directory_join(PREFIX, name="supp.json", version=version), force=force)
     def _inner() -> list[dict[str, Any]]:
         path = ensure_path(PREFIX, url=get_supplemental_url(version), version=version)
         root = _get_xml_root(path)

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -28,7 +28,8 @@ import sssom_pydantic
 from curies import Converter, ReferenceTuple
 from curies import vocabulary as _cv
 from more_click import force_option, verbose_option
-from pystow.utils import safe_open
+from pydantic import BaseModel
+from pystow.utils import safe_open, write_pydantic_json
 from tqdm.auto import tqdm
 
 from . import vocabulary as v
@@ -263,6 +264,13 @@ default_synonym_typedefs: dict[ReferenceTuple, SynonymTypeDef] = {
     acronym.pair: acronym,
     uk_spelling.pair: uk_spelling,
 }
+
+
+class VersionMetadata(BaseModel):
+    """A model for version metadata information."""
+
+    version: str
+    date: datetime.date | None = None
 
 
 @dataclass
@@ -1329,8 +1337,7 @@ class Obo:
         metadata = self.get_metadata()
         for path in (self._root_metadata_path, self._get_cache_path(CacheArtifact.metadata)):
             logger.debug("[%s] caching metadata to %s", self._prefix_version, path)
-            with safe_open(path, operation="write") as file:
-                json.dump(metadata, file, indent=2)
+            write_pydantic_json(metadata, path, indent=2)
 
     def write_prefix_map(self) -> None:
         """Write a prefix map file that includes all prefixes used in this ontology."""
@@ -1588,12 +1595,9 @@ class Obo:
         )
         return rv
 
-    def get_metadata(self) -> dict[str, Any]:
+    def get_metadata(self) -> VersionMetadata:
         """Get metadata."""
-        return {
-            "version": self.data_version,
-            "date": self.date and self.date.isoformat(),
-        }
+        return VersionMetadata(version=self.data_version, date=self.date)
 
     def iterate_references(self, *, use_tqdm: bool = False) -> Iterable[Reference]:
         """Iterate over identifiers."""

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -28,7 +28,6 @@ import sssom_pydantic
 from curies import Converter, ReferenceTuple
 from curies import vocabulary as _cv
 from more_click import force_option, verbose_option
-from pydantic import BaseModel
 from pystow.utils import safe_open, write_pydantic_json
 from tqdm.auto import tqdm
 
@@ -62,7 +61,6 @@ from .struct_utils import (
     _tag_property_targets,
 )
 from .utils import _boolean_tag, obo_escape_slim
-from ..api.utils import get_version
 from ..constants import (
     BUILD_SUBDIRECTORY_NAME,
     DATE_FORMAT,
@@ -82,6 +80,7 @@ from ..utils.path import (
     get_relation_cache_path,
     prefix_directory_join,
 )
+from ..utils.ver import VersionMetadata, get_version
 from ..version import get_version as get_pyobo_version
 
 __all__ = [
@@ -264,13 +263,6 @@ default_synonym_typedefs: dict[ReferenceTuple, SynonymTypeDef] = {
     acronym.pair: acronym,
     uk_spelling.pair: uk_spelling,
 }
-
-
-class VersionMetadata(BaseModel):
-    """A model for version metadata information."""
-
-    version: str | None = None
-    date: datetime.date | None = None
 
 
 @dataclass

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -269,7 +269,7 @@ default_synonym_typedefs: dict[ReferenceTuple, SynonymTypeDef] = {
 class VersionMetadata(BaseModel):
     """A model for version metadata information."""
 
-    version: str
+    version: str | None = None
     date: datetime.date | None = None
 
 
@@ -1267,7 +1267,7 @@ class Obo:
 
     @property
     def _root_metadata_path(self) -> Path:
-        return prefix_directory_join(self.ontology, name="metadata.json")
+        return prefix_directory_join(self.ontology, name=CacheArtifact.metadata.value)
 
     @property
     def _obo_path(self) -> Path:

--- a/src/pyobo/utils/cache.py
+++ b/src/pyobo/utils/cache.py
@@ -10,7 +10,6 @@ import networkx as nx
 from pystow.cache import Cached
 from pystow.cache import CachedCollection as cached_collection  # noqa:N813
 from pystow.cache import CachedDataFrame as cached_df  # noqa:N813
-from pystow.cache import CachedJSON as cached_json  # noqa:N813
 from pystow.cache import CachedPickle as cached_pickle  # noqa:N813
 from pystow.utils import safe_open
 
@@ -22,7 +21,6 @@ __all__ = [
     # implemented here
     "cached_graph",
     # from pystow
-    "cached_json",
     "cached_mapping",
     "cached_multidict",
     "cached_pickle",

--- a/src/pyobo/utils/cache.py
+++ b/src/pyobo/utils/cache.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from abc import ABC
 from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Generic, TypeVar
@@ -31,7 +32,7 @@ logger = logging.getLogger(__name__)
 X = TypeVar("X")
 
 
-class _CachedMapping(Cached[X], Generic[X]):
+class _CachedMapping(Cached[X], Generic[X], ABC):
     """A cache for simple mappings."""
 
     def __init__(

--- a/src/pyobo/utils/ver.py
+++ b/src/pyobo/utils/ver.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "VersionError",
+    "VersionMetadata",
     "get_version",
     "get_version_from_kwargs",
     "get_version_pins",
@@ -29,11 +30,6 @@ __all__ = [
 
 class VersionError(ValueError):
     """A catch-all for version getting failure."""
-
-
-# docstr-coverage:excused `overload`
-@overload
-def get_version(prefix: str) -> str | None: ...
 
 
 # docstr-coverage:excused `overload`

--- a/src/pyobo/utils/ver.py
+++ b/src/pyobo/utils/ver.py
@@ -1,0 +1,152 @@
+"""Version utils."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import os
+from functools import lru_cache
+from typing import Literal, cast, overload
+
+import bioversions
+from pydantic import BaseModel
+from pystow.utils import read_pydantic_json
+
+from .path import CacheArtifact, prefix_directory_join
+from ..constants import GetOntologyKwargs
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "VersionError",
+    "get_version",
+    "get_version_from_kwargs",
+    "get_version_pins",
+    "pin_version",
+]
+
+
+class VersionError(ValueError):
+    """A catch-all for version getting failure."""
+
+
+# docstr-coverage:excused `overload`
+@overload
+def get_version(prefix: str) -> str | None: ...
+
+
+# docstr-coverage:excused `overload`
+@overload
+def get_version(prefix: str, *, strict: Literal[True] = ...) -> str: ...
+
+
+# docstr-coverage:excused `overload`
+@overload
+def get_version(prefix: str, *, strict: Literal[False] = ...) -> str | None: ...
+
+
+@lru_cache(None)
+def get_version(prefix: str, *, strict: bool = False) -> str | None:
+    """Get the version for the resource, if available.
+
+    :param prefix: the resource name
+    :param strict: Should an error be raised if no version is available?
+
+    :returns: The version if available else None
+
+    :raises VersionError: if the version is not available and strict mode is enabled
+    """
+    # Prioritize loaded environment variable PYOBO_VERSION_PINS dictionary
+    if version := get_version_pins().get(prefix):
+        return version
+
+    try:
+        version = bioversions.get_version(prefix)
+    except (KeyError, ValueError):
+        pass  # this prefix isn't available from bioversions, or an error occurred during parsing
+    except Exception as e:
+        msg = f"[{prefix}] could not get version from bioversions"
+        if strict:
+            raise ValueError(msg) from e
+        logger.warning(msg)
+        raise
+    else:
+        if version:
+            return version
+
+    metadata_path = prefix_directory_join(
+        prefix, name=CacheArtifact.metadata.value, ensure_exists=False
+    )
+    if metadata_path.exists():
+        metadata = read_pydantic_json(metadata_path, VersionMetadata)
+        if metadata.version:
+            return metadata.version
+
+    if strict:
+        raise ValueError
+
+    return None
+
+
+def get_version_from_kwargs(prefix: str, kwargs: GetOntologyKwargs) -> str | None:
+    """Get the version for the resource based on generic keyword arguments."""
+    if version := kwargs.get("version"):
+        return version
+    # it's okay if none gets returned after getting this far, we at least tried
+    return get_version(prefix, strict=False)
+
+
+def pin_version(prefix: str, version: str) -> None:
+    """Pin the version."""
+    get_version_pins()[prefix] = version
+
+
+@lru_cache(1)
+def get_version_pins() -> dict[str, str]:
+    """Retrieve user-defined resource version pins.
+
+    To set your own resource pins, set your machine's environmental variable
+    "PYOBO_VERSION_PINS" to a JSON string containing string resource prefixes as keys
+    and string versions of their respective resource as values. Constraining version
+    pins will make PyOBO rely on cached versions of a resource. A user might want to pin
+    resource versions that are used by PyOBO due to the fact that PyOBO will download
+    the latest version of a resource if it is not pinned. This downloading process can
+    lead to a slow-down in downstream applications that rely on PyOBO.
+    """
+    version_pins_str = os.getenv("PYOBO_VERSION_PINS")
+    if not version_pins_str:
+        return {}
+
+    try:
+        version_pins = cast(dict[str, str], json.loads(version_pins_str))
+    except ValueError as e:
+        logger.error(
+            "The value for the environment variable PYOBO_VERSION_PINS "
+            "must be a valid JSON string: %s",
+            e,
+        )
+        return {}
+
+    for prefix, version in list(version_pins.items()):
+        if not isinstance(prefix, str) or not isinstance(version, str):
+            logger.error(f"The prefix:{prefix} and version:{version} name must both be strings")
+            del version_pins[prefix]
+
+    logger.debug(
+        f"These are the resource versions that are pinned.\n"
+        f"{version_pins}. "
+        f"\nPyobo will download the latest version of a resource if it's "
+        f"not pinned.\nIf you want to use a specific version of a "
+        f"resource, edit your PYOBO_VERSION_PINS environmental "
+        f"variable which is a JSON string to include a prefix and version "
+        f"name."
+    )
+    return version_pins
+
+
+class VersionMetadata(BaseModel):
+    """A model for version metadata information."""
+
+    version: str | None = None
+    date: datetime.date | None = None

--- a/tests/test_get_version.py
+++ b/tests/test_get_version.py
@@ -4,12 +4,12 @@ import os
 import unittest
 from unittest import mock
 
-from pyobo.api.utils import get_version, get_version_pins
 from pyobo.utils.misc import (
     _get_version_from_artifact,
     _prioritize_version,
     cleanup_version,
 )
+from pyobo.utils.ver import get_version, get_version_pins
 
 MOCK_PYOBO_VERSION_PINS = '{"ncbitaxon": "2024-07-03", "vo":"2024-04-09", "chebi":"235", "bfo":5}'
 FAULTY_MOCK_PYOBO_VERSION_PINS = "{'ncbitaxon': '2024-07-03'}"


### PR DESCRIPTION
- refactor metadata to be a pydantic model instead of a `dict[str, Any]`
- catch value errors from `get_version()`, which are now being thrown by OMIM since they put a captcha on their site