### PR TITLE
Add CLI for getting SSSOM

### DIFF
--- a/src/pyobo/api/xrefs.py
+++ b/src/pyobo/api/xrefs.py
@@ -2,7 +2,7 @@
 
 import logging
 import warnings
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from functools import lru_cache
 
 import bioregistry
@@ -112,10 +112,15 @@ def get_sssom_df(prefix: str | Obo, **kwargs: Unpack[GetOntologyKwargs]) -> pd.D
 
 
 def get_semantic_mappings(
-    prefix: str,
-    names: bool = False,
-    **kwargs: Unpack[GetOntologyKwargs],
+    prefix: str, **kwargs: Unpack[GetOntologyKwargs]
 ) -> list[SemanticMapping]:
+    """Get semantic mappings."""
+    return _get_sssom_getter(prefix, **kwargs)().mappings
+
+
+def _get_sssom_getter(
+    prefix: str, **kwargs: Unpack[GetOntologyKwargs]
+) -> Callable[[], sssom_pydantic.SemanticMappingPack]:
     """Get semantic mappings."""
     version = get_version_from_kwargs(prefix, kwargs)
 
@@ -138,10 +143,7 @@ def get_semantic_mappings(
             mappings=mappings, converter=converter, mapping_set=mapping_set
         )
 
-    mappings = _mapping_getter().mappings
-    if names:
-        raise NotImplementedError
-    return mappings
+    return _mapping_getter
 
 
 def get_mappings_df(

--- a/src/pyobo/cli/lookup.py
+++ b/src/pyobo/cli/lookup.py
@@ -103,6 +103,27 @@ def mappings(target: str | None, prefix: str, **kwargs: Unpack[GetOntologyKwargs
 
 @lookup_annotate
 @prefix_argument
+@click.option("--output", "-o")
+def sssom(prefix: str, output: str, **kwargs: Unpack[GetOntologyKwargs]) -> None:
+    """Get SSSOM for the given resource."""
+    import sys
+
+    import sssom_pydantic
+
+    from ..api.xrefs import _get_sssom_getter
+
+    mapping_pack = _get_sssom_getter(prefix, **kwargs)()
+
+    sssom_pydantic.write(
+        mapping_pack.mappings,
+        path=output or sys.stdout,
+        converter=mapping_pack.converter,
+        metadata=mapping_pack.mapping_set,
+    )
+
+
+@lookup_annotate
+@prefix_argument
 def metadata(prefix: str, **kwargs: Unpack[GetOntologyKwargs]) -> None:
     """Print the metadata for the given namespace."""
     from ..api import get_metadata


### PR DESCRIPTION
This PR adds an explicit CLI tool for writing full SSSOM. This shares an implementation with `pyobo lookup mappings` but also includes the full SSSOM metadata. Use it with:

```console
$ pyobo lookup sssom uberon -o uberon.sssom.tsv
```

alternatively, if `--output/-o` is not given, will write to STDOUT