### PR TITLE
Generalize `is_metadata_tag`

### DIFF
--- a/src/pyobo/constants.py
+++ b/src/pyobo/constants.py
@@ -28,6 +28,7 @@ __all__ = [
     "OntologyFormat",
     "OntologyPathPack",
     "SlimGetOntologyKwargs",
+    "TypeDefType",
     "check_should_cache",
     "check_should_force",
     "check_should_use_tqdm",
@@ -319,3 +320,7 @@ def get_semantic_mapping_metadata(
         confidence=confidence,
         version=version,
     )
+
+
+#: The type of a typedef.
+TypeDefType = Literal["object", "annotation", "data"]

--- a/src/pyobo/sources/civic_gene.py
+++ b/src/pyobo/sources/civic_gene.py
@@ -20,8 +20,8 @@ GENE = Term(reference=default_reference(PREFIX, "gene", name="gene"))
 FACTOR = Term(reference=default_reference(PREFIX, "factor", name="factor"))
 FUSION = Term(reference=default_reference(PREFIX, "fusion", name="fusion"))
 REGION = Term(reference=default_reference(PREFIX, "region", name="region"))
-HAS_3P = TypeDef.default(PREFIX, "has3p", name="has 3' gene", is_metadata_tag=False)
-HAS_5P = TypeDef.default(PREFIX, "has5p", name="has 5' gene", is_metadata_tag=False)
+HAS_3P = TypeDef.default(PREFIX, "has3p", name="has 3' gene", predicate_type="object")
+HAS_5P = TypeDef.default(PREFIX, "has5p", name="has 5' gene", predicate_type="object")
 
 TYPES = {
     "Gene": GENE,

--- a/src/pyobo/sources/clinicaltrials.py
+++ b/src/pyobo/sources/clinicaltrials.py
@@ -19,13 +19,13 @@ INVESTIGATES_CONDITION = TypeDef(
     reference=default_reference(
         prefix=PREFIX, identifier="investigates_condition", name="investigates condition"
     ),
-    is_metadata_tag=True,
+    predicate_type="annotation",
 )
 HAS_INTERVENTION = TypeDef(
     reference=default_reference(
         prefix=PREFIX, identifier="has_intervention", name="has intervention"
     ),
-    is_metadata_tag=True,
+    predicate_type="annotation",
 )
 
 INVESTIGATION_TERM = Term(

--- a/src/pyobo/sources/cvx.py
+++ b/src/pyobo/sources/cvx.py
@@ -16,9 +16,9 @@ __all__ = [
 cvx_url = "https://www2a.cdc.gov/vaccines/iis/iisstandards/downloads/cvx.txt"
 PREFIX = "cvx"
 STATUS = TypeDef(
-    reference=default_reference(PREFIX, "status", name="has status"), is_metadata_tag=True
+    reference=default_reference(PREFIX, "status", name="has status"), predicate_type="annotation"
 )
-NONVACCINE = TypeDef(reference=default_reference(PREFIX, "nonvaccine"), is_metadata_tag=True)
+NONVACCINE = TypeDef(reference=default_reference(PREFIX, "nonvaccine"), predicate_type="annotation")
 
 ACRONYM_RE = re.compile("^[A-Z]+$")
 

--- a/src/pyobo/sources/geonames/utils.py
+++ b/src/pyobo/sources/geonames/utils.py
@@ -33,7 +33,8 @@ FEATURE_TERM = Term(reference=FEATURE)
 
 # Type definitions
 CODE_TYPEDEF = TypeDef(
-    reference=default_reference(PREFIX, "code", name="GeoNames code"), is_metadata_tag=True
+    reference=default_reference(PREFIX, "code", name="GeoNames code"),
+    predicate_type="annotation",
 )
 
 SYNONYMS_DF_COLUMNS = [

--- a/src/pyobo/sources/goldbook.py
+++ b/src/pyobo/sources/goldbook.py
@@ -18,7 +18,7 @@ PREFIX = "goldbook"
 URL = "https://goldbook.iupac.org/terms/index/all/json/download"
 TERM_URL_FORMAT = "https://goldbook.iupac.org/terms/view/{}/json"
 
-HAS_STATUS = TypeDef(reference=default_reference(PREFIX, "hasStatus"), is_metadata_tag=True)
+HAS_STATUS = TypeDef(reference=default_reference(PREFIX, "hasStatus"), predicate_type="annotation")
 
 
 class GoldBookGetter(Obo):

--- a/src/pyobo/sources/iana_media_type.py
+++ b/src/pyobo/sources/iana_media_type.py
@@ -66,7 +66,7 @@ PREDICATE = TypeDef(
     domain=ROOT_MEDIA_TYPE.reference,
     range=ROOT_FILE_FORMAT.reference,
     definition="Connects a media type with a file format that has been observed to encode it",
-    is_metadata_tag=True,
+    predicate_type="annotation",
 )
 
 

--- a/src/pyobo/sources/icd/icd11.py
+++ b/src/pyobo/sources/icd/icd11.py
@@ -34,7 +34,9 @@ logger = logging.getLogger(__name__)
 PREFIX = "icd11"
 CODE_PREFIX = "icd11.code"
 
-CODE_PROP = TypeDef(reference=default_reference(PREFIX, "icd_mms_code"), is_metadata_tag=True)
+CODE_PROP = TypeDef(
+    reference=default_reference(PREFIX, "icd_mms_code"), predicate_type="annotation"
+)
 
 
 class ICD11Getter(Obo):

--- a/src/pyobo/sources/msigdb.py
+++ b/src/pyobo/sources/msigdb.py
@@ -20,14 +20,20 @@ logger = logging.getLogger(__name__)
 PREFIX = "msigdb"
 BASE_URL = "https://data.broadinstitute.org/gsea-msigdb/msigdb/release"
 
-CATEGORY_CODE = TypeDef.default(PREFIX, "category_code", name="category code", is_metadata_tag=True)
-SUB_CATEGORY_CODE = TypeDef.default(
-    PREFIX, "sub_category_code", name="sub-category code", is_metadata_tag=True
+CATEGORY_CODE = TypeDef.default(
+    PREFIX, "category_code", name="category code", predicate_type="annotation"
 )
-CONTRIBUTOR = TypeDef.default(PREFIX, "contributor", name="contributor", is_metadata_tag=True)
-EXACT_SOURCE = TypeDef.default(PREFIX, "exact_source", name="exact source", is_metadata_tag=True)
+SUB_CATEGORY_CODE = TypeDef.default(
+    PREFIX, "sub_category_code", name="sub-category code", predicate_type="annotation"
+)
+CONTRIBUTOR = TypeDef.default(
+    PREFIX, "contributor", name="contributor", predicate_type="annotation"
+)
+EXACT_SOURCE = TypeDef.default(
+    PREFIX, "exact_source", name="exact source", predicate_type="annotation"
+)
 EXTERNAL_DETAILS_URL = TypeDef.default(
-    PREFIX, "external_details_url", name="external details URL", is_metadata_tag=True
+    PREFIX, "external_details_url", name="external details URL", predicate_type="annotation"
 )
 
 PROPERTIES = [

--- a/src/pyobo/sources/pharmgkb/pharmgkb_variant.py
+++ b/src/pyobo/sources/pharmgkb/pharmgkb_variant.py
@@ -16,7 +16,7 @@ URL = "https://api.pharmgkb.org/v1/download/file/data/variants.zip"
 
 
 HAS_GENE_ASSOCIATION = TypeDef.default(
-    PREFIX, "hasGeneAssociation", name="has gene association", is_metadata_tag=True
+    PREFIX, "hasGeneAssociation", name="has gene association", predicate_type="annotation"
 )
 
 

--- a/src/pyobo/sources/pombase.py
+++ b/src/pyobo/sources/pombase.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 PREFIX = "pombase"
 GENE_NAMES_URL = "https://www.pombase.org/data/names_and_identifiers/gene_IDs_names_products.tsv"
 ORTHOLOGS_URL = "https://www.pombase.org/data/orthologs/human-orthologs.txt.gz"
-CHROMOSOME = TypeDef.default(PREFIX, "chromosome", is_metadata_tag=True)
+CHROMOSOME = TypeDef.default(PREFIX, "chromosome", predicate_type="annotation")
 
 
 class PomBaseGetter(Obo):

--- a/src/pyobo/sources/rhea.py
+++ b/src/pyobo/sources/rhea.py
@@ -23,13 +23,16 @@ PREFIX = "rhea"
 RHEA_RDF_GZ_URL = "ftp://ftp.expasy.org/databases/rhea/rdf/rhea.rdf.gz"
 
 has_left_to_right_reaction = TypeDef.default(
-    PREFIX, "hasLeftToRightReaction", name="has left to right reaction", is_metadata_tag=True
+    PREFIX, "hasLeftToRightReaction", name="has left to right reaction", predicate_type="annotation"
 ).append_xref(v.has_left_to_right_reaction)
 has_right_to_left_reaction = TypeDef.default(
-    PREFIX, "hasRightToLeftReaction", name="has right to left reaction", is_metadata_tag=True
+    PREFIX, "hasRightToLeftReaction", name="has right to left reaction", predicate_type="annotation"
 ).append_xref(v.has_right_to_left_reaction)
 has_bidirectional_reaction = TypeDef.default(
-    PREFIX, "hasBidirectionalReaction", name="has bidirectional reaction", is_metadata_tag=True
+    PREFIX,
+    "hasBidirectionalReaction",
+    name="has bidirectional reaction",
+    predicate_type="annotation",
 ).append_xref(v.has_bidirectional_reaction)
 
 

--- a/src/pyobo/sources/slm.py
+++ b/src/pyobo/sources/slm.py
@@ -36,7 +36,7 @@ COLUMNS = [
     "HMDB",
     "PMID",
 ]
-LEVEL = TypeDef.default(PREFIX, "level", is_metadata_tag=True)
+LEVEL = TypeDef.default(PREFIX, "level", predicate_type="annotation")
 
 
 class SLMGetter(Obo):

--- a/src/pyobo/sources/spdx.py
+++ b/src/pyobo/sources/spdx.py
@@ -25,13 +25,13 @@ IS_OSI = TypeDef(
     reference=Reference(
         prefix=SPDX_TERM_PREFIX, identifier="isOsiApproved", name="is OSI approved"
     ),
-    is_metadata_tag=True,
+    predicate_type="annotation",
     domain=ROOT.reference,
     range=xsd_boolean,
 )
 IS_FSF = TypeDef(
     reference=Reference(prefix=SPDX_TERM_PREFIX, identifier="isFsfLibre", name="is FSF Libre"),
-    is_metadata_tag=True,
+    predicate_type="annotation",
     domain=ROOT.reference,
     range=xsd_boolean,
 )

--- a/src/pyobo/sources/uniprot/uniprot.py
+++ b/src/pyobo/sources/uniprot/uniprot.py
@@ -52,7 +52,7 @@ PARAMS = {
     "query": QUERY,
     "fields": FIELDS,
 }
-IS_REVIEWED = TypeDef(reference=default_reference(PREFIX, "reviewed"), is_metadata_tag=True)
+IS_REVIEWED = TypeDef(reference=default_reference(PREFIX, "reviewed"), predicate_type="annotation")
 
 
 class UniProtGetter(Obo):

--- a/src/pyobo/ssg/index.html
+++ b/src/pyobo/ssg/index.html
@@ -106,8 +106,8 @@
                 {% for term in manifest %}
                     <tr>
                         <td>
-                            {% if term.is_metadata_tag %}
-                                Property
+                            {% if term.predicate_type %}
+                                {{ term.predicate_type.capitalize }}Property
                             {% else %}
                                 {{ term.type }}
                             {% endif %}

--- a/src/pyobo/ssg/typedef.html
+++ b/src/pyobo/ssg/typedef.html
@@ -5,10 +5,8 @@
 {% block content -%}
     <div class="card">
         <h5 class="card-header">
-            {% if typedef.is_metadata_tag %}
-                <span class="badge badge-info">Property</span>
-            {% else %}
-                <span class="badge badge-info">Relation</span>
+            {% if typedef.predicate_type %}
+                <span class="badge badge-info">{{ typedef.predicate_type.capitalize() }}Property</span>
             {% endif %}
             {{ typedef.name or typedef.identifier }}
             {% if typedef.is_obsolete %}

--- a/src/pyobo/struct/functional.py
+++ b/src/pyobo/struct/functional.py
@@ -220,10 +220,10 @@ def get_typedef_axioms(typedef: TypeDef) -> Iterable[f.Box]:
     """Iterate over functional OWL axioms for a typedef."""
     r = f.IdentifierBox(typedef.reference)
     # 40
-    if typedef.predicate_type == "annotation":
-        yield f.Declaration(r, type="AnnotationProperty")
-    elif typedef.predicate_type == "object":
+    if typedef.predicate_type is None or typedef.predicate_type == "object":
         yield f.Declaration(r, type="ObjectProperty")
+    elif typedef.predicate_type == "annotation":
+        yield f.Declaration(r, type="AnnotationProperty")
     elif typedef.predicate_type == "data":
         yield f.Declaration(r, type="DataProperty")
     else:
@@ -257,20 +257,20 @@ def get_typedef_axioms(typedef: TypeDef) -> Iterable[f.Box]:
     yield from _yield_properties(typedef, r)
     # 12
     if typedef.domain:
-        if typedef.predicate_type == "annotation":
-            yield f.AnnotationPropertyDomain(r, typedef.domain)
-        elif typedef.predicate_type == "object":
+        if typedef.predicate_type is None or typedef.predicate_type == "object":
             yield f.ObjectPropertyDomain(r, typedef.domain)
+        elif typedef.predicate_type == "annotation":
+            yield f.AnnotationPropertyDomain(r, typedef.domain)
         elif typedef.predicate_type == "data":
             yield f.DataPropertyDomain(r, typedef.domain)
         else:
             raise ValueError
     # 13
     if typedef.range:
-        if typedef.predicate_type == "annotation":
-            yield f.AnnotationPropertyRange(r, typedef.range)
-        elif typedef.predicate_type == "object":
+        if typedef.predicate_type is None or typedef.predicate_type == "object":
             yield f.ObjectPropertyRange(r, typedef.range)
+        elif typedef.predicate_type == "annotation":
+            yield f.AnnotationPropertyRange(r, typedef.range)
         elif typedef.predicate_type == "data":
             yield f.DataPropertyRange(r, typedef.range)
         else:
@@ -304,10 +304,10 @@ def get_typedef_axioms(typedef: TypeDef) -> Iterable[f.Box]:
         yield f.InverseFunctionalObjectProperty(r)
     # 23
     for parent in typedef.parents:
-        if typedef.predicate_type == "annotation":
-            yield f.SubAnnotationPropertyOf(r, parent)
-        elif typedef.predicate_type == "object":
+        if typedef.predicate_type is None or typedef.predicate_type == "object":
             yield f.SubObjectPropertyOf(r, parent)
+        elif typedef.predicate_type == "annotation":
+            yield f.SubAnnotationPropertyOf(r, parent)
         elif typedef.predicate_type == "data":
             yield f.SubDataPropertyOf(r, parent)
         else:

--- a/src/pyobo/struct/functional.py
+++ b/src/pyobo/struct/functional.py
@@ -220,10 +220,14 @@ def get_typedef_axioms(typedef: TypeDef) -> Iterable[f.Box]:
     """Iterate over functional OWL axioms for a typedef."""
     r = f.IdentifierBox(typedef.reference)
     # 40
-    if typedef.is_metadata_tag:
+    if typedef.predicate_type == "annotation":
         yield f.Declaration(r, type="AnnotationProperty")
-    else:
+    elif typedef.predicate_type == "object":
         yield f.Declaration(r, type="ObjectProperty")
+    elif typedef.predicate_type == "data":
+        yield f.Declaration(r, type="DataProperty")
+    else:
+        raise ValueError
     # 2
     if typedef.is_anonymous is not None:
         yield m.IsAnonymousMacro(r, typedef.is_anonymous)
@@ -253,16 +257,24 @@ def get_typedef_axioms(typedef: TypeDef) -> Iterable[f.Box]:
     yield from _yield_properties(typedef, r)
     # 12
     if typedef.domain:
-        if typedef.is_metadata_tag:
+        if typedef.predicate_type == "annotation":
             yield f.AnnotationPropertyDomain(r, typedef.domain)
-        else:
+        elif typedef.predicate_type == "object":
             yield f.ObjectPropertyDomain(r, typedef.domain)
+        elif typedef.predicate_type == "data":
+            yield f.DataPropertyDomain(r, typedef.domain)
+        else:
+            raise ValueError
     # 13
     if typedef.range:
-        if typedef.is_metadata_tag:
+        if typedef.predicate_type == "annotation":
             yield f.AnnotationPropertyRange(r, typedef.range)
-        else:
+        elif typedef.predicate_type == "object":
             yield f.ObjectPropertyRange(r, typedef.range)
+        elif typedef.predicate_type == "data":
+            yield f.DataPropertyRange(r, typedef.range)
+        else:
+            raise ValueError
     # 14
     if typedef.builtin is not None:
         yield m.IsOBOBuiltinMacro(r, typedef.builtin)
@@ -292,10 +304,14 @@ def get_typedef_axioms(typedef: TypeDef) -> Iterable[f.Box]:
         yield f.InverseFunctionalObjectProperty(r)
     # 23
     for parent in typedef.parents:
-        if typedef.is_metadata_tag:
+        if typedef.predicate_type == "annotation":
             yield f.SubAnnotationPropertyOf(r, parent)
-        else:
+        elif typedef.predicate_type == "object":
             yield f.SubObjectPropertyOf(r, parent)
+        elif typedef.predicate_type == "data":
+            yield f.SubDataPropertyOf(r, parent)
+        else:
+            raise ValueError
     # 24 TODO intersection_of, ROBOT does not create any output
     # 25 TODO union_of, ROBOT does not create any output
     # 26
@@ -306,10 +322,14 @@ def get_typedef_axioms(typedef: TypeDef) -> Iterable[f.Box]:
         yield f.DisjointObjectProperties([x, r])
     # 28
     if typedef.inverse:
-        if typedef.is_metadata_tag:
+        if typedef.predicate_type == "annotation":
             pass  # not sure what to do
-        else:
+        elif typedef.predicate_type == "object":
             yield f.InverseObjectProperties(r, typedef.inverse)
+        elif typedef.predicate_type == "data":
+            pass
+        else:
+            raise ValueError
     # 29
     for to in typedef.transitive_over:
         yield m.TransitiveOver(r, to)

--- a/src/pyobo/struct/obo/reader.py
+++ b/src/pyobo/struct/obo/reader.py
@@ -901,7 +901,7 @@ def iterate_typedefs(
         typedef = TypeDef(
             reference=reference,
             namespace=data.get("namespace"),
-            is_metadata_tag=_get_boolean(data, "is_metadata_tag"),
+            predicate_type="annotation" if _get_boolean(data, "is_metadata_tag") else None,
             is_class_level=_get_boolean(data, "is_class_level"),
             builtin=_get_boolean(data, "builtin"),
             is_obsolete=_get_boolean(data, "is_obsolete"),

--- a/src/pyobo/struct/obograph/export.py
+++ b/src/pyobo/struct/obograph/export.py
@@ -13,6 +13,7 @@ from pystow.utils import safe_open
 from pyobo.identifier_utils.api import get_converter
 from pyobo.struct import Obo, OBOLiteral, Stanza, Term, TypeDef
 from pyobo.struct import typedef as tdv
+from pyobo.struct.obograph.utils import PROPERTY_TYPE_MAP
 
 __all__ = [
     "to_obograph",
@@ -305,7 +306,7 @@ def _get_typedef_node(typedef: TypeDef) -> og.StandardizedNode:
         label=typedef.name,
         meta=_meta_or_none(meta),
         type="PROPERTY",
-        property_type="ANNOTATION" if typedef.is_metadata_tag else "OBJECT",
+        property_type=PROPERTY_TYPE_MAP[typedef.predicate_type] if typedef.predicate_type else None,
     )
 
 

--- a/src/pyobo/struct/obograph/reader.py
+++ b/src/pyobo/struct/obograph/reader.py
@@ -20,6 +20,7 @@ from pyobo import Obo, Reference, StanzaType, Synonym, Term, TypeDef, build_onto
 from pyobo.identifier_utils import get_converter
 from pyobo.struct import Annotation, OBOLiteral
 from pyobo.struct import vocabulary as v
+from pyobo.struct.obograph.utils import INVERSE_PROPERTY_TYPE_MAP
 from pyobo.struct.typedef import has_ontology_root_term
 
 __all__ = [
@@ -178,7 +179,9 @@ def _from_term(node: StandardizedNode) -> Term:
 def _from_property(node: StandardizedNode) -> TypeDef:
     typedef = TypeDef(
         reference=_get_ref(node),
-        is_metadata_tag=node.property_type == "ANNOTATION",
+        predicate_type=INVERSE_PROPERTY_TYPE_MAP[node.property_type]
+        if node.property_type
+        else None,
     )
     if node.meta is not None:
         _process_typedef_meta(node.meta, typedef)

--- a/src/pyobo/struct/obograph/utils.py
+++ b/src/pyobo/struct/obograph/utils.py
@@ -3,8 +3,11 @@
 import unittest
 from typing import cast
 
+import obographs as og
 from curies import Reference
 from obographs import StandardizedGraph, StandardizedMeta
+
+from pyobo.constants import TypeDefType
 
 __all__ = [
     "assert_graph_equal",
@@ -45,3 +48,13 @@ def assert_graph_equal(
             exclude_none=True, exclude_unset=True, exclude_defaults=True, exclude=excludes
         ),
     )
+
+
+PROPERTY_TYPE_MAP: dict[TypeDefType, og.PropertyType] = {
+    "annotation": "ANNOTATION",
+    "data": "DATA",
+    "object": "OBJECT",
+}
+INVERSE_PROPERTY_TYPE_MAP: dict[og.PropertyType, TypeDefType] = {
+    v: k for k, v in PROPERTY_TYPE_MAP.items()
+}

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -2150,10 +2150,10 @@ class Obo:
     @staticmethod
     def _get_stanza_type(stanza: Stanza) -> curies.Reference | None:
         if isinstance(stanza, TypeDef):
-            if stanza.predicate_type == "annotation":
-                return _cv.owl_annotation_property
-            elif stanza.predicate_type == "object":
+            if stanza.predicate_type is None or stanza.predicate_type == "object":
                 return _cv.owl_object_property
+            elif stanza.predicate_type == "annotation":
+                return _cv.owl_annotation_property
             elif stanza.predicate_type == "data":
                 return _cv.owl_data_property
             else:

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -2519,12 +2519,12 @@ class TypeDef(Stanza):
 
     @classmethod
     def default(
-        cls, prefix: str, identifier: str, *, name: str | None = None, is_metadata_tag: bool
+        cls, prefix: str, identifier: str, *, name: str | None = None, predicate_type: TypeDefType
     ) -> Self:
         """Construct a default type definition from within the OBO namespace."""
         return cls(
             reference=default_reference(prefix, identifier, name=name),
-            predicate_type="annotation" if is_metadata_tag else "object",
+            predicate_type=predicate_type,
         )
 
 

--- a/src/pyobo/struct/struct.py
+++ b/src/pyobo/struct/struct.py
@@ -70,6 +70,7 @@ from ..constants import (
     RELATION_PREFIX,
     TARGET_ID,
     TARGET_PREFIX,
+    TypeDefType,
     get_semantic_mapping_metadata,
 )
 from ..utils.cache import write_gzipped_graph
@@ -2149,10 +2150,14 @@ class Obo:
     @staticmethod
     def _get_stanza_type(stanza: Stanza) -> curies.Reference | None:
         if isinstance(stanza, TypeDef):
-            if stanza.is_metadata_tag:
+            if stanza.predicate_type == "annotation":
                 return _cv.owl_annotation_property
-            else:
+            elif stanza.predicate_type == "object":
                 return _cv.owl_object_property
+            elif stanza.predicate_type == "data":
+                return _cv.owl_data_property
+            else:
+                raise ValueError
         elif stanza.type == "Term":
             return _cv.owl_class
         elif stanza.type == "Instance":
@@ -2307,7 +2312,7 @@ class TypeDef(Stanza):
     #: that is useful to track, but does not impact the definition of the object or how it should
     #: be treated by a reasoner. Metadata tags might be used to record special term synonyms or
     #: structured notes about a term, for example.
-    is_metadata_tag: Annotated[bool | None, 40, "typedef-only"] = None
+    predicate_type: Annotated[TypeDefType | None, 40, "typedef-only"] = None
     is_class_level: Annotated[bool | None, 41] = None
 
     type: StanzaType = "TypeDef"
@@ -2502,7 +2507,8 @@ class TypeDef(Stanza):
         # 38 TODO expand_assertion_to
         # 39 TODO expand_expression_to
         # 40
-        yield from _boolean_tag("is_metadata_tag", self.is_metadata_tag)
+        if self.predicate_type == "annotation":
+            yield from _boolean_tag("is_metadata_tag", True)
         # 41
         yield from _boolean_tag("is_class_level", self.is_class_level)
 
@@ -2518,7 +2524,7 @@ class TypeDef(Stanza):
         """Construct a default type definition from within the OBO namespace."""
         return cls(
             reference=default_reference(prefix, identifier, name=name),
-            is_metadata_tag=is_metadata_tag,
+            predicate_type="annotation" if is_metadata_tag else "object",
         )
 
 

--- a/src/pyobo/struct/typedef.py
+++ b/src/pyobo/struct/typedef.py
@@ -100,11 +100,11 @@ species_specific = TypeDef(
     "like a pathway, and X is the version that appears in a species. X should state which"
     "species with RO:0002162 (in taxon)",
 )
-has_left_to_right_reaction = TypeDef(v.has_left_to_right_reaction, is_metadata_tag=True)
-has_right_to_left_reaction = TypeDef(v.has_right_to_left_reaction, is_metadata_tag=True)
+has_left_to_right_reaction = TypeDef(v.has_left_to_right_reaction, predicate_type="annotation")
+has_right_to_left_reaction = TypeDef(v.has_right_to_left_reaction, predicate_type="annotation")
 has_bidirectional_reaction = TypeDef(
     reference=default_reference("RO", "hasBiDirectionalReaction"),
-    is_metadata_tag=True,
+    predicate_type="annotation",
 ).append_xref(Reference(prefix="debio", identifier="0000009", name="has bi-directional reaction"))
 reaction_enabled_by_molecular_function = TypeDef(
     reference=default_reference("RO", "reactionEnabledByMolecularFunction")
@@ -151,11 +151,11 @@ ends = TypeDef(
 contributes_to_condition = TypeDef(
     reference=Reference(prefix=RO_PREFIX, identifier="0003304", name="contributes to condition"),
 )
-exact_match = TypeDef(reference=v.exact_match, is_metadata_tag=True)
-narrow_match = TypeDef(reference=v.narrow_match, is_metadata_tag=True)
-broad_match = TypeDef(reference=v.broad_match, is_metadata_tag=True)
-close_match = TypeDef(reference=v.close_match, is_metadata_tag=True)
-related_match = TypeDef(reference=v.related_match, is_metadata_tag=True)
+exact_match = TypeDef(reference=v.exact_match, predicate_type="annotation")
+narrow_match = TypeDef(reference=v.narrow_match, predicate_type="annotation")
+broad_match = TypeDef(reference=v.broad_match, predicate_type="annotation")
+close_match = TypeDef(reference=v.close_match, predicate_type="annotation")
+related_match = TypeDef(reference=v.related_match, predicate_type="annotation")
 owl_same_as = TypeDef(
     reference=v.owl_same_as,
 )
@@ -165,12 +165,12 @@ equivalent_property = TypeDef(reference=v.equivalent_property)
 is_a = TypeDef(reference=v.is_a)
 rdf_type = TypeDef(reference=v.rdf_type)
 subproperty_of = TypeDef(reference=v.subproperty_of)
-see_also = TypeDef(reference=v.see_also, is_metadata_tag=True)
-has_comment = TypeDef(reference=v.comment, is_metadata_tag=True)
-label = TypeDef(reference=v.label, is_metadata_tag=True)
+see_also = TypeDef(reference=v.see_also, predicate_type="annotation")
+has_comment = TypeDef(reference=v.comment, predicate_type="annotation")
+label = TypeDef(reference=v.label, predicate_type="annotation")
 is_defined_by = TypeDef(
     reference=Reference(prefix="rdfs", identifier="isDefinedBy", name="is defined by"),
-    is_metadata_tag=True,
+    predicate_type="annotation",
 )
 member_of_reference = Reference(prefix=RO_PREFIX, identifier="0002350", name="member of")
 has_member = TypeDef(
@@ -239,15 +239,15 @@ has_salt = TypeDef(
     reference=Reference(prefix="debio", identifier="0000006", name="has salt"),
 )
 
-term_replaced_by = TypeDef(reference=v.term_replaced_by, is_metadata_tag=True)
+term_replaced_by = TypeDef(reference=v.term_replaced_by, predicate_type="annotation")
 example_of_usage = TypeDef(
     reference=Reference(prefix=IAO_PREFIX, identifier="0000112", name="example of usage"),
-    is_metadata_tag=True,
+    predicate_type="annotation",
 )
-alternative_term = TypeDef(reference=v.alternative_term, is_metadata_tag=True)
-has_ontology_root_term = TypeDef(reference=v.has_ontology_root_term, is_metadata_tag=True)
+alternative_term = TypeDef(reference=v.alternative_term, predicate_type="annotation")
+has_ontology_root_term = TypeDef(reference=v.has_ontology_root_term, predicate_type="annotation")
 has_ontology_hierarchy_predicate = TypeDef(
-    reference=v.has_ontology_hierarchy_predicate, is_metadata_tag=True
+    reference=v.has_ontology_hierarchy_predicate, predicate_type="annotation"
 )
 """
 You can annotate this into an ontology with
@@ -260,7 +260,7 @@ You can annotate this into an ontology with
 """
 definition_source = TypeDef(
     reference=Reference(prefix=IAO_PREFIX, identifier="0000119", name="definition source"),
-    is_metadata_tag=True,
+    predicate_type="annotation",
 )
 may_be_identical_to = TypeDef(
     reference=Reference(prefix=IAO_PREFIX, identifier="0006011", name="may be identical to")
@@ -273,11 +273,11 @@ has_curation_status = TypeDef(
     reference=Reference(prefix=IAO_PREFIX, identifier="0000114", name="has curation status")
 )
 
-has_dbxref = TypeDef(reference=v.has_dbxref, is_metadata_tag=True)
+has_dbxref = TypeDef(reference=v.has_dbxref, predicate_type="annotation")
 
 editor_note = TypeDef(
     reference=Reference(prefix=IAO_PREFIX, identifier="0000116", name="editor note"),
-    is_metadata_tag=True,
+    predicate_type="annotation",
 )
 
 is_immediately_transformed_from = TypeDef.from_triple(
@@ -347,77 +347,81 @@ directly_regulates_activity_of = TypeDef.from_triple(
 
 is_mentioned_by = TypeDef(
     reference=v.is_mentioned_by,
-    is_metadata_tag=True,
+    predicate_type="annotation",
     inverse=v.mentions,
     range=v.document,
 )
 mentions = TypeDef(
     reference=v.mentions,
-    is_metadata_tag=True,
+    predicate_type="annotation",
     inverse=v.is_mentioned_by,
     domain=v.document,
 )
 
-has_smiles = TypeDef(reference=v.has_smiles, is_metadata_tag=True).append_xref(v.debio_has_smiles)
-has_canonical_smiles = TypeDef(reference=v.has_canonical_smiles, is_metadata_tag=True).append_xref(
+has_smiles = TypeDef(reference=v.has_smiles, predicate_type="annotation").append_xref(
     v.debio_has_smiles
 )
-has_isomeric_smiles = TypeDef(reference=v.has_isomeric_smiles, is_metadata_tag=True).append_xref(
-    v.debio_has_smiles
-)
+has_canonical_smiles = TypeDef(
+    reference=v.has_canonical_smiles, predicate_type="annotation"
+).append_xref(v.debio_has_smiles)
+has_isomeric_smiles = TypeDef(
+    reference=v.has_isomeric_smiles, predicate_type="annotation"
+).append_xref(v.debio_has_smiles)
 
 # https://chemkg.github.io/chemrof/isomeric_smiles_string/
 
-has_inchi = TypeDef(reference=v.has_inchi, is_metadata_tag=True).append_xref(v.debio_has_inchi)
+has_inchi = TypeDef(reference=v.has_inchi, predicate_type="annotation").append_xref(
+    v.debio_has_inchi
+)
 
-has_homepage = TypeDef(reference=v.has_homepage, is_metadata_tag=True)
-has_depiction = TypeDef(reference=v.has_depiction, is_metadata_tag=True)
-has_mailbox = TypeDef(reference=v.has_mailbox, is_metadata_tag=True)
-has_mailing_list = TypeDef(reference=v.has_mailing_list, is_metadata_tag=True)
-has_repository = TypeDef(reference=v.has_repository, is_metadata_tag=True)
+has_homepage = TypeDef(reference=v.has_homepage, predicate_type="annotation")
+has_depiction = TypeDef(reference=v.has_depiction, predicate_type="annotation")
+has_mailbox = TypeDef(reference=v.has_mailbox, predicate_type="annotation")
+has_mailing_list = TypeDef(reference=v.has_mailing_list, predicate_type="annotation")
+has_repository = TypeDef(reference=v.has_repository, predicate_type="annotation")
 
 has_category = TypeDef(
     reference=Reference(prefix="biolink", identifier="category", name="has category"),
-    is_metadata_tag=True,
+    predicate_type="annotation",
 )
 
 has_taxonomy_rank = TypeDef(
     reference=Reference(prefix="taxrank", identifier="1000000", name="has rank"),
-    is_metadata_tag=True,
+    predicate_type="annotation",
 )
 
 mapping_has_justification = TypeDef(
     reference=v.mapping_has_justification,
-    is_metadata_tag=True,
+    predicate_type="annotation",
     range=Reference(prefix="semapv", identifier="Matching", name="matching process"),
 )
 mapping_has_confidence = TypeDef(
-    reference=v.mapping_has_confidence, is_metadata_tag=True, range=v.xsd_float
+    reference=v.mapping_has_confidence, predicate_type="annotation", range=v.xsd_float
 )
-has_contributor = TypeDef(reference=v.has_contributor, is_metadata_tag=True)
-has_source = TypeDef(reference=v.has_source, is_metadata_tag=True)
+has_contributor = TypeDef(reference=v.has_contributor, predicate_type="annotation")
+has_source = TypeDef(reference=v.has_source, predicate_type="annotation")
 
 has_start_date = TypeDef(
     reference=Reference(prefix="dcat", identifier="startDate", name="has start date"),
-    is_metadata_tag=True,
+    predicate_type="annotation",
 )
 has_end_date = TypeDef(
     reference=Reference(prefix="dcat", identifier="endDate", name="has end date"),
-    is_metadata_tag=True,
+    predicate_type="annotation",
 )
 
-has_title = TypeDef(reference=v.has_title, is_metadata_tag=True)
-has_license = TypeDef(reference=v.has_license, is_metadata_tag=True)
-has_creator = TypeDef(reference=v.has_creator, is_metadata_tag=True)
+has_title = TypeDef(reference=v.has_title, predicate_type="annotation")
+has_license = TypeDef(reference=v.has_license, predicate_type="annotation")
+has_creator = TypeDef(reference=v.has_creator, predicate_type="annotation")
 
-has_description = TypeDef(reference=v.has_description, is_metadata_tag=True)
-obo_autogenerated_by = TypeDef(reference=v.obo_autogenerated_by, is_metadata_tag=True)
-obo_has_format_version = TypeDef(reference=v.obo_has_format_version, is_metadata_tag=True)
-obo_is_metadata_tag = TypeDef(reference=v.obo_is_metadata_tag, is_metadata_tag=True)
-obo_has_id = TypeDef(reference=v.obo_has_id, is_metadata_tag=True)
+has_description = TypeDef(reference=v.has_description, predicate_type="annotation")
+obo_autogenerated_by = TypeDef(reference=v.obo_autogenerated_by, predicate_type="annotation")
+obo_has_format_version = TypeDef(reference=v.obo_has_format_version, predicate_type="annotation")
+obo_is_metadata_tag = TypeDef(reference=v.obo_is_metadata_tag, predicate_type="annotation")
+obo_has_id = TypeDef(reference=v.obo_has_id, predicate_type="annotation")
 
-in_subset = TypeDef(reference=v.in_subset, is_metadata_tag=True)
-has_term_editor = TypeDef(reference=v.has_term_editor, is_metadata_tag=True)
+in_subset = TypeDef(reference=v.in_subset, predicate_type="annotation")
+has_term_editor = TypeDef(reference=v.has_term_editor, predicate_type="annotation")
 
 default_typedefs: dict[ReferenceTuple, TypeDef] = {
     v.pair: v for v in locals().values() if isinstance(v, TypeDef)

--- a/tests/test_obo_reader/test_reader_typedef.py
+++ b/tests/test_obo_reader/test_reader_typedef.py
@@ -458,7 +458,34 @@ class TestReaderTypedef(unittest.TestCase):
 
     def test_40_is_metadata_tag(self) -> None:
         """Test the ``is_metadata_tag`` tag."""
-        self.assert_boolean_tag("is_metadata_tag")
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: BFO:0000066
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertIsNone(typedef.predicate_type)
+
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: BFO:0000066
+            is_metadata_tag: false
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertIsNone(typedef.predicate_type)
+
+        ontology = from_str("""\
+            ontology: ro
+
+            [Typedef]
+            id: BFO:0000066
+            is_metadata_tag: true
+        """)
+        typedef = self.get_only_typedef(ontology)
+        self.assertEqual("annotation", typedef.predicate_type)
 
     def test_41_is_class_level(self) -> None:
         """Test the ``is_class_level`` tag."""

--- a/tests/test_struct/test_obo/test_typedef.py
+++ b/tests/test_struct/test_obo/test_typedef.py
@@ -150,7 +150,7 @@ class TestTypeDef(unittest.TestCase):
 
         annotation_property = TypeDef(
             reference=Reference(prefix=exact_match.prefix, identifier=exact_match.identifier),
-            is_metadata_tag=True,
+            predicate_type="annotation",
         )
         self.assert_obo_stanza(
             """\
@@ -449,7 +449,7 @@ class TestTypeDef(unittest.TestCase):
         typedef_annotation = TypeDef(
             reference=Reference(prefix="BFO", identifier="0000066"),
             domain=Reference(prefix="BFO", identifier="0000003", name="occurrent"),
-            is_metadata_tag=True,
+            predicate_type="annotation",
         )
         self.assert_obo_stanza(
             """\
@@ -507,7 +507,7 @@ class TestTypeDef(unittest.TestCase):
         typedef_annotation = TypeDef(
             reference=Reference(prefix="BFO", identifier="0000066"),
             range=Reference(prefix="BFO", identifier="0000004", name="independent continuant"),
-            is_metadata_tag=True,
+            predicate_type="annotation",
         )
         self.assert_obo_stanza(
             """\
@@ -626,7 +626,7 @@ class TestTypeDef(unittest.TestCase):
         typedef = TypeDef(
             reference=Reference(prefix="skos", identifier="exactMatch", name="exact match"),
             parents=[Reference(prefix="skos", identifier="closeMatch", name="close match")],
-            is_metadata_tag=True,
+            predicate_type="annotation",
         )
         self.assert_obo_stanza(
             """\

--- a/tests/test_struct/test_obo/test_typedef.py
+++ b/tests/test_struct/test_obo/test_typedef.py
@@ -877,18 +877,66 @@ class TestTypeDef(unittest.TestCase):
 
     def test_40_is_metadata_tag(self) -> None:
         """Test the ``is_metadata_tag`` tag."""
-        td_true, td_false = self.assert_boolean_tag("is_metadata_tag", test_funowl=False)
-        self.assert_funowl_lines(
-            """
-            Declaration(AnnotationProperty(GO:0000001))
+        ref = Reference(prefix="GO", identifier="0000001")
+        typedef = TypeDef(reference=ref, predicate_type=None)
+        self.assert_obo_stanza(
+            """\
+            [Typedef]
+            id: GO:0000001
             """,
-            td_true,
+            typedef,
         )
         self.assert_funowl_lines(
             """
             Declaration(ObjectProperty(GO:0000001))
             """,
-            td_false,
+            typedef,
+        )
+
+        typedef = TypeDef(reference=ref, predicate_type="annotation")
+        self.assert_obo_stanza(
+            """\
+            [Typedef]
+            id: GO:0000001
+            is_metadata_tag: true
+            """,
+            typedef,
+        )
+        self.assert_funowl_lines(
+            """
+            Declaration(AnnotationProperty(GO:0000001))
+            """,
+            typedef,
+        )
+
+        typedef = TypeDef(reference=ref, predicate_type="object")
+        self.assert_obo_stanza(
+            """\
+            [Typedef]
+            id: GO:0000001
+            """,
+            typedef,
+        )
+        self.assert_funowl_lines(
+            """
+            Declaration(ObjectProperty(GO:0000001))
+            """,
+            typedef,
+        )
+
+        typedef = TypeDef(reference=ref, predicate_type="data")
+        self.assert_obo_stanza(
+            """\
+            [Typedef]
+            id: GO:0000001
+            """,
+            typedef,
+        )
+        self.assert_funowl_lines(
+            """
+            Declaration(DataProperty(GO:0000001))
+            """,
+            typedef,
         )
 
     def test_41_is_class_level(self) -> None:

--- a/tests/test_struct/test_obograph/test_full.py
+++ b/tests/test_struct/test_obograph/test_full.py
@@ -57,6 +57,7 @@ class TestFull(unittest.TestCase):
         td = TypeDef(
             reference=Reference(prefix="sssom", identifier="confidence"),
             range=Reference.from_reference(xsd_float),
+            predicate_type="object",
         )
         ontology = build_ontology(
             prefix="test",


### PR DESCRIPTION
From the OBO data model, this is just a boolean. This PR generalizes the TypeDef object to keep track of an enumeration of the three possibilities (annotation, data, or object) for properties.

This also makes much nicer i/o with OFN and OBO Graphs